### PR TITLE
frontend: show a link to the usergeo object the search was created from

### DIFF
--- a/frontend/search/details.js
+++ b/frontend/search/details.js
@@ -5,6 +5,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import * as ReactDOM from 'react-dom/client'
 import Collapsible from 'react-collapsible'
+import { Button } from 'react-bootstrap'
 
 import $ from 'jquery'
 
@@ -27,6 +28,13 @@ class SearchDetails extends SMMObjectDetails {
       <tr key='created_for'>
         <td>Asset Type:</td>
         <td>{data.created_for}</td>
+      </tr>
+    ))
+
+    tableRows.push((
+      <tr key='datum'>
+        <td>Created From:</td>
+        <td><Button href={ `/data/usergeo/${data.datum}/` }>{data.datum}</Button></td>
       </tr>
     ))
 

--- a/search/models.py
+++ b/search/models.py
@@ -112,6 +112,7 @@ class Search(GeoTime):
         'created_at',
         'created_by',
         'created_for',
+        'datum',
         'deleted_at',
         'deleted_by',
         'replaced_at',


### PR DESCRIPTION
## Description

This can help improve the context of the search because the usergeo can include a label which might help identifying the feature/search target

Resolves: #384

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change