### PR TITLE
search: use the geometry version of st_azimuth

### DIFF
--- a/search/models.py
+++ b/search/models.py
@@ -408,7 +408,7 @@ class Search(GeoTime):
             f" FROM data_geotimelabel, generate_series(1, ST_NPoints(geo::geometry) - 1) AS pos WHERE id = {params.from_geo().pk}"
 
         line_data_query = \
-            f"SELECT segment.start AS start, ST_Azimuth(segment.start, segment.end) AS direction, ST_Distance(segment.start, segment.end) AS distance FROM ({segment_query}) AS segment"
+            f"SELECT segment.start AS start, ST_Azimuth(segment.start::geometry, segment.end::geometry) AS direction, ST_Distance(segment.start, segment.end) AS distance FROM ({segment_query}) AS segment"
         line_points_query = \
             f"SELECT direction AS direction, ST_Project(linedata.start, {params.sweep_width()} * i, direction) AS point"\
             f" FROM ({line_data_query}) AS linedata, generate_series(0, (linedata.distance/{params.sweep_width()})::integer) AS i"


### PR DESCRIPTION
When running on debian bullseye we see an issue where the geography version of st_azimuth doesn't return the correct value in all cases. At least until the next debian release is available, this is the best way to avoid this issue.

This issue manifests as creeping line ahead searches not following the line they are created from, in some cases they will go in the opposite direction, and in others they will deviate away.
The order/direction the line is draw has an impact on whether the issue will occur or not.