### PR TITLE
Simplify the cookie name for layers

### DIFF
--- a/frontend/map.js
+++ b/frontend/map.js
@@ -53,10 +53,14 @@ class SMMMap {
     this.setupMap()
   }
 
+  convertCookieName(name) {
+    return name.replace(/[^a-zA-Z0-9]/g, '_')
+  }
+
   layerStateChanged(e) {
     const layer = this.layerControlMaps._getLayer(Util.stamp(e.target))
     const cookieJar = new Cookies(null, { path: '/', maxAge: 31536000, sameSite: 'strict' })
-    cookieJar.set(`layer_${layer.name}_on_map`, e.type === 'add')
+    cookieJar.set(`layer_${this.convertCookieName(layer.name)}_on_map`, e.type === 'add')
   }
 
   mapLayersCallback(data) {
@@ -81,7 +85,7 @@ class SMMMap {
       } else {
         this.layerControlMaps.addOverlay(tileLayer, layer.name)
         const cookieJar = new Cookies(null, { path: '/', maxAge: 31536000, sameSite: 'strict' })
-        const layerEnabled = cookieJar.get(`layer_${layer.name}_on_map`)
+        const layerEnabled = cookieJar.get(`layer_${this.convertCookieName(layer.name)}_on_map`)
         if (layerEnabled === true) {
           tileLayer.addTo(this.map)
         }


### PR DESCRIPTION
## Description

The universe cookie code now has limits on which characters can be present in the name.
Implement a reduced set of characters, and replace anything that doesn't match with an underscore.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change