### PR TITLE
Convert the header on the timeline to be dynamically generated

### DIFF
--- a/frontend/mission/header.js
+++ b/frontend/mission/header.js
@@ -1,0 +1,32 @@
+import { Table } from 'react-bootstrap'
+
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { MissionListRow } from './list'
+
+class MissionHeader extends React.Component {
+  render () {
+    return (
+      <Table>
+        <thead>
+          <tr>
+            <td>Misssion</td>
+            <td>Created</td>
+            <td>By</td>
+            <td>Closed</td>
+            <td>By</td>
+          </tr>
+        </thead>
+        <tbody>
+          <MissionListRow mission={this.props.mission} showButtons={false} showClosed={true} />
+        </tbody>
+      </Table>
+    )
+  }
+}
+MissionHeader.propTypes = {
+  mission: PropTypes.object.isRequired
+}
+
+export { MissionHeader }

--- a/frontend/mission/list.js
+++ b/frontend/mission/list.js
@@ -8,32 +8,46 @@ import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
 
-class MissionRow extends React.Component {
+class MissionListRow extends React.Component {
   render () {
     const mission = this.props.mission
-    const buttons = [
-      (<Button key='map' href={`/mission/${mission.id}/map/` }>Map</Button>),
-      (<Button key='details' href={`/mission/${mission.id}/details/` }>Details</Button>),
-      (<Button key='timeline' href={ `/mission/${mission.id}/timeline/`}>Timeline</Button>)
-    ]
-    if (!mission.closed && mission.admin) {
-      buttons.push((<Button key='close' className='btn-danger' href={ `/mission/${mission.id}/close/` }>Close</Button>))
+    const dataFields = []
+    dataFields.push((<td key='name'>{mission.name}</td>))
+    dataFields.push((<td key='opened'>{(new Date(mission.started)).toLocaleString()}</td>))
+    dataFields.push((<td key='creator'>{mission.creator}</td>))
+
+    if (this.props.showClosed) {
+      dataFields.push((<td key='closed'>{ mission.closed ? (new Date(mission.closed)).toLocaleString() : '' }</td>))
+      dataFields.push((<td key='closer'>{mission.closed_by}</td>))
     }
-    return ((
-      <tr key={mission.id}>
-        <td>{mission.name}</td>
-        <td>{(new Date(mission.started)).toLocaleString()}</td>
-        <td>{mission.creator}</td>
+
+    if (this.props.showButtons) {
+      const buttons = [
+        (<Button key='map' href={`/mission/${mission.id}/map/` }>Map</Button>),
+        (<Button key='details' href={`/mission/${mission.id}/details/` }>Details</Button>),
+        (<Button key='timeline' href={ `/mission/${mission.id}/timeline/`}>Timeline</Button>)
+      ]
+      if (!mission.closed && mission.admin) {
+        buttons.push((<Button key='close' className='btn-danger' href={ `/mission/${mission.id}/close/` }>Close</Button>))
+      }
+      dataFields.push((
         <td>
-          <ButtonGroup>
+          <ButtonGroup key='buttons'>
             { buttons }
           </ButtonGroup>
         </td>
+      ))
+    }
+    return ((
+      <tr key={mission.id}>
+        {dataFields}
       </tr>))
   }
 }
-MissionRow.propTypes = {
-  mission: PropTypes.object.isRequired
+MissionListRow.propTypes = {
+  mission: PropTypes.object.isRequired,
+  showButtons: PropTypes.bool.isRequired,
+  showClosed: PropTypes.bool.isRequired
 }
 
 class ActiveMissionList extends React.Component {
@@ -42,9 +56,11 @@ class ActiveMissionList extends React.Component {
     for (const missionIdx in this.props.missions) {
       const mission = this.props.missions[missionIdx]
       missionRows.push((
-        <MissionRow
+        <MissionListRow
           key={mission.id}
-          mission={mission} />
+          mission={mission}
+          showButtons={true}
+          showClosed={false} />
       ))
     }
     return (
@@ -88,20 +104,24 @@ class CompletedMissionList extends React.Component {
     for (const missionIdx in this.props.missions) {
       const mission = this.props.missions[missionIdx]
       missionRows.push((
-        <MissionRow
+        <MissionListRow
           key={mission.id}
-          mission={mission} />
+          mission={mission}
+          showButtons={true}
+          showClosed={true} />
       ))
     }
     return (
       <Table>
         <thead>
           <tr key='heading'>
-            <th colSpan={4} align='center'>Completed Missions</th>
+            <th colSpan={6} align='center'>Completed Missions</th>
           </tr>
           <tr key='labels'>
             <th>Mission Name</th>
             <th>Started</th>
+            <th>By</th>
+            <th>Closed</th>
             <th>By</th>
             <th>Actions</th>
           </tr>
@@ -116,7 +136,7 @@ CompletedMissionList.propTypes = {
   missions: PropTypes.array.isRequired
 }
 
-export class MissionListPage extends React.Component {
+class MissionListPage extends React.Component {
   constructor (props) {
     super(props)
 
@@ -168,9 +188,11 @@ export class MissionListPage extends React.Component {
   }
 }
 
-export function createMissionList (elementId) {
+function createMissionList (elementId) {
   const div = ReactDOM.createRoot(document.getElementById(elementId))
   div.render(<MissionListPage />)
 }
+
+export { MissionListRow, MissionListPage }
 
 globalThis.createMissionList = createMissionList

--- a/frontend/mission/timeline.js
+++ b/frontend/mission/timeline.js
@@ -8,6 +8,8 @@ import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
 
+import { MissionHeader } from './header'
+
 class MissionTimelineEntry extends React.Component {
   render () {
     const entry = this.props.timelineEntry
@@ -30,7 +32,7 @@ class MissionTimelineButtons extends React.Component {
   render () {
     const buttons = [
       (<Button key='map' href={`/mission/${this.props.missionId}/map/`}>Map</Button>),
-      (<Button key='map' href={`/mission/${this.props.missionId}/details/`}>Details</Button>)
+      (<Button key='details' href={`/mission/${this.props.missionId}/details/`}>Details</Button>)
     ]
     if (!this.props.missionClosed) {
       buttons.push((<Button key='addEntry' href={`/mission/${this.props.missionId}/timeline/add/`}>Add Entry</Button>))
@@ -53,6 +55,7 @@ export class MissionTimeLine extends React.Component {
 
     this.state = {
       timelineEntries: [],
+      missionData: null,
       missionClosed: false
     }
   }
@@ -72,6 +75,7 @@ export class MissionTimeLine extends React.Component {
     const self = this
     await $.get(`/mission/${this.props.missionId}/timeline/json/`, function (data) {
       self.updateTimeline(data.timeline)
+      self.updateMission(data.mission)
       if (!self.state.missionClosed && data.mission.closed !== null) {
         self.setMissionClosed()
       }
@@ -82,6 +86,14 @@ export class MissionTimeLine extends React.Component {
     this.setState(function () {
       return {
         timelineEntries
+      }
+    })
+  }
+
+  updateMission (missionData) {
+    this.setState(function () {
+      return {
+        missionData
       }
     })
   }
@@ -101,8 +113,14 @@ export class MissionTimeLine extends React.Component {
       timelineEntries.push((<MissionTimelineEntry key={timelineEntry.id} timelineEntry={timelineEntry}></MissionTimelineEntry>))
     }
 
+    let missionData = null
+    if (this.state.missionData !== null) {
+      missionData = (<MissionHeader key='missionHeader' mission={this.state.missionData} />)
+    }
+
     return (
       <div>
+        { missionData }
         <MissionTimelineButtons missionId={this.props.missionId} missionClosed={this.state.missionClosed} />
         <Table>
           <thead>

--- a/mission/templates/mission_timeline.html
+++ b/mission/templates/mission_timeline.html
@@ -7,11 +7,6 @@
         <script src="mission/timeline.js"></script>
     </head>
     <body style="height: 100%">
-        <table class="table">
-            <tr><td>Mission</td><td colspan="3">{{ mission.mission_name }}</td></tr>
-            <tr><td>Created</td><td>By</td><td>Closed</td><td>By</td></tr>
-            <tr><td>{{ mission.started }}</td><td>{{ mission.creator }}</td><td>{{ mission.closed }}</td><td>{{ mission.closed_by }}</td></tr>
-        </table>
         <div id='root'></div>
     </body>
     <script>


### PR DESCRIPTION
Reuse the the mission list row entry and allow it to be customized. Also, use this customization to change the way that closed missions are shown.

This allows the mission header to be displayed consistently across pages.