### PR TITLE
map: Center locate control within button

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -49,7 +49,7 @@ mkdir -p map/static/leaflet/dialog/
 	cp Leaflet.Dialog-${LEAFLET_DIALOG_VERSION}/Leaflet.Dialog.{js,css} ../map/static/leaflet/dialog/)
 rm -fr tmp; mkdir tmp
 mkdir -p map/static/leaflet/locatecontrol/
-(cd tmp; tar xf ../dl/${LEAFLET_LOCATECONTROL_FILE}; cp leaflet-locatecontrol-${LEAFLET_LOCATECONTROL_VERSION}/dist/*.min.{js,css} ../map/static/leaflet/locatecontrol/)
+(cd tmp; tar xf ../dl/${LEAFLET_LOCATECONTROL_FILE}; cp leaflet-locatecontrol-${LEAFLET_LOCATECONTROL_VERSION}/dist/L.Control.Locate.min.{js,css} ../map/static/leaflet/locatecontrol/)
 rm -fr tmp
 
 # Grab fontawesome


### PR DESCRIPTION
Problem:
The leaflet-locate-control icon was off center.

Fix:
Don't add the L.Control.Locate.mapbox.min.css file to our static css
The file contains only two tiny padding classes, one of which pushes
the leaflet-locate-control icon to the right of center.

We were only grabbing three files from /dist - L.Control.Locate.min.css and L.Control.Locate.min.js and L.Control.Locate.mapbox.min.css. Only the final file is excluded by the change.