### PR TITLE
frontend: hold leaflet on 1.7 for leaflet-dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "bootstrap": "^4.6.1",
     "jquery": "^3.6.0",
-    "leaflet": "^1.7.1",
+    "leaflet": "~1.7.1",
     "leaflet-dialog": "^1.0.5",
     "leaflet-realtime": "^2.2.0",
     "leaflet.locatecontrol": "^0.76.0",


### PR DESCRIPTION
leaflet-dialog needs some patches before it can be used with leaflet 1.8