### PR TITLE
Split mission tests

### DIFF
--- a/mission/test_mission_org.py
+++ b/mission/test_mission_org.py
@@ -1,0 +1,124 @@
+"""
+Tests for Mission interactions with Organizations
+"""
+from .tests import MissionBaseTestCase
+
+
+class MissionOrganizationBaseTestCase(MissionBaseTestCase):
+    """
+    Base setup/functions for testing Mission/Organization integration
+    """
+    def create_organization(self, organization_name='org', client=None):
+        """
+        Create an organization
+        """
+        organization_create_url = '/organization/create/'
+        if client is None:
+            client = self.client1
+        response = client.post(organization_create_url, {'name': organization_name})
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    def add_user_to_org(self, organization=None, user=None, client=None, role='M'):
+        """
+        Add a user to an organization
+        """
+        if client is None:
+            client = self.client1
+        if organization is None:
+            organization = self.create_organization(client=client)
+        organization_user_add_url = f"/organization/{organization['id']}/user/{user}/"
+        response = client.post(organization_user_add_url, {'role': role})
+        self.assertEqual(response.status_code, 200)
+
+    def del_user_from_org(self, organization=None, user=None, client=None):
+        """
+        Remove a user from the organization
+        """
+        if client is None:
+            client = self.client1
+        if organization is None:
+            organization = self.create_organization(client=client)
+        organization_user_del_url = f"/organization/{organization['id']}/user/{user}/"
+        response = client.delete(organization_user_del_url)
+        self.assertEqual(response.status_code, 200)
+
+    def add_organization_to_mission(self, mission, organization):
+        """
+        Add an organization to a mission
+        """
+        add_org_url = f'/mission/{mission.pk}/organizations/add/'
+        response = self.client1.post(add_org_url, data={'organization': organization['id']}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.redirect_chain[0][1], 302)
+
+
+class MissionOrganizationsTestCase(MissionOrganizationBaseTestCase):
+    """
+    Test Mission and Organization integration
+    """
+    def test_mission_organization_list(self):
+        """
+        Check that users in organizations can see one copy of the mission in the list
+        """
+        # Check there are no missions in the list
+        mission_list = self.get_mission_list()
+        self.assertEqual(len(mission_list), 0)
+        # Create a mission and check it appears
+        mission = self.create_mission_by_url('test_mission_org_list', mission_description='mission org list')
+        mission_list = self.get_mission_list()
+        self.assertEqual(len(mission_list), 1)
+        # Create an organization and add it to this mission
+        org1 = self.create_organization()
+        # Add this organization to the mission
+        self.add_organization_to_mission(mission, org1)
+        # Check the mission list still only has 1 entry
+        mission_list = self.get_mission_list()
+        self.assertEqual(len(mission_list), 1)
+
+    def test_mission_organization_list_for_other(self):
+        """
+        Check that users can see missions because they are a member of an organization added to the mission
+        """
+        # Check there are no missions in the list
+        mission_list = self.get_mission_list(client=self.client2)
+        self.assertEqual(len(mission_list), 0)
+        # Create a mission and check it appears
+        mission = self.create_mission_by_url('test_mission_list', mission_description='test description')
+        # Check the other user cant see this mission yet
+        mission_list = self.get_mission_list(client=self.client2)
+        self.assertEqual(len(mission_list), 0)
+        # Create an organization and add it to this mission
+        org1 = self.create_organization()
+        # Add this organization to the mission
+        self.add_organization_to_mission(mission, org1)
+        # Add the other user to the organization
+        self.add_user_to_org(organization=org1, user=self.user2, client=self.client1)
+        # Check the other user can now see this mission
+        mission_list = self.get_mission_list(client=self.client2)
+        self.assertEqual(len(mission_list), 1)
+
+    def test_mission_organization_deleted_user(self):
+        """
+        Check that a user removed from an organization no longer sees missions that organization is a member of
+        """
+        # Create an organization, make both users a member
+        org1 = self.create_organization()
+        self.add_user_to_org(organization=org1, user=self.user2, client=self.client1)
+        # Check there are no missions in the list
+        mission_list = self.get_mission_list(client=self.client2)
+        self.assertEqual(len(mission_list), 0)
+        # Create a mission and check it appears
+        mission = self.create_mission_by_url('test_mission_org_removed', mission_description='test description')
+        # Check the other user cant see this mission yet
+        mission_list = self.get_mission_list(client=self.client2)
+        self.assertEqual(len(mission_list), 0)
+        # Add this organization to the mission
+        self.add_organization_to_mission(mission, org1)
+        # Check the other user can now see this mission
+        mission_list = self.get_mission_list(client=self.client2)
+        self.assertEqual(len(mission_list), 1)
+        # Remove the user from the organization, check it disappears for them
+        self.del_user_from_org(organization=org1, user=self.user2, client=self.client1)
+        mission_list = self.get_mission_list(client=self.client2)
+        self.assertEqual(len(mission_list), 0)

--- a/mission/test_mission_org_asset.py
+++ b/mission/test_mission_org_asset.py
@@ -1,0 +1,97 @@
+"""
+Tests for mission interactions with Organization owned Assets
+"""
+
+from .test_mission_org import MissionOrganizationBaseTestCase
+
+
+class MissionOrganizationsAssetsTestCase(MissionOrganizationBaseTestCase):
+    """
+    Test Mission and Organization integration for Assets
+    """
+    def add_asset_to_organization(self, asset=None, organization=None, client=None, expected_status=200):
+        """
+        Add an asset to an organization
+        """
+        if client is None:
+            client = self.client1
+        if organization is None:
+            organization = self.create_organization(client=client)
+        if asset is None:
+            asset = self.create_asset()
+        organization_add_asset_url = f"/organization/{organization['id']}/assets/{asset.pk}/"
+        response = client.post(organization_add_asset_url, {})
+        self.assertEqual(response.status_code, expected_status)
+
+    def test_mission_organization_add_asset(self):
+        """
+        Check that users in organizations can add organization assets to the mission
+        """
+        # Create a mission
+        mission = self.create_mission_by_url('test_mission_list', mission_description='test description')
+        # Create an organization and add it to this mission
+        org1 = self.create_organization(client=self.client2)
+        # Add this organization to the mission
+        self.add_organization_to_mission(mission, org1)
+        # Add an asset to the organization
+        asset = self.create_asset(owner=self.user2)
+        self.add_asset_to_organization(asset=asset, organization=org1, client=self.client2)
+        # Check a user in the organization can add an organization asset
+        mission_add_asset_url = f'/mission/{mission.pk}/assets/add/'
+        mission_assets_json = f'/mission/{mission.pk}/assets/json/'
+        response = self.client2.post(mission_add_asset_url, {'asset': asset.pk}, follow=True)
+        self.assertEqual(response.redirect_chain[0][1], 302)
+        # Check a user in the organization can remove the asset
+        mission_del_asset_url = f'/mission/{mission.pk}/assets/{asset.pk}/remove/'
+        response = self.client2.post(mission_del_asset_url, follow=True)
+        self.assertEqual(response.redirect_chain[0][1], 302)
+        response = self.client2.get(mission_assets_json)
+        self.assertEqual(response.status_code, 200)
+        assets_data = response.json()
+        self.assertEqual(len(assets_data['assets']), 0)
+
+    def test_mission_organization_removed_users_add_del_asset(self):
+        """
+        Check that users removed from an organization cannot add/remove organization assets from a mission
+        """
+        # Create a mission
+        mission = self.create_mission_by_url('test_mission_list', mission_description='test description')
+        # Create an organization and add it to this mission
+        org1 = self.create_organization(client=self.client1)
+        # Add second user to organization
+        self.add_user_to_org(organization=org1, user=self.user2, client=self.client1, role='A')
+        # Add an asset to the organization
+        asset = self.create_asset(owner=self.user1)
+        self.add_asset_to_organization(asset=asset, organization=org1, client=self.client1)
+        # Add this organization to the mission
+        self.add_organization_to_mission(mission, org1)
+        # Check a user in the organization can add an organization asset
+        mission_add_asset_url = f'/mission/{mission.pk}/assets/add/'
+        mission_assets_json = f'/mission/{mission.pk}/assets/json/'
+        response = self.client2.post(mission_add_asset_url, {'asset': asset.pk}, follow=True)
+        self.assertEqual(response.redirect_chain[0][1], 302)
+        # Check a user in the organization can remove the asset
+        mission_del_asset_url = f'/mission/{mission.pk}/assets/{asset.pk}/remove/'
+        response = self.client2.post(mission_del_asset_url, follow=True)
+        self.assertEqual(response.redirect_chain[0][1], 302)
+        response = self.client2.get(mission_assets_json)
+        self.assertEqual(response.status_code, 200)
+        assets_data = response.json()
+        self.assertEqual(len(assets_data['assets']), 0)
+        # Remove the user from organization and try again
+        self.del_user_from_org(organization=org1, user=self.user2, client=self.client1)
+        response = self.client2.post(mission_add_asset_url, {'asset': asset.pk}, follow=True)
+        self.assertEqual(response.status_code, 404)
+        # Add the user to mission directly
+        mission_add_user_url = f'/mission/{mission.pk}/users/add/'
+        response = self.client1.post(mission_add_user_url, {'user': self.user2.pk})
+        self.assertEqual(response.status_code, 302)
+        # Try adding the asset
+        response = self.client2.post(mission_add_asset_url, {'asset': asset.pk})
+        self.assertEqual(response.status_code, 200)  # this is a failure, the form is being shown
+        # Add with a user that is actually allowed to
+        response = self.client1.post(mission_add_asset_url, {'asset': asset.pk}, follow=True)
+        self.assertEqual(response.redirect_chain[0][1], 302)
+        # Try removing the asset
+        response = self.client2.post(mission_del_asset_url)
+        self.assertEqual(response.status_code, 403)

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -2,8 +2,6 @@
 Tests for missions
 """
 
-import json
-
 from django.test import Client
 
 from assets.tests import AssetTestFunctionsBase
@@ -32,6 +30,14 @@ class MissionBaseTestCase(AssetTestFunctionsBase):
         Add user2 to the mission
         """
         MissionUser(mission=mission, user=self.user2, creator=self.user1).save()
+
+    def get_mission_list(self, client=None):
+        """
+        Get the current mission list
+        """
+        if client is None:
+            client = self.client1
+        return client.get('/mission/list/').json()['missions']
 
 
 class MissionTestCase(MissionBaseTestCase):
@@ -147,180 +153,40 @@ class MissionTestCase(MissionBaseTestCase):
         """
         Check the mission list contains missions and their correct details
         """
-        mission_list_url = '/mission/list/'
         # Check there are no missions in the list
-        response = self.client1.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 0)
+        mission_list = self.get_mission_list()
+        self.assertEqual(len(mission_list), 0)
         # Create a mission and check it appears in the list
         mission = self.create_mission_by_url('test_mission_list', mission_description='test description')
-        response = self.client1.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 1)
+        mission_list = self.get_mission_list()
+        self.assertEqual(len(mission_list), 1)
         # Check the details of the mission appear
-        self.assertEqual(mission_data['missions'][0]['id'], mission.pk)
-        self.assertEqual(mission_data['missions'][0]['name'], 'test_mission_list')
-        self.assertEqual(mission_data['missions'][0]['description'], 'test description')
-        self.assertIsNotNone(mission_data['missions'][0]['started'])
-        self.assertEqual(mission_data['missions'][0]['creator'], self.user1.username)
-        self.assertIsNone(mission_data['missions'][0]['closed'])
-        self.assertIsNone(mission_data['missions'][0]['closed_by'])
+        self.assertEqual(mission_list[0]['id'], mission.pk)
+        self.assertEqual(mission_list[0]['name'], 'test_mission_list')
+        self.assertEqual(mission_list[0]['description'], 'test description')
+        self.assertIsNotNone(mission_list[0]['started'])
+        self.assertEqual(mission_list[0]['creator'], self.user1.username)
+        self.assertIsNone(mission_list[0]['closed'])
+        self.assertIsNone(mission_list[0]['closed_by'])
         # Check the mission doesn't appear in other users lists
-        response = self.client2.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 0)
+        mission_list = self.get_mission_list(client=self.client2)
+        self.assertEqual(len(mission_list), 0)
         # Add a user and check they now see the mission
-        self.mission_add_user2(mission)
-        response = self.client2.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 1)
+        mission_list = self.get_mission_list(client=self.client2)
+        self.assertEqual(len(mission_list), 1)
         # Close the mission and check it appears as closed
         mission_close_url = f'/mission/{mission.pk}/close/'
         self.client1.get(mission_close_url)
-        response = self.client1.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 1)
+        mission_list = self.get_mission_list()
+        self.assertEqual(len(mission_list), 1)
         # Check the details of the mission appear
-        self.assertEqual(mission_data['missions'][0]['id'], mission.pk)
-        self.assertEqual(mission_data['missions'][0]['name'], 'test_mission_list')
-        self.assertEqual(mission_data['missions'][0]['description'], 'test description')
-        self.assertIsNotNone(mission_data['missions'][0]['started'])
-        self.assertEqual(mission_data['missions'][0]['creator'], self.user1.username)
-        self.assertIsNotNone(mission_data['missions'][0]['closed'])
-        self.assertEqual(mission_data['missions'][0]['closed_by'], self.user1.username)
-
-
-class MissionOrganizationBaseTestCase(MissionBaseTestCase):
-    """
-    Base setup/functions for testing Mission/Organization integration
-    """
-    def create_organization(self, organization_name='org', client=None):
-        """
-        Create an organization
-        """
-        organization_create_url = '/organization/create/'
-        if client is None:
-            client = self.client1
-        response = client.post(organization_create_url, {'name': organization_name})
-        self.assertEqual(response.status_code, 200)
-        return response.json()
-
-    def add_user_to_org(self, organization=None, user=None, client=None, role='M'):
-        """
-        Add a user to an organization
-        """
-        if client is None:
-            client = self.client1
-        if organization is None:
-            organization = self.create_organization(client=client)
-        organization_user_add_url = f"/organization/{organization['id']}/user/{user}/"
-        response = client.post(organization_user_add_url, {'role': role})
-        self.assertEqual(response.status_code, 200)
-
-    def del_user_from_org(self, organization=None, user=None, client=None):
-        """
-        Remove a user from the organization
-        """
-        if client is None:
-            client = self.client1
-        if organization is None:
-            organization = self.create_organization(client=client)
-        organization_user_del_url = f"/organization/{organization['id']}/user/{user}/"
-        response = client.delete(organization_user_del_url)
-        self.assertEqual(response.status_code, 200)
-
-    def add_organization_to_mission(self, mission, organization):
-        """
-        Add an organization to a mission
-        """
-        add_org_url = f'/mission/{mission.pk}/organizations/add/'
-        response = self.client1.post(add_org_url, data={'organization': organization['id']}, follow=True)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.redirect_chain[0][1], 302)
-
-
-class MissionOrganizationsTestCase(MissionOrganizationBaseTestCase):
-    """
-    Test Mission and Organization integration
-    """
-    def test_mission_organization_list(self):
-        """
-        Check that users in organizations can see one copy of the mission in the list
-        """
-        mission_list_url = '/mission/list/'
-        # Check there are no missions in the list
-        response = self.client1.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 0)
-        # Create a mission and check it appears
-        mission = self.create_mission_by_url('test_mission_list', mission_description='test description')
-        response = self.client1.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 1)
-        # Create an organization and add it to this mission
-        org1 = self.create_organization()
-        # Add this organization to the mission
-        self.add_organization_to_mission(mission, org1)
-        # Check the mission list still only has 1 entry
-        response = self.client1.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 1)
-
-    def test_mission_organization_list_for_other(self):
-        """
-        Check that users can see missions because they are a member of an organization added to the mission
-        """
-        mission_list_url = '/mission/list/'
-        # Check there are no missions in the list
-        response = self.client2.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 0)
-        # Create a mission and check it appears
-        mission = self.create_mission_by_url('test_mission_list', mission_description='test description')
-        # Check the other user cant see this mission yet
-        response = self.client2.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 0)
-        # Create an organization and add it to this mission
-        org1 = self.create_organization()
-        # Add this organization to the mission
-        self.add_organization_to_mission(mission, org1)
-        # Add the other user to the organization
-        self.add_user_to_org(organization=org1, user=self.user2, client=self.client1)
-        # Check the other user can now see this mission
-        response = self.client2.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 1)
-
-    def test_mission_organization_deleted_user(self):
-        """
-        Check that a user removed from an organization no longer sees missions that organization is a member of
-        """
-        mission_list_url = '/mission/list/'
-        # Create an organization, make both users a member
-        org1 = self.create_organization()
-        self.add_user_to_org(organization=org1, user=self.user2, client=self.client1)
-        # Check there are no missions in the list
-        response = self.client2.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 0)
-        # Create a mission and check it appears
-        mission = self.create_mission_by_url('test_mission_org_removed', mission_description='test description')
-        # Check the other user cant see this mission yet
-        response = self.client2.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 0)
-        # Add this organization to the mission
-        self.add_organization_to_mission(mission, org1)
-        # Check the other user can now see this mission
-        response = self.client2.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 1)
-        # Remove the user from the organization, check it disappears for them
-        self.del_user_from_org(organization=org1, user=self.user2, client=self.client1)
-        response = self.client2.get(mission_list_url)
-        mission_data = json.loads(response.content)
-        self.assertEqual(len(mission_data['missions']), 0)
+        self.assertEqual(mission_list[0]['id'], mission.pk)
+        self.assertEqual(mission_list[0]['name'], 'test_mission_list')
+        self.assertEqual(mission_list[0]['description'], 'test description')
+        self.assertIsNotNone(mission_list[0]['started'])
+        self.assertEqual(mission_list[0]['creator'], self.user1.username)
+        self.assertIsNotNone(mission_list[0]['closed'])
+        self.assertEqual(mission_list[0]['closed_by'], self.user1.username)
 
 
 class MissionAssetsTestCase(MissionBaseTestCase):
@@ -387,14 +253,14 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         mission_assets_json = f'/mission/{mission.pk}/assets/json/'
         response = self.client1.get(mission_assets_json)
         self.assertEqual(response.status_code, 200)
-        assets_data = json.loads(response.content)
+        assets_data = response.json()
         self.assertEqual(len(assets_data['assets']), 0)
         # Add the asset
         response = self.client1.post(mission_add_asset_url, {'asset': self.asset.pk}, follow=True)
         self.assertEqual(response.redirect_chain[0][1], 302)
         response = self.client1.get(mission_assets_json)
         self.assertEqual(response.status_code, 200)
-        assets_data = json.loads(response.content)
+        assets_data = response.json()
         self.assertEqual(len(assets_data['assets']), 1)
         self.assertEqual(assets_data['assets'][0]['name'], self.asset.name)
         self.assertEqual(assets_data['assets'][0]['type_name'], self.asset_type.name)
@@ -403,97 +269,5 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         self.assertEqual(response.redirect_chain[0][1], 302)
         response = self.client1.get(mission_assets_json)
         self.assertEqual(response.status_code, 200)
-        assets_data = json.loads(response.content)
+        assets_data = response.json()
         self.assertEqual(len(assets_data['assets']), 0)
-
-
-class MissionOrganizationsAssetsTestCase(MissionOrganizationBaseTestCase):
-    """
-    Test Mission and Organization integration for Assets
-    """
-    def add_asset_to_organization(self, asset=None, organization=None, client=None, expected_status=200):
-        """
-        Add an asset to an organization
-        """
-        if client is None:
-            client = self.client1
-        if organization is None:
-            organization = self.create_organization(client=client)
-        if asset is None:
-            asset = self.create_asset()
-        organization_add_asset_url = f"/organization/{organization['id']}/assets/{asset.pk}/"
-        response = client.post(organization_add_asset_url, {})
-        self.assertEqual(response.status_code, expected_status)
-
-    def test_mission_organization_add_asset(self):
-        """
-        Check that users in organizations can add organization assets to the mission
-        """
-        # Create a mission
-        mission = self.create_mission_by_url('test_mission_list', mission_description='test description')
-        # Create an organization and add it to this mission
-        org1 = self.create_organization(client=self.client2)
-        # Add this organization to the mission
-        self.add_organization_to_mission(mission, org1)
-        # Add an asset to the organization
-        asset = self.create_asset(owner=self.user2)
-        self.add_asset_to_organization(asset=asset, organization=org1, client=self.client2)
-        # Check a user in the organization can add an organization asset
-        mission_add_asset_url = f'/mission/{mission.pk}/assets/add/'
-        mission_assets_json = f'/mission/{mission.pk}/assets/json/'
-        response = self.client2.post(mission_add_asset_url, {'asset': asset.pk}, follow=True)
-        self.assertEqual(response.redirect_chain[0][1], 302)
-        # Check a user in the organization can remove the asset
-        mission_del_asset_url = f'/mission/{mission.pk}/assets/{asset.pk}/remove/'
-        response = self.client2.post(mission_del_asset_url, follow=True)
-        self.assertEqual(response.redirect_chain[0][1], 302)
-        response = self.client2.get(mission_assets_json)
-        self.assertEqual(response.status_code, 200)
-        assets_data = json.loads(response.content)
-        self.assertEqual(len(assets_data['assets']), 0)
-
-    def test_mission_organization_removed_users_add_del_asset(self):
-        """
-        Check that users removed from an organization cannot add/remove organization assets from a mission
-        """
-        # Create a mission
-        mission = self.create_mission_by_url('test_mission_list', mission_description='test description')
-        # Create an organization and add it to this mission
-        org1 = self.create_organization(client=self.client1)
-        # Add second user to organization
-        self.add_user_to_org(organization=org1, user=self.user2, client=self.client1, role='A')
-        # Add an asset to the organization
-        asset = self.create_asset(owner=self.user1)
-        self.add_asset_to_organization(asset=asset, organization=org1, client=self.client1)
-        # Add this organization to the mission
-        self.add_organization_to_mission(mission, org1)
-        # Check a user in the organization can add an organization asset
-        mission_add_asset_url = f'/mission/{mission.pk}/assets/add/'
-        mission_assets_json = f'/mission/{mission.pk}/assets/json/'
-        response = self.client2.post(mission_add_asset_url, {'asset': asset.pk}, follow=True)
-        self.assertEqual(response.redirect_chain[0][1], 302)
-        # Check a user in the organization can remove the asset
-        mission_del_asset_url = f'/mission/{mission.pk}/assets/{asset.pk}/remove/'
-        response = self.client2.post(mission_del_asset_url, follow=True)
-        self.assertEqual(response.redirect_chain[0][1], 302)
-        response = self.client2.get(mission_assets_json)
-        self.assertEqual(response.status_code, 200)
-        assets_data = json.loads(response.content)
-        self.assertEqual(len(assets_data['assets']), 0)
-        # Remove the user from organization and try again
-        self.del_user_from_org(organization=org1, user=self.user2, client=self.client1)
-        response = self.client2.post(mission_add_asset_url, {'asset': asset.pk}, follow=True)
-        self.assertEqual(response.status_code, 404)
-        # Add the user to mission directly
-        mission_add_user_url = f'/mission/{mission.pk}/users/add/'
-        response = self.client1.post(mission_add_user_url, {'user': self.user2.pk})
-        self.assertEqual(response.status_code, 302)
-        # Try adding the asset
-        response = self.client2.post(mission_add_asset_url, {'asset': asset.pk})
-        self.assertEqual(response.status_code, 200)  # this is a failure, the form is being shown
-        # Add with a user that is actually allowed to
-        response = self.client1.post(mission_add_asset_url, {'asset': asset.pk}, follow=True)
-        self.assertEqual(response.redirect_chain[0][1], 302)
-        # Try removing the asset
-        response = self.client2.post(mission_del_asset_url)
-        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
## Description

Split the mission tests based on what they are testing

Also:
* refactor the tests so they don't directly use the json library
* use common function to get the mission list

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change