### PR TITLE
asset: obey the users selection

### DIFF
--- a/frontend/asset/picker.js
+++ b/frontend/asset/picker.js
@@ -14,6 +14,8 @@ class AssetDetailsPicker extends React.Component {
       assets: [],
       selectedAsset: null
     }
+
+    this.changeSelectedAsset = this.changeSelectedAsset.bind(this)
   }
 
   componentDidMount () {


### PR DESCRIPTION
not binding changeSelectedAsset was causing an error when the selected asset was changed making it impossible to directly access the asset page for any asset that isn't first in the list.