### PR TITLE
search: resolve an issue with queuing searches for a specific asset

### DIFF
--- a/frontend/search/map.js
+++ b/frontend/search/map.js
@@ -90,6 +90,7 @@ class SMMSearchNotStarted extends SMMSearch {
   }
 
   searchQueueDialog (searchID, assetType) {
+    const self = this
     const contents = [
       `<div>Queue for <select id='queue_${searchID}_select_type'><option value='type'>Asset Type</option><option value='asset'>Specific Asset</option></select></div>`,
       `<div><select id='queue_${searchID}_select_asset'></select></div>`,
@@ -125,7 +126,7 @@ class SMMSearchNotStarted extends SMMSearch {
           value: $(`#queue_${searchID}_select_asset`).val()
         })
       }
-      $.post(`/mission/${self.mission_id}/search/${searchID}/queue/`, data, function (data) {
+      $.post(`/mission/${self.missionId}/search/${searchID}/queue/`, data, function (data) {
         QueueDialog.destroy()
       })
     })

--- a/search/models.py
+++ b/search/models.py
@@ -230,7 +230,7 @@ class Search(GeoTime):
         Search.objects.filter(pk=self.pk, inprogress_by__isnull=True, deleted_at__isnull=True, queued_at__isnull=True).update(queued_at=timezone.now(), queued_for_asset=asset)
         self.refresh_from_db()
         if self.queued_for_asset == asset:
-            timeline_record_search_queue(mission_user.mission, mission_user.user, self, asset.assettype, asset)
+            timeline_record_search_queue(mission_user.mission, mission_user.user, self, asset.asset_type, asset)
             return True
         return False
 


### PR DESCRIPTION
2 bugs prevented this from working:
- self wasn't set in map.js before being used to get the missionId
- the wrong name was used for the asset_type field when populating the timeline