### PR TITLE
frontend: split out points list from search details

### DIFF
--- a/frontend/geometry/details.js
+++ b/frontend/geometry/details.js
@@ -1,0 +1,60 @@
+import { Table } from 'react-bootstrap'
+
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
+
+function coordinateToLatLng (point) {
+  return {
+    lat: point[1],
+    lng: point[0]
+  }
+}
+
+function mapCoordinates (points) {
+  if (!Array.isArray(points[0])) {
+    return coordinateToLatLng(points)
+  }
+  return points.map(p => mapCoordinates(p))
+}
+
+class GeometryPoints extends React.Component {
+  render () {
+    let points = mapCoordinates(this.props.points)
+    if (!Array.isArray(points)) {
+      points = [points]
+    }
+    if (Array.isArray(points[0])) {
+      points = points[0]
+    }
+
+    const tableRows = []
+    for (const pointIdx in points) {
+      tableRows.push((
+        <tr key={pointIdx}>
+          <td>{degreesToDM(points[pointIdx].lng)}</td>
+          <td>{degreesToDM(points[pointIdx].lat, true)}</td>
+        </tr>
+      ))
+    }
+    return (
+      <Table>
+        <thead>
+          <tr>
+            <td>Longitude</td>
+            <td>Latitude</td>
+          </tr>
+        </thead>
+        <tbody>
+          {tableRows}
+        </tbody>
+      </Table>
+    )
+  }
+}
+GeometryPoints.propTypes = {
+  points: PropTypes.array.isRequired
+}
+
+export { GeometryPoints }

--- a/frontend/search/details.js
+++ b/frontend/search/details.js
@@ -1,6 +1,5 @@
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
-import { Table } from 'react-bootstrap'
 
 import React from 'react'
 import PropTypes from 'prop-types'
@@ -9,8 +8,8 @@ import Collapsible from 'react-collapsible'
 
 import $ from 'jquery'
 
-import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { SMMObjectDetails } from '../SMMObjects/details'
+import { GeometryPoints } from '../geometry/details'
 
 class SearchDetails extends SMMObjectDetails {
   renderModelSpecificData (tableRows, data) {
@@ -98,36 +97,6 @@ class SearchDetails extends SMMObjectDetails {
   }
 }
 
-class SearchPoints extends React.Component {
-  render () {
-    const tableRows = []
-    for (const pointIdx in this.props.points) {
-      tableRows.push((
-        <tr key={pointIdx}>
-          <td>{degreesToDM(this.props.points[pointIdx][0])}</td>
-          <td>{degreesToDM(this.props.points[pointIdx][1], true)}</td>
-        </tr>
-      ))
-    }
-    return (
-      <Table>
-        <thead>
-          <tr>
-            <td>Longitude</td>
-            <td>Latitude</td>
-          </tr>
-        </thead>
-        <tbody>
-          { tableRows }
-        </tbody>
-      </Table>
-    )
-  }
-}
-SearchPoints.propTypes = {
-  points: PropTypes.array.isRequired
-}
-
 class SearchDetailsPage extends React.Component {
   constructor (props) {
     super(props)
@@ -171,7 +140,7 @@ class SearchDetailsPage extends React.Component {
     if (this.state.geometry !== null && this.state.geometry.points !== null) {
       parts.push((
         <Collapsible key='points' trigger='Coordinates'>
-          <SearchPoints
+          <GeometryPoints
             points={this.state.geometry.coordinates}
           />
         </Collapsible>


### PR DESCRIPTION
This is so this class can be reused with other user geometry objects

Calls a function to convert points from SMM into points with the latitude/longitude named to make it more obvious which way around they go
The wrapper function is used to deal with points that are stored in different levels of nested arrays (i.e. linestring [] vs polygon [][])