### PR TITLE
search: ignore inprogress searches in other missions

### DIFF
--- a/search/view_helpers.py
+++ b/search/view_helpers.py
@@ -21,11 +21,11 @@ def search_json(request, search_id, object_class):
     return to_geojson(object_class, [search])
 
 
-def check_searches_in_progress(asset):
+def check_searches_in_progress(mission, asset):
     """
-    Check if the specified asset has any searches in progress
+    Check if the specified asset has any searches in progress in the specific mission
     """
-    searches = Search.objects.filter(inprogress_by=asset).exclude(completed_at__isnull=False)
+    searches = Search.objects.filter(inprogress_by=asset,mission=mission).exclude(completed_at__isnull=False)
     if searches.exists():
         return searches[0]
 

--- a/search/views.py
+++ b/search/views.py
@@ -75,7 +75,7 @@ def find_next_search(request, asset, mission):
         return JsonResponse(data)
 
     # If this asset already has a search in progress, only offer that
-    search = check_searches_in_progress(asset)
+    search = check_searches_in_progress(mission, asset)
     if search:
         return search_data(search)
 


### PR DESCRIPTION
Sometimes a mission can be closed while searches are in progress.
If the asset is then assigned to a new mission,
it was still being given the search it was doing previously,
this isn't expected, hard to identify and could result in a fly-away.
So now we only consider searches in the mission the asset is currently
assigned to when deciding if there is an in-progress search to return.