### PR TITLE
frontend: fix deleting of usergeo objects

### DIFF
--- a/frontend/usergeo/line.js
+++ b/frontend/usergeo/line.js
@@ -10,6 +10,7 @@ class SMMLine {
     this.coords = line.geometry.coordinates
     this.LineLabel = line.properties.label
     this.LineID = line.properties.pk
+    this.setXHR = this.setXHR.bind(this)
     this.editCallback = this.editCallback.bind(this)
     this.deleteCallback = this.deleteCallback.bind(this)
     this.createSearchCallback = this.createSearchCallback.bind(this)
@@ -19,10 +20,15 @@ class SMMLine {
     L.LineAdder(this.parent.map, this.parent.missionId, this.parent.csrftoken, this.coords.map(x => L.latLng(x[1], x[0])), this.LineID, this.LineLabel)
   }
 
+  setXHR (xhr) {
+    xhr.setRequestHeader('X-CSRFToken', this.parent.csrftoken)
+  }
+
   deleteCallback () {
     $.ajax({
-      url: `/data/userlines/${this.LineID}/`,
-      method: 'DELETE'
+      url: `/data/usergeo/${this.LineID}/`,
+      type: 'DELETE',
+      beforeSend: this.setXHR
     })
   }
 

--- a/frontend/usergeo/poi.js
+++ b/frontend/usergeo/poi.js
@@ -14,6 +14,7 @@ class SMMPOI {
     this.POILabel = poi.properties.label
     this.poiID = poi.properties.pk
     this.editCallback = this.editCallback.bind(this)
+    this.setXHR = this.setXHR.bind(this)
     this.deleteCallback = this.deleteCallback.bind(this)
     this.createSearchCallback = this.createSearchCallback.bind(this)
     this.calculateTDVCallback = this.calculateTDVCallback.bind(this)
@@ -23,10 +24,15 @@ class SMMPOI {
     L.POIAdder(this.parent.map, this.parent.missionId, this.parent.csrftoken, L.latLng(this.coords[1], this.coords[0]), this.poiID, this.POILabel)
   }
 
+  setXHR (xhr) {
+    xhr.setRequestHeader('X-CSRFToken', this.parent.csrftoken)
+  }
+
   deleteCallback () {
     $.ajax({
-      url: `/data/pois/${this.poiID}/`,
-      method: 'DELETE'
+      url: `/data/usergeo/${this.poiID}/`,
+      type: 'DELETE',
+      beforeSend: this.setXHR
     })
   }
 

--- a/frontend/usergeo/polygon.js
+++ b/frontend/usergeo/polygon.js
@@ -11,6 +11,7 @@ class SMMPolygon {
     this.PolyID = polygon.properties.pk
     this.coords = polygon.geometry.coordinates
     this.editCallback = this.editCallback.bind(this)
+    this.setXHR = this.setXHR.bind(this)
     this.deleteCallback = this.deleteCallback.bind(this)
     this.createSearchCallback = this.createSearchCallback.bind(this)
   }
@@ -19,10 +20,15 @@ class SMMPolygon {
     L.PolygonAdder(this.parent.map, this.parent.missionId, this.parent.csrftoken, this.coords[0].map(x => L.latLng(x[1], x[0])), this.PolyID, this.PolyLabel)
   }
 
+  setXHR (xhr) {
+    xhr.setRequestHeader('X-CSRFToken', this.parent.csrftoken)
+  }
+
   deleteCallback () {
     $.ajax({
       url: `/data/usergeo/${this.PolyID}/`,
-      method: 'DELETE'
+      type: 'DELETE',
+      beforeSend: this.setXHR
     })
   }
 


### PR DESCRIPTION
## Description

Send the delete to the correct path, and include the CSRF token

Fixes: b2685df frontend: use the new usergeo DELETE API to remove objects

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change