### PR TITLE
frontend: fix use of incorrect variable name in asset class

### DIFF
--- a/frontend/asset/map.js
+++ b/frontend/asset/map.js
@@ -13,10 +13,11 @@ class SMMAsset {
     this.lastUpdate = null
     this.path = []
     this.updating = false
+    this.polyline = L.polyline([], { color: this.color })
   }
 
   overlay () {
-    return L.polyline([], { color: this.color })
+    return this.polyline
   }
 
   update () {
@@ -39,7 +40,7 @@ class SMMAsset {
           self.path.push(L.latLng(lat, lon))
           self.lastUpdate = route.features[f].properties.created_at
         }
-        self.track.setLatLngs(self.path)
+        self.polyline.setLatLngs(self.path)
         self.updating = false
       },
       error: function () {


### PR DESCRIPTION
When this code was split out, a reference to self.track was left that didn't refer to anything, in the previous code track was the PolyLine, so fix this up here so avoid a run-time error and also actually show the assest track.

Fixes: cd9f503 frontend: split out asset presentation functionality