### PR TITLE
check-code: check the return codes of the called programs

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 source venv/bin/activate
 


### PR DESCRIPTION
Actually cause check-code to fail if the tests fails