### PR TITLE
Show asset and user names when mousing over marker icons on the map

### DIFF
--- a/frontend/asset/map.js
+++ b/frontend/asset/map.js
@@ -155,7 +155,7 @@ class SMMAssets extends SMMRealtime {
   }
 
   updateAssetNameMap () {
-    $.getJSON(`/mission/${this.missionId}/assets/json/`, this.assetListCB)
+    $.getJSON(`/mission/${this.missionId}/assets/json/?include_removed=true`, this.assetListCB)
   }
 
   realtime () {

--- a/frontend/asset/map.js
+++ b/frontend/asset/map.js
@@ -257,6 +257,9 @@ class SMMAssets extends SMMRealtime {
     if (asset.geometry.type === 'Point') {
       const c = asset.geometry.coordinates
       oldLayer.setLatLng([c[1], c[0]])
+      if (oldLayer._icon.title !== this.assetNameMap[assetId]) {
+        oldLayer._icon.title = this.assetNameMap[assetId]
+      }
       return oldLayer
     }
   }

--- a/frontend/user/map.js
+++ b/frontend/user/map.js
@@ -62,6 +62,7 @@ class SMMUserPositions extends SMMRealtime {
     this.userObjects = {}
     this.createPopup = this.createPopup.bind(this)
     this.userUpdate = this.userUpdate.bind(this)
+    this.userLayer = this.userLayer.bind(this)
   }
 
   getUrl () {
@@ -76,7 +77,8 @@ class SMMUserPositions extends SMMRealtime {
       interval: this.interval,
       onEachFeature: this.createPopup,
       updateFeature: this.userUpdate,
-      getFeatureId: function (feature) { return feature.properties.user }
+      getFeatureId: function (feature) { return feature.properties.user },
+      pointToLayer: this.userLayer
     })
   }
 
@@ -100,6 +102,12 @@ class SMMUserPositions extends SMMRealtime {
     popupContent.appendChild(document.createTextNode(userName))
 
     layer.bindPopup(popupContent, { minWidth: 200 })
+  }
+
+  userLayer (user, latlng) {
+    return L.marker(latlng, {
+      title: user.properties.user
+    })
   }
 
   userPathUpdate (userName) {

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -79,13 +79,16 @@ class MissionTestWrapper:
             client = self.smm.client1
         return client.get(f'/mission/{self.mission_pk}/assets/{asset.pk}/remove/', follow=True)
 
-    def get_asset_list(self, client=None):
+    def get_asset_list(self, client=None, include_removed=False):
         """
         Get the list of assets in this mission
         """
         if client is None:
             client = self.smm.client1
-        return client.get(f'/mission/{self.mission_pk}/assets/json/')
+        extra = ''
+        if include_removed:
+            extra = '?include_removed=true'
+        return client.get(f'/mission/{self.mission_pk}/assets/json/{extra}')
 
     def add_organization(self, organization, client=None):
         """
@@ -386,3 +389,8 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         self.assertEqual(response.status_code, 200)
         assets_data = response.json()
         self.assertEqual(len(assets_data['assets']), 0)
+        # Check getting all results
+        response = mission.get_asset_list(client=self.smm.client1, include_removed=True)
+        self.assertEqual(response.status_code, 200)
+        assets_data = response.json()
+        self.assertEqual(len(assets_data['assets']), 1)

--- a/mission/views.py
+++ b/mission/views.py
@@ -292,7 +292,11 @@ def mission_asset_json(request, mission_user):
     """
     List Assets in a Mission
     """
-    assets = MissionAsset.objects.filter(mission=mission_user.mission, removed__isnull=True)
+    include_removed = request.GET.get('include_removed', False)
+    if include_removed:
+        assets = MissionAsset.objects.filter(mission=mission_user.mission)
+    else:
+        assets = MissionAsset.objects.filter(mission=mission_user.mission, removed__isnull=True)
     assets_json = []
     for mission_asset in assets:
         assets_json.append({


### PR DESCRIPTION
## Description

On the map, the default icon for all assets and users is the same. The user can click on each one to see which asset/user it is, or turn on the trails.
We can also make it easier to identify which is which by setting the title of the marker so when it is moused over the name of the asset/user will appear.

Additionally, there is an issue with the displaying of asset names for assets that have been removed from the mission.
This is resolved by making it optional to get all assets from the mission, not just the current one

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change