### PR TITLE
Split assets into a different layer control

### DIFF
--- a/frontend/map.js
+++ b/frontend/map.js
@@ -39,9 +39,11 @@ class SMMMap {
     this.map = L.map(mapElem)
     this.layerControl = L.control.layers({}, {})
     this.layerControlMaps = L.control.layers({}, {})
+    this.layerControlAssets = L.control.layers({}, {})
     this.missionId = missionId
     this.csrftoken = csrftoken
     this.overlayAdd = this.overlayAdd.bind(this)
+    this.overlayAddAsset = this.overlayAddAsset.bind(this)
     this.setupMap()
   }
 
@@ -79,6 +81,7 @@ class SMMMap {
 
     this.layerControl.addTo(this.map)
     this.layerControlMaps.addTo(this.map)
+    this.layerControlAssets.addTo(this.map)
 
     this.map.setView(new LatLng(0, 0), 16)
 
@@ -107,7 +110,7 @@ class SMMMap {
     // Default leaflet path color
     const defaultColor = '#3388ff'
 
-    this.assets = new SMMAssets(this.map, this.csrftoken, this.missionId, assetUpdateFreq, 'red', this.overlayAdd)
+    this.assets = new SMMAssets(this.map, this.csrftoken, this.missionId, assetUpdateFreq, 'red', this.overlayAddAsset)
     this.overlayAdd('Assets', this.assets.realtime().addTo(this.map))
 
     this.POIs = new SMMPOI(this.map, this.csrftoken, this.missionId, userDataUpdateFreq, defaultColor)
@@ -139,6 +142,10 @@ class SMMMap {
 
   overlayAdd (name, layer) {
     this.layerControl.addOverlay(layer, name)
+  }
+
+  overlayAddAsset (name, layer) {
+    this.layerControlAssets.addOverlay(layer, name)
   }
 }
 

--- a/frontend/map.js
+++ b/frontend/map.js
@@ -38,6 +38,7 @@ class SMMMap {
   constructor (mapElem, missionId, csrftoken) {
     this.map = L.map(mapElem)
     this.layerControl = L.control.layers({}, {})
+    this.layerControlMaps = L.control.layers({}, {})
     this.missionId = missionId
     this.csrftoken = csrftoken
     this.overlayAdd = this.overlayAdd.bind(this)
@@ -53,8 +54,6 @@ class SMMMap {
 
     $.get('/map/tile/layers/', function (data) {
       let baseSelected = false
-      const layersBase = {}
-      const layersExtra = {}
       for (const d in data.layers) {
         const layer = data.layers[d]
         const options = {
@@ -67,19 +66,19 @@ class SMMMap {
         }
         const tileLayer = L.tileLayer(layer.url, options)
         if (layer.base) {
+          self.layerControlMaps.addBaseLayer(tileLayer, layer.name)
           if (!baseSelected) {
             tileLayer.addTo(self.map)
             baseSelected = true
           }
-          layersBase[layer.name] = tileLayer
         } else {
-          layersExtra[layer.name] = tileLayer
+          self.layerControlMaps.addOverlay(tileLayer, layer.name)
         }
       }
-      L.control.layers(layersBase, layersExtra).addTo(self.map)
     })
 
     this.layerControl.addTo(this.map)
+    this.layerControlMaps.addTo(this.map)
 
     this.map.setView(new LatLng(0, 0), 16)
 


### PR DESCRIPTION
## Description
Change the assets so they show in their own layer control rather as part of the list of standard objects

## Checklist
- [x] I wrote this code myself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change