### PR TITLE
Allow users to add assets from organizations they are a member of

### DIFF
--- a/organization/models.py
+++ b/organization/models.py
@@ -88,6 +88,13 @@ class OrganizationMember(models.Model):
     def is_radio_operator(self):
         return self.role in ('A', 'R')
 
+    @classmethod
+    def user_current(cls, user):
+        """
+        Get all the OrganizationMember classes a user is currently in
+        """
+        return cls.objects.filter(user=user, removed__isnull=True)
+
 
 class OrganizationAsset(models.Model):
     organization = models.ForeignKey(Organization, on_delete=models.PROTECT, related_name='organization_%(app_label)s_%(class)s_related')


### PR DESCRIPTION
When:
- An organization has been added to a mission
- The user is a member of that organization
- The asset is owned by that organization Treat the user as an owner of the asset in the mission.