### PR TITLE
frontend: split generic smm object details from search details

### DIFF
--- a/frontend/SMMObjects/details.js
+++ b/frontend/SMMObjects/details.js
@@ -1,0 +1,74 @@
+import { Table } from 'react-bootstrap'
+
+import React from 'react'
+import PropTypes from 'prop-types'
+
+class SMMObjectDetails extends React.Component {
+  renderCreatedDeletedReplaced (tableRows, data) {
+    tableRows.push((
+      <tr key='created_at'>
+        <td>Created:</td>
+        <td>{(new Date(data.created_at)).toLocaleString()}</td>
+      </tr>
+    ))
+    tableRows.push((
+      <tr key='created_by'>
+        <td>Creator:</td>
+        <td>{data.created_by}</td>
+      </tr>
+    ))
+    if (data.deleted_at !== null) {
+      tableRows.push((
+        <tr key='deleted_at'>
+          <td>Deleted:</td>
+          <td>{(new Date(data.deleted_at)).toLocaleString()}</td>
+        </tr>
+      ))
+      tableRows.push((
+        <tr key='deleted_by'>
+          <td>Deleted By:</td>
+          <td>{data.deleted_by}</td>
+        </tr>
+      ))
+    }
+    if (data.replaced_at) {
+      tableRows.push((
+        <tr key='replaced_at'>
+          <td>Replaced:</td>
+          <td>{(new Date(data.replaced_at)).toLocaleString()}</td>
+        </tr>
+      ))
+      tableRows.push((
+        <tr key='replaced_by'>
+          <td>Replacement:</td>
+          <td>{data.replaced_by}</td>
+        </tr>
+      ))
+    }
+  }
+
+  renderModelSpecificData (tableRows, data) {
+
+  }
+
+  render () {
+    const data = this.props.data
+    const tableRows = []
+
+    this.renderCreatedDeletedReplaced(tableRows, data)
+    this.renderModelSpecificData(tableRows, data)
+
+    return (
+      <Table>
+        <tbody>
+          {tableRows}
+        </tbody>
+      </Table>
+    )
+  }
+}
+SMMObjectDetails.propTypes = {
+  data: PropTypes.object.isRequired
+}
+
+export { SMMObjectDetails }

--- a/frontend/search/details.js
+++ b/frontend/search/details.js
@@ -10,12 +10,10 @@ import Collapsible from 'react-collapsible'
 import $ from 'jquery'
 
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
+import { SMMObjectDetails } from '../SMMObjects/details'
 
-class SearchDetails extends React.Component {
-  render () {
-    const data = this.props.data
-    const tableRows = []
-
+class SearchDetails extends SMMObjectDetails {
+  renderModelSpecificData (tableRows, data) {
     tableRows.push((
       <tr key='search_type'>
         <td>Type:</td>
@@ -23,12 +21,6 @@ class SearchDetails extends React.Component {
       </tr>
     ))
 
-    tableRows.push((
-      <tr key='created_at'>
-        <td>Created:</td>
-        <td>{(new Date(data.created_at)).toLocaleString()}</td>
-      </tr>
-    ))
     tableRows.push((
       <tr key='created_for'>
         <td>Asset Type:</td>
@@ -103,18 +95,7 @@ class SearchDetails extends React.Component {
         </tr>
       ))
     }
-
-    return (
-      <Table>
-        <tbody>
-          { tableRows }
-        </tbody>
-      </Table>
-    )
   }
-}
-SearchDetails.propTypes = {
-  data: PropTypes.object.isRequired
 }
 
 class SearchPoints extends React.Component {

--- a/search/models.py
+++ b/search/models.py
@@ -110,7 +110,12 @@ class Search(GeoTime):
     GEOJSON_FIELDS = (
         'pk',
         'created_at',
+        'created_by',
         'created_for',
+        'deleted_at',
+        'deleted_by',
+        'replaced_at',
+        'replaced_by',
         'inprogress_at',
         'inprogress_by',
         'sweep_width',


### PR DESCRIPTION
This allows the generic details block to be reused for other object details