### PR TITLE
Fix organization member query that returns removed users

### DIFF
--- a/organization/decorators.py
+++ b/organization/decorators.py
@@ -10,7 +10,7 @@ def organization_member_get(organization_id, user):
     Get the organization_member for the given organization id and user.
     """
     organization = get_object_or_404(Organization, pk=organization_id)
-    organization_member = get_object_or_404(OrganizationMember, organization=organization, user=user)
+    organization_member = get_object_or_404(OrganizationMember, organization=organization, user=user, removed__isnull=True)
     return organization_member
 
 


### PR DESCRIPTION
## Description

The organization member decorate wasn't accounting for whether a user has been removed
This results in users having access to data they shouldn't, and also errors when the user is re-added to the org


## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change