### PR TITLE
frontend: fix display of the asset name

### DIFF
--- a/frontend/asset/map.js
+++ b/frontend/asset/map.js
@@ -85,15 +85,13 @@ class SMMAssets extends SMMRealtime {
   }
 
   createPopup (asset, layer) {
-    console.log(asset)
-
     const assetName = asset.properties.asset
 
     this.createAsset(assetName)
 
     const popupContent = document.createElement('div')
 
-    popupContent.appendChild(document.createElement(`<div>${assetName}</div>`))
+    popupContent.appendChild(document.createTextElement(assetName))
 
     layer.bindPopup(popupContent)
   }


### PR DESCRIPTION
This was causing an extra log and an error every time the asset label was created