### PR TITLE
fix: Use bootstrap4

### DIFF
--- a/map/templates/map_main.html
+++ b/map/templates/map_main.html
@@ -1,6 +1,6 @@
 {% load leaflet_tags %}
 {% load staticfiles %}
-{% load bootstrap3 %}
+{% load bootstrap4 %}
 <!DOCTYPE html>
 <html style="height: 100%">
     <head>


### PR DESCRIPTION
/map/templates/map_main.html 
Should have {% load bootstrap4 %} instead of {% load bootstrap3 %} 