### PR TITLE
search: return the correct status when deleting a search

### DIFF
--- a/search/models.py
+++ b/search/models.py
@@ -256,7 +256,7 @@ class Search(GeoTime):
         '''
         time = timezone.now()
         Search.objects.filter(pk=self.pk, inprogress_by__isnull=True, deleted_at__isnull=True).update(deleted_at=time, deleted_by=user)
-        self.check_and_record_delete(time)
+        return self.check_and_record_delete(time)
 
     @staticmethod
     def create_sector_search(params, save=False):

--- a/search/views.py
+++ b/search/views.py
@@ -178,12 +178,13 @@ def search_delete(request, mission_user, search_id):
     """
     search = get_object_or_404(Search, pk=search_id)
 
-    if search.delete(mission_user.user):
-        return HttpResponse('Success')
-
     error = check_search_state(search, 'delete', None)
     if error is not None:
         return error
+
+    if search.delete(mission_user.user):
+        return HttpResponse('Success')
+
     return HttpResponseNotFound('Try again')
 
 


### PR DESCRIPTION
When a search was being deleted a 403 was being returned because the check for the status was being done after the search was deleted.