### PR TITLE
frontend: pass missionid/csrftoken to SMMAdmin control

### DIFF
--- a/frontend/map.js
+++ b/frontend/map.js
@@ -92,7 +92,7 @@ class SMMMap {
       }).addTo(this.map)
       L.control.imageuploader({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
     }
-    L.control.smmadmin({}).addTo(this.map)
+    L.control.smmadmin({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
 
     const assetUpdateFreq = 3 * 1000
     const userDataUpdateFreq = 10 * 1000


### PR DESCRIPTION
In: e4d0805 Use eslint to check and standardize the javascript code the SMMAdmin control was updated to take missionId and csrftoken as parameters, but the call in map.js was never updated to pass these in.