### PR TITLE
Update python version used in tests to 3.11

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Setup venv
         run:
           ./setup-venv.sh

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Setup venv
         run: ./setup-venv.sh
         env:


### PR DESCRIPTION
This is needed before we update to django 5.0 which doesn't support 3.9

## Description

Please describe the purpose of this change
* the django 5.0 update from dependabot is failing because python 3.9 is not supported in django 5.0
* See: #296 

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have updated the documentation
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Collaborators
Nil