### PR TITLE
Fix: removing an asset as organization member was not possible

### DIFF
--- a/mission/tests.py
+++ b/mission/tests.py
@@ -204,11 +204,10 @@ class MissionTestCase(MissionBaseTestCase):
         self.assertEqual(mission_data['missions'][0]['closed_by'], self.user1.username)
 
 
-class MissionOrganizationsTestCase(MissionBaseTestCase):
+class MissionOrganizationBaseTestCase(MissionBaseTestCase):
     """
-    Test Mission and Organization integration
+    Base setup/functions for testing Mission/Organization integration
     """
-
     def create_organization(self, organization_name='org', client=None):
         """
         Create an organization
@@ -241,6 +240,11 @@ class MissionOrganizationsTestCase(MissionBaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.redirect_chain[0][1], 302)
 
+
+class MissionOrganizationsTestCase(MissionOrganizationBaseTestCase):
+    """
+    Test Mission and Organization integration
+    """
     def test_mission_organization_list(self):
         """
         Check that users in organizations can see one copy of the mission in the list
@@ -375,6 +379,64 @@ class MissionAssetsTestCase(TestCase):
         response = self.client1.post(mission_del_asset_url, follow=True)
         self.assertEqual(response.redirect_chain[0][1], 302)
         response = self.client1.get(mission_assets_json)
+        self.assertEqual(response.status_code, 200)
+        assets_data = json.loads(response.content)
+        self.assertEqual(len(assets_data['assets']), 0)
+
+
+class MissionOrganizationsAssetsTestCase(MissionOrganizationBaseTestCase):
+    """
+    Test Mission and Organization integration for Assets
+    """
+    def create_asset(self, name='test-asset', owner=None):
+        """
+        Add an asset to the system
+        """
+        if owner is None:
+            owner = self.user1
+        asset_type = AssetType(name='test_type')
+        asset_type.save()
+        asset = Asset(name=name, owner=owner, asset_type=asset_type)
+        asset.save()
+        return asset
+
+    def add_asset_to_organization(self, asset=None, organization=None, client=None, expected_status=200):
+        """
+        Add an asset to an organization
+        """
+        if client is None:
+            client = self.client1
+        if organization is None:
+            organization = self.create_organization(client=client)
+        if asset is None:
+            asset = self.create_asset()
+        organization_add_asset_url = f"/organization/{organization['id']}/assets/{asset.pk}/"
+        response = client.post(organization_add_asset_url, {})
+        self.assertEqual(response.status_code, expected_status)
+
+    def test_mission_organization_add_asset(self):
+        """
+        Check that users in organizations can add organization assets to the mission
+        """
+        # Create a mission
+        mission = self.create_mission_by_url('test_mission_list', mission_description='test description')
+        # Create an organization and add it to this mission
+        org1 = self.create_organization(client=self.client2)
+        # Add this organization to the mission
+        self.add_organization_to_mission(mission, org1)
+        # Add an asset to the organization
+        asset = self.create_asset(owner=self.user2)
+        self.add_asset_to_organization(asset=asset, organization=org1, client=self.client2)
+        # Check a user in the organization can add an organization asset
+        mission_add_asset_url = f'/mission/{mission.pk}/assets/add/'
+        mission_assets_json = f'/mission/{mission.pk}/assets/json/'
+        response = self.client2.post(mission_add_asset_url, {'asset': asset.pk}, follow=True)
+        self.assertEqual(response.redirect_chain[0][1], 302)
+        # Check a user in the organization can remove the asset
+        mission_del_asset_url = f'/mission/{mission.pk}/assets/{asset.pk}/remove/'
+        response = self.client2.post(mission_del_asset_url, follow=True)
+        self.assertEqual(response.redirect_chain[0][1], 302)
+        response = self.client2.get(mission_assets_json)
         self.assertEqual(response.status_code, 200)
         assets_data = json.loads(response.content)
         self.assertEqual(len(assets_data['assets']), 0)

--- a/mission/views.py
+++ b/mission/views.py
@@ -302,7 +302,7 @@ def mission_asset_remove(request, mission_user, asset_id):
     mission_asset = get_object_or_404(MissionAsset, mission=mission_user.mission, asset=asset, removed__isnull=True)
     if mission_user.is_admin() or \
        mission_asset.asset.owner != request.user or \
-       OrganizationAsset.objects.filter(asset=asset, organization__in=MissionOrganization.objects.get(organization__in=OrganizationMember.user_current(request.user)).values_list('organization')):
+       OrganizationAsset.objects.filter(asset=asset, organization__in=[organization_member.organization for organization_member in OrganizationMember.objects.filter(user=request.user)]).values_list('organization'):
         HttpResponseForbidden('Only assets owners or a mission admin can remove assets')
     mission_asset.remover = request.user
     mission_asset.removed = timezone.now()


### PR DESCRIPTION
## Description
The code that checked if a user is allowed to remove an asset from the mission didn't handle the case where the user was a member of an organization (and would produce a backtrace)

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change