### PR TITLE
Remove direct dependency on popper.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "jquery": "^3.6.0",
         "leaflet": "^1.8.0",
         "leaflet-realtime": "^2.2.0",
-        "leaflet.locatecontrol": "^0.76.0",
-        "popper.js": "^1.16.1"
+        "leaflet.locatecontrol": "^0.76.0"
       }
     },
     "node_modules/@canterbury-air-patrol/leaflet-dialog": {
@@ -465,6 +464,7 @@
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
       "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -752,7 +752,8 @@
     "popper.js": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "peer": true
     },
     "prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "jquery": "^3.6.0",
     "leaflet": "^1.8.0",
     "leaflet-realtime": "^2.2.0",
-    "leaflet.locatecontrol": "^0.76.0",
-    "popper.js": "^1.16.1"
+    "leaflet.locatecontrol": "^0.76.0"
   }
 }


### PR DESCRIPTION
This isn't directly used here, so remove it as a direct dependency