### PR TITLE
Suppress warnings about too many positional arguments

### DIFF
--- a/mission/test_mission_asset_status.py
+++ b/mission/test_mission_asset_status.py
@@ -30,7 +30,7 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         """
         return MissionAssetStatusValue.objects.create(name=name, description=description)
 
-    # pylint: disable=R0913
+    # pylint: disable=R0913,R0917
     def set_mission_asset_status(self, mission, asset, status, notes=None, client=None):
         """
         Set the mission assets status

--- a/search/models.py
+++ b/search/models.py
@@ -78,7 +78,7 @@ class FirstPointDistance(Func):
     function = 'ST_Distance'
 
     def as_sql(self, compiler, connection, function=None, template=None, arg_joiner=None, **extra_context):
-        # pylint: disable=R0913
+        # pylint: disable=R0913,R0917
         point_sql = f"ST_Point({self.extra['point'].x},{self.extra['point'].y},4326)::geography"
         return super().as_sql(compiler, connection, function='ST_Distance', template="%(function)s(ST_PointN(geo::geometry,1)::geography, " + point_sql + ")",
                               arg_joiner=arg_joiner, extra_context=extra_context)
@@ -171,7 +171,7 @@ class Search(GeoTime):
         return cls.filter_objects(objects, current_at=current_at, started=started, finished=finished)
 
     @classmethod
-    # pylint: disable=R0913
+    # pylint: disable=R0913,R0917
     def all_current_user(cls, user, current_at=None, current_only=False, started=False, finished=False):
         """
         Get all the searches that are current and finished as per params
@@ -521,7 +521,7 @@ class ExpandingBoxSearchParams(SearchParams):
     Parameters for an expanding box search
     """
     def __init__(self, from_geo, asset_type, creator, sweep_width, iterations, first_bearing):
-        # pylint: disable=R0913
+        # pylint: disable=R0913,R0917
         super().__init__(from_geo, asset_type, creator, sweep_width)
         self._iterations = int(iterations)
         if self._iterations < 1:
@@ -548,7 +548,7 @@ class TrackLineCreepingSearchParams(SearchParams):
     Parameters for a track line creeping search
     """
     def __init__(self, from_geo, asset_type, creator, sweep_width, width):
-        # pylint: disable=R0913
+        # pylint: disable=R0913,R0917
         super().__init__(from_geo, asset_type, creator, sweep_width)
         self._width = int(width)
         if self._width < 0:

--- a/search/tests.py
+++ b/search/tests.py
@@ -103,7 +103,7 @@ class SearchHelpers:
         return SearchWrapper(self.smm, response.json())
 
     def create_expanding_box_search(self, poi, sweep_width, iterations, asset_type, first_bearing=None, client=None):
-        # pylint: disable=R0913
+        # pylint: disable=R0913,R0917
         """
         Create an expanding box search
         """
@@ -147,7 +147,7 @@ class SearchHelpers:
         return SearchWrapper(self.smm, response.json())
 
     def create_creepingline_search_line(self, line, sweep_width, search_width, asset_type, client=None):
-        # pylint: disable=R0913
+        # pylint: disable=R0913,R0917
         """
         Create a creeping line search from a line
         """
@@ -215,7 +215,7 @@ class SearchTestCase(TestCase):
         self.mission1.add_asset(self.asset1)
 
     def create_poi(self, lat, long, label='Test Point', user=None, mission=None):
-        # pylint: disable=R0913
+        # pylint: disable=R0913,R0917
         """
         Create a POI at lat/long
         """


### PR DESCRIPTION
## Description
These have started appearing in pylint 3.3, since we already suppress the too many arguments warning, might as well suppress these too

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change