### PR TITLE
asset: use asset id rather than name in urls

### DIFF
--- a/assets/decorators.py
+++ b/assets/decorators.py
@@ -16,12 +16,12 @@ def asset_is_recorder(view_func):
     """
     def recorder_check(*args, **kwargs):
         allowed = False
-        asset = get_object_or_404(Asset, name=kwargs['asset_name'])
+        asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
         if asset.owner == args[0].user or organization_user_is_asset_recorder(args[0].user, asset):
             allowed = True
         if not allowed:
             return HttpResponseForbidden("Not Authorized to record the position of this asset")
-        kwargs.pop('asset_name')
+        kwargs.pop('asset_id')
         return view_func(*args, asset=asset, **kwargs)
     return recorder_check
 

--- a/assets/models.py
+++ b/assets/models.py
@@ -71,9 +71,9 @@ class Asset(models.Model):
 
     def natural_key(self):
         """
-        Use the asset name when referring to the asset during serialization (i.e. to geojson).
+        Use the asset id when referring to the asset during serialization (i.e. to geojson).
         """
-        return self.name
+        return self.pk
 
     def __str__(self):
         return self.name

--- a/assets/templates/assets/ui.html
+++ b/assets/templates/assets/ui.html
@@ -13,6 +13,6 @@
         <div id="root"></div>
     </body>
     <script>
-        createAssetUI('root', '{{assetName}}')
+        createAssetUI('root', '{{assetId}}')
     </script>
 </html>

--- a/assets/test_asset.py
+++ b/assets/test_asset.py
@@ -50,15 +50,15 @@ class AssetTestCase(TestCase):
 
     def test_asset_natural_key(self):
         """
-        Check the natural key is the name
+        Check the natural key is the pk
         """
         pccr = Asset.objects.get(name='PCCR')
         fx_79_1 = Asset.objects.get(name='FX-79-1')
         fx_79_2 = Asset.objects.get(name='FX-79-2')
-        self.assertEqual(pccr.natural_key(), 'PCCR')
-        self.assertEqual(fx_79_1.natural_key(), 'FX-79-1')
-        self.assertEqual(fx_79_2.natural_key(), 'FX-79-2')
-        # Check it works correctly as the primry key
+        self.assertEqual(pccr.natural_key(), pccr.pk)
+        self.assertEqual(fx_79_1.natural_key(), fx_79_1.pk)
+        self.assertEqual(fx_79_2.natural_key(), fx_79_2.pk)
+        # Check it works correctly as the primary key
         serialised = serializers.serialize('json', [pccr], use_natural_primary_keys=True)
         data = json.loads(serialised)
         self.assertFalse('pk' in data[0])

--- a/assets/test_asset_status.py
+++ b/assets/test_asset_status.py
@@ -147,7 +147,7 @@ class AssetStatusUrlTestCase(AssetStatusBase):
             client = self.client1
         if asset is None:
             asset = self.asset1
-        return client.get(f'/assets/{asset.name}/details/').json()
+        return client.get(f'/assets/{asset.pk}/details/').json()
 
     def get_asset_status(self, client=None, asset=None):
         """
@@ -157,7 +157,7 @@ class AssetStatusUrlTestCase(AssetStatusBase):
             client = self.client1
         if asset is None:
             asset = self.asset1
-        return client.get(f'/assets/{asset.name}/status/').json()
+        return client.get(f'/assets/{asset.pk}/status/').json()
 
     def set_asset_status(self, client=None, asset=None, value=None, notes=None):
         """
@@ -174,7 +174,7 @@ class AssetStatusUrlTestCase(AssetStatusBase):
         }
         if notes is not None:
             data['notes'] = notes
-        return client.post(f'/assets/{asset.name}/status/', data=data)
+        return client.post(f'/assets/{asset.pk}/status/', data=data)
 
     def test_0001_get_asset_status(self):
         """

--- a/assets/tests.py
+++ b/assets/tests.py
@@ -171,7 +171,7 @@ class AssetTestCase(AssetTestFunctionsBase):
         asset_type = self.create_asset_type()
         asset_name = 'test_asset'
         asset = self.create_asset(name=asset_name, asset_type=asset_type)
-        asset_details_url = f'/assets/{asset_name}/details/'
+        asset_details_url = f'/assets/{asset.pk}/details/'
         response = self.client1.get(asset_details_url)
         self.assertEqual(response.status_code, 200)
         json_data = response.json()
@@ -199,7 +199,7 @@ class AssetTestCase(AssetTestFunctionsBase):
         asset_type = self.create_asset_type()
         asset_name = 'test_asset'
         asset = self.create_asset(name=asset_name, asset_type=asset_type)
-        asset_details_url = f'/assets/{asset_name}/details/'
+        asset_details_url = f'/assets/{asset.pk}/details/'
         mission_asset = self.add_asset_to_mission(asset=asset)
         response = self.client1.get(asset_details_url)
         self.assertEqual(response.status_code, 200)
@@ -241,7 +241,7 @@ class AssetTestCase(AssetTestFunctionsBase):
         Check that only the owner can access the assets UI page
         """
         asset = self.create_asset()
-        asset_ui_url = f'/assets/{asset.name}/ui/'
+        asset_ui_url = f'/assets/{asset.pk}/ui/'
 
         # Check the owner has access
         response = self.client1.get(asset_ui_url)
@@ -261,8 +261,8 @@ class AssetTestCase(AssetTestFunctionsBase):
         in response to reporting their position
         """
         asset = self.create_asset()
-        asset_details_url = f'/assets/{asset.name}/details/'
-        asset_report_position_url = f'/data/assets/{asset.name}/position/add/'
+        asset_details_url = f'/assets/{asset.pk}/details/'
+        asset_report_position_url = f'/data/assets/{asset.pk}/position/add/'
         asset_set_command_url = f'/mission/{self.mission.pk}/assets/command/set/'
 
         # Check the initial case (no command)

--- a/assets/urls.py
+++ b/assets/urls.py
@@ -11,9 +11,9 @@ urlpatterns = [
     re_path(r'^assets/assettypes/json/$', views.asset_types_list, name='asset_types_list'),
     re_path(r'^assets/mine/json/$', views.assets_mine_list, name='assets_mine_list'),
     re_path(r'^assets/$', views.assets_list, name='assets_list'),
-    re_path(r'^assets/(?P<asset_name>.*)/ui/$', views.assets_ui, name='assets_ui'),
-    re_path(r'^assets/(?P<asset_name>.*)/details/$', views.asset_details, name='assets_details'),
-    re_path(r'^assets/(?P<asset_name>.*)/status/$', views.asset_status, name='assets_status'),
+    re_path(r'^assets/(?P<asset_id>\d+)/ui/$', views.assets_ui, name='assets_ui'),
+    re_path(r'^assets/(?P<asset_id>\d+)/details/$', views.asset_details, name='assets_details'),
+    re_path(r'^assets/(?P<asset_id>\d+)/status/$', views.asset_status, name='assets_status'),
     re_path(r'^assets/status/values/$', views.assets_status_value_list, name='asset_status_values_list'),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/command/set/$', views.asset_command_set, name='asset_command_set'),
 ]

--- a/assets/views.py
+++ b/assets/views.py
@@ -60,15 +60,15 @@ def assets_ui(request, asset):
     """
     Present UI for an Asset
     """
-    return render(request, 'assets/ui.html', {'assetName': asset.name})
+    return render(request, 'assets/ui.html', {'assetId': asset.pk, 'assetName': asset.name})
 
 
 @login_required
-def asset_details(request, asset_name):
+def asset_details(request, asset_id):
     """
     Provide the details of an asset
     """
-    asset = get_object_or_404(Asset, name=asset_name)
+    asset = get_object_or_404(Asset, pk=asset_id)
 
     data = {
         'asset_id': asset.pk,
@@ -127,11 +127,11 @@ def asset_command_set(request, mission_user):
 
 
 @login_required
-def asset_status(request, asset_name):
+def asset_status(request, asset_id):
     """
     Get or set the asset status for a given asset
     """
-    asset = get_object_or_404(Asset, name=asset_name)
+    asset = get_object_or_404(Asset, pk=asset_id)
 
     if request.method == 'GET':
         status = AssetStatus.current_for_asset(asset)

--- a/data/urls.py
+++ b/data/urls.py
@@ -9,8 +9,8 @@ from . import views
 
 urlpatterns = [
     re_path(r'^mission/(?P<mission_id>\d+)/data/assets/positions/latest/$', views.assets_position_latest, name='assets_position_latest'),
-    re_path(r'^data/assets/(?P<asset_name>.*)/position/add/$', views.asset_record_position, name='asset_record_position'),
-    re_path(r'^mission/(?P<mission_id>\d+)/data/assets/(?P<asset_name>.*)/position/history/$', views.asset_position_history_mission, name='asset_position_history'),
+    re_path(r'^data/assets/(?P<asset_id>\d+)/position/add/$', views.asset_record_position, name='asset_record_position'),
+    re_path(r'^mission/(?P<mission_id>\d+)/data/assets/(?P<asset_id>\d+)/position/history/$', views.asset_position_history_mission, name='asset_position_history'),
 
     re_path(r'^mission/(?P<mission_id>\d+)/data/users/positions/latest/$', views.users_position_latest, name='users_position_latest'),
     re_path(r'^mission/(?P<mission_id>\d+)/data/user/(?P<user>.*)/position/add/$', views.user_record_position, name='user_position_record'),
@@ -40,7 +40,7 @@ urlpatterns = [
     re_path(r'^mission/(?P<mission_id>\d+)/data/assets/typhoon/upload/$', views.upload_typhoonh_data, name='upload_typhoonh_data'),
 
     re_path(r'^mission/all/data/assets/positions/latest/$', views.assets_position_latest_user, {'current_only': False}),
-    re_path(r'^mission/all/data/assets/(?P<asset_name>.*)/position/history/$', views.asset_position_history_user, {'current_only': False}),
+    re_path(r'^mission/all/data/assets/(?P<asset_id>\d+)/position/history/$', views.asset_position_history_user, {'current_only': False}),
     re_path(r'^mission/all/data/users/positions/latest/$', views.users_position_latest_user, {'current_only': False}),
     re_path(r'^mission/all/data/users/(?P<user>.*)/position/history/$', views.user_position_history_user, {'current_only': False}),
     re_path(r'^mission/all/data/pois/current/$', views.data_all_all_missions_type, {'geo_type': 'poi'}),
@@ -48,7 +48,7 @@ urlpatterns = [
     re_path(r'^mission/all/data/userlines/current/$', views.data_all_all_missions_type, {'geo_type': 'line'}),
 
     re_path(r'^mission/current/data/assets/positions/latest/$', views.assets_position_latest_user, {'current_only': True}),
-    re_path(r'^mission/current/data/assets/(?P<asset_name>.*)/position/history/$', views.asset_position_history_user, {'current_only': True}),
+    re_path(r'^mission/current/data/assets/(?P<asset_id>\d+)/position/history/$', views.asset_position_history_user, {'current_only': True}),
     re_path(r'^mission/current/data/users/positions/latest/$', views.users_position_latest_user, {'current_only': True}),
     re_path(r'^mission/current/data/users/(?P<user>.*)/position/history/$', views.user_position_history_user, {'current_only': True}),
     re_path(r'^mission/current/data/pois/current/$', views.data_all_current_missions_type, {'geo_type': 'poi'}),

--- a/data/views.py
+++ b/data/views.py
@@ -131,7 +131,7 @@ def asset_record_position(request, asset):
     return HttpResponse("Continue")
 
 
-def asset_position_history(request, asset_name, mission=None, user=None, current_only=False):
+def asset_position_history(request, asset_id, mission=None, user=None, current_only=False):
     """
     Get the full track from an asset.
 
@@ -143,7 +143,7 @@ def asset_position_history(request, asset_name, mission=None, user=None, current
         if request.GET.get('oldest'):
             oldest = request.GET.get('oldest')
 
-    asset = get_object_or_404(Asset, name=asset_name)
+    asset = get_object_or_404(Asset, pk=asset_id)
 
     positions = AssetPointTime.objects
     if mission is not None:
@@ -165,23 +165,23 @@ def asset_position_history(request, asset_name, mission=None, user=None, current
 
 @login_required
 @mission_is_member
-def asset_position_history_mission(request, mission_user, asset_name):
+def asset_position_history_mission(request, mission_user, asset_id):
     """
     Get the full track from an asset.
 
     When from is provided, only points after the timestamp from are considered.
     """
-    return asset_position_history(request, asset_name, mission=mission_user.mission)
+    return asset_position_history(request, asset_id, mission=mission_user.mission)
 
 
 @login_required
-def asset_position_history_user(request, asset_name, current_only):
+def asset_position_history_user(request, asset_id, current_only):
     """
     Get the full track from an asset.
 
     When from is provided, only points after the timestamp from are considered.
     """
-    return asset_position_history(request, asset_name, user=request.user, current_only=current_only)
+    return asset_position_history(request, asset_id, user=request.user, current_only=current_only)
 
 
 @login_required

--- a/frontend/asset/list.js
+++ b/frontend/asset/list.js
@@ -21,7 +21,7 @@ class AssetListRow extends React.Component {
 
     if (this.props.showButtons) {
       const buttons = [
-        (<Button key='interface' href={`/assets/${asset.name}/ui/`}>Interface</Button>)
+        (<Button key='interface' href={`/assets/${asset.id}/ui/`}>Interface</Button>)
       ]
       dataFields.push((
         <td key='buttons'>

--- a/frontend/asset/ui.js
+++ b/frontend/asset/ui.js
@@ -445,16 +445,16 @@ class AssetUI extends React.Component {
   }
 }
 AssetUI.propTypes = {
-  asset: PropTypes.string.isRequired,
+  asset: PropTypes.number.isRequired,
   csrftoken: PropTypes.string.isRequired
 }
 
-function createAssetUI (elementId, assetName) {
+function createAssetUI (elementId, assetId) {
   const div = ReactDOM.createRoot(document.getElementById(elementId))
 
   const csrftoken = $('[name=csrfmiddlewaretoken]').val()
 
-  div.render(<><SMMTopBar /><AssetUI asset={assetName} csrftoken={csrftoken} /></>)
+  div.render(<><SMMTopBar /><AssetUI asset={assetId} csrftoken={csrftoken} /></>)
 }
 
 globalThis.createAssetUI = createAssetUI

--- a/frontend/organization/radio-operator.js
+++ b/frontend/organization/radio-operator.js
@@ -74,7 +74,7 @@ class OrganizationRadioOperatorPage extends React.Component {
     const assets = []
     for (const assetId in this.state.organizationAssets) {
       const asset = this.state.organizationAssets[assetId]
-      assets.push((<RadioOperatorAsset key={asset.id} asset={asset.asset.name} />))
+      assets.push((<RadioOperatorAsset key={asset.id} asset={asset.asset.id} />))
     }
     return (
       <Table responsive>


### PR DESCRIPTION
## Description

This means that assets can have overlapping names because they are now always identified by their id in the API

Fixes #318 

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change