### PR TITLE
images: use a mission decorator that doesn't cause an error

### DIFF
--- a/images/views.py
+++ b/images/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponseBadRequest, HttpResponseRedirect, FileRespon
 from django.contrib.auth.decorators import login_required
 from django.contrib.gis.geos import Point
 
-from mission.decorators import mission_is_member
+from mission.decorators import mission_is_member, mission_is_member_no_variable
 from data.decorators import data_get_mission_id
 from data.view_helpers import to_geojson
 from timeline.helpers import timeline_record_image_priority_changed
@@ -85,7 +85,7 @@ def images_list_important_current(request):
 @login_required
 @image_from_id
 @data_get_mission_id(arg_name='image')
-@mission_is_member
+@mission_is_member_no_variable
 def image_get_full(request, image):
     """
     Return the full sized version of the image
@@ -96,7 +96,7 @@ def image_get_full(request, image):
 @login_required
 @image_from_id
 @data_get_mission_id(arg_name='image')
-@mission_is_member
+@mission_is_member_no_variable
 def image_get_thumbnail(request, image):
     """
     Return the thumbnail version of the image

--- a/mission/decorators.py
+++ b/mission/decorators.py
@@ -27,6 +27,17 @@ def mission_user_get(mission_id, user):
     raise Http404("Not Found")
 
 
+def mission_is_member_no_variable(view_func):
+    """
+    Make sure that user is a member of the mission
+    """
+    def wrapper_is_member(*args, **kwargs):
+        mission_user_get(kwargs['mission_id'], args[0].user)
+        kwargs.pop('mission_id')
+        return view_func(*args, **kwargs)
+    return wrapper_is_member
+
+
 def mission_is_member(view_func):
     """
     Make sure that user is a member of the mission


### PR DESCRIPTION
The mission_is_member decorator adds an argument to the function which at least for these image functions we don't actually use. We still want the effect of the check, so create an alternative version that doesn't add the extra argument.