### PR TITLE
Add psycopg connection pool support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytz
 
 # Database
 psycopg[binary]==3.2.1
+psycopg[pool]==3.2.1
 
 # Code checking
 pycodestyle

--- a/smm/local_settings.py.template
+++ b/smm/local_settings.py.template
@@ -21,5 +21,8 @@ DATABASES = {
         'NAME': 'POSTGRES_DBNAME',
         'USER': 'POSTGRES_USER',
         'PASSWORD': 'POSTGRES_PASSWORD',
+        'OPTIONS': {
+            'pool': True,
+        },
     }
 }


### PR DESCRIPTION
## Description

Django supports connection pools from 5.1 onwards, so make use of them

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change