### PR TITLE
organizations: add radio operator tests

### DIFF
--- a/assets/decorators.py
+++ b/assets/decorators.py
@@ -5,7 +5,7 @@ Function decorators for assets
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponseForbidden, HttpResponseNotAllowed
 
-from organization.helpers import organization_user_is_asset_recorder
+from organization.helpers import organization_user_is_asset_recorder, organization_user_is_asset_radio_operator
 
 from .models import Asset
 
@@ -52,7 +52,9 @@ def asset_id_in_get_post(view_func):
         else:
             return HttpResponseNotAllowed("Only GET and POST are supported")
         asset = get_object_or_404(Asset, pk=asset_id)
-        if asset.owner != request.user:
+        if asset.owner == request.user or organization_user_is_asset_radio_operator(args[0].user, asset):
+            allowed = True
+        if not allowed:
             return HttpResponseForbidden("Wrong User for Asset")
 
         return view_func(*args, asset=asset, **kwargs)

--- a/organization/helpers.py
+++ b/organization/helpers.py
@@ -13,3 +13,17 @@ def organization_user_is_asset_recorder(user, asset):
         if org_user.is_asset_recorder():
             return True
     return False
+
+
+def organization_user_is_asset_radio_operator(user, asset):
+    """
+    Check if given user is has privileges to act as radio operator for an asset
+    """
+    # Find all the organizations that this asset is a member of
+    org_memberships = OrganizationAsset.objects.filter(asset=asset, removed__isnull=True)
+    for org in org_memberships:
+        # see if this user is in the org
+        org_user = OrganizationMember.objects.get(user=user, organization=org.organization, removed__isnull=True)
+        if org_user.is_radio_operator():
+            return True
+    return False

--- a/organization/tests.py
+++ b/organization/tests.py
@@ -72,6 +72,14 @@ class OrganizationWrapper:
             client = self.smm.client1
         return client.post(f'/organization/{self.org_id}/assets/{asset.pk}/', {})
 
+    def get_radio_operator_ui(self, client=None):
+        """
+        Get the radio operator ui
+        """
+        if client is None:
+            client = self.smm.client1
+        return client.get(f'/organization/{self.org_id}/radio/operator/')
+
 
 class OrganizationFunctions:
     """

--- a/organization/tests_radio_operator.py
+++ b/organization/tests_radio_operator.py
@@ -1,0 +1,110 @@
+"""
+Tests for the radio operator role
+"""
+
+from django.test import TestCase
+from django.contrib.gis.geos import Point
+
+from data.models import GeoTimeLabel
+from search.models import Search, SearchParams
+
+from smm.tests import SMMTestUsers
+from assets.tests import AssetsHelpers
+from mission.tests import MissionFunctions
+from .tests import OrganizationFunctions
+
+
+class RadioOperatorTestCase(TestCase):
+    """
+    Tests for radio operator functionality
+    """
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        self.assets = AssetsHelpers(self.smm)
+        self.orgs = OrganizationFunctions(self.smm)
+        self.missions = MissionFunctions(self.smm)
+
+    def test_0001_radio_operator(self):
+        """
+        Check access to the radio operator url
+        """
+        org1 = self.orgs.create_organization(client=self.smm.client1)
+        # check the admin can access the radio operator url
+        response = org1.get_radio_operator_ui(client=self.smm.client1)
+        self.assertEqual(response.status_code, 200)
+        # check a user who is not in the organization cannot access it
+        response = org1.get_radio_operator_ui(client=self.smm.client2)
+        self.assertEqual(response.status_code, 404)
+        # check an unauthenticated client gets asked to authenticate
+        response = org1.get_radio_operator_ui(client=self.smm.unauth_client)
+        self.assertEqual(response.status_code, 302)
+
+    def test_0002_radio_operator_role(self):
+        """
+        Check a user that has the radio operator role can access the radio operator url
+        """
+        org1 = self.orgs.create_organization(client=self.smm.client1)
+        org1.add_user(self.smm.user2, role='R')
+        response = org1.get_radio_operator_ui(client=self.smm.client2)
+        self.assertEqual(response.status_code, 200)
+
+    def test_0010_asset_details(self):
+        """
+        Check a radio operator can access the asset details
+        """
+        org1 = self.orgs.create_organization(client=self.smm.client1)
+        asset1 = self.assets.create_asset()
+        asset_details_url = f'/assets/{asset1.pk}/details/'
+        response = self.smm.client1.get(asset_details_url)
+        self.assertEqual(response.status_code, 200)
+        # check another user cannot access the details currently
+        response = self.smm.client2.get(asset_details_url)
+        self.assertEqual(response.status_code, 200)
+        # Add the asset to the org
+        org1.add_asset(asset1)
+        response = self.smm.client2.get(asset_details_url)
+        self.assertEqual(response.status_code, 200)
+        # Check regular org members cannot access the asset details
+        org1.add_user(self.smm.user2, role='M')
+        response = self.smm.client2.get(asset_details_url)
+        self.assertEqual(response.status_code, 200)
+        # Check radio operators can access the details
+        org1.add_user(self.smm.user2, role='R')
+        response = self.smm.client2.get(asset_details_url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_0100_mission_asset_accept_search(self):
+        """
+        Check that a radio operator can accept a search on behalf of a half an asset
+        """
+        org1 = self.orgs.create_organization(client=self.smm.client1)
+        asset_type = self.assets.create_asset_type()
+        asset1 = self.assets.create_asset(asset_type=asset_type)
+        org1.add_asset(asset1)
+        mission = self.missions.create_mission('test_mission')
+        mission.add_organization(org1)
+        mission.add_asset(asset1)
+        asset_details_url = f'/assets/{asset1.pk}/details/'
+        json_data = self.smm.client1.get(asset_details_url).json()
+        # Create the POI and search object
+        poi = GeoTimeLabel.objects.create(geo=Point(172.5, -43.5), created_by=self.smm.user1, label='Test Point', geo_type='poi', mission=mission.get_object())
+        sector_search_create = '/search/sector/create/'
+        search_data = self.smm.client1.post(sector_search_create, {
+            'poi_id': poi.pk,
+            'asset_type_id': asset_type.pk,
+            'sweep_width': 200
+        }).json()
+        search_queue_url = f"/search/{search_data['features'][0]['properties']['pk']}/queue/"
+        self.smm.client1.post(search_queue_url, {'asset': asset1.pk})
+        search_begin_url = f"/search/${search_data['features'][0]['properties']['pk']}/begin/"
+        # Check a non-org member cannot do this
+        response = self.smm.client2.get(search_begin_url)
+        self.assertEqual(response.status_code, 404)
+        # Check that an org member who is not a radio operator cannot do this
+        org1.add_user(self.smm.user2, role='M')
+        response = self.smm.client2.get(search_begin_url)
+        self.assertEqual(response.status_code, 404)
+        # Check that the radio operator can begin this search
+        org1.add_user(self.smm.user2, role='R')
+        response = self.smm.client2.get(search_begin_url)
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Description

Add tests for the radio operator API

Resolves the issue where radio operators couldn't actually act as an asset to begin/complete a search for the asset.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change