### PR TITLE
frontend: move buttons key to correct level in mission details

### DIFF
--- a/frontend/mission/list.js
+++ b/frontend/mission/list.js
@@ -31,8 +31,8 @@ class MissionListRow extends React.Component {
         buttons.push((<Button key='close' className='btn-danger' href={ `/mission/${mission.id}/close/` }>Close</Button>))
       }
       dataFields.push((
-        <td>
-          <ButtonGroup key='buttons'>
+        <td key='buttons'>
+          <ButtonGroup>
             { buttons }
           </ButtonGroup>
         </td>


### PR DESCRIPTION
react was showing an error because the key is meant to be at the outer most level of the elements in the array.