### PR TITLE
organization: address errors with added/removed users

### DIFF
--- a/organization/models.py
+++ b/organization/models.py
@@ -19,7 +19,7 @@ class Organization(models.Model):
         """
         role = ''
         try:
-            organization_member = OrganizationMember.objects.get(organization=self, user=user)
+            organization_member = OrganizationMember.objects.get(organization=self, user=user, removed__isnull=True)
             role = organization_member.user_role_name()
         except ObjectDoesNotExist:
             role = ''

--- a/organization/views.py
+++ b/organization/views.py
@@ -30,7 +30,7 @@ def organization_details(request, organization_id):
     organization = get_object_or_404(Organization, pk=organization_id)
 
     # if json is requested, then send all the data this user is allowed to see
-    if "application/json" in request.META.get('HTTP_ACCEPT'):
+    if "application/json" in request.META.get('HTTP_ACCEPT', ''):
         organization_data = organization.as_object(request.user)
 
         organization_assets = OrganizationAsset.objects.filter(organization=organization, removed__isnull=True)
@@ -92,7 +92,7 @@ def organization_list_mine(request):
     if request.method != 'GET':
         return HttpResponseNotAllowed(['GET'])
 
-    organization_memberships = OrganizationMember.objects.filter(organization__deleted__isnull=True, user=request.user)
+    organization_memberships = OrganizationMember.user_current(user=request.user).filter(organization__deleted__isnull=True)
 
     return JsonResponse({'organizations': [om.organization.as_object(request.user) for om in organization_memberships]})
 


### PR DESCRIPTION
## Description

Resolves #337, resolves #338

The code that looks at organization membership didn't always take into account if the user was removed.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change
