### PR TITLE
Revert "build(deps): update pylint requirement from ==2.14.* to ==2.15.*"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psycopg2-binary
 
 # Code checking
 pycodestyle
-pylint==2.15.*
+pylint==2.14.*
 pylint-django
 
 # Numerical


### PR DESCRIPTION
Reverts canterbury-air-patrol/search-management-map#88

Updating to 2.15 breaks the check code script because pylint-django cannot read the django config