### PR TITLE
Only show the organization radio operator link when the user can access it

### DIFF
--- a/frontend/menu/topbar.js
+++ b/frontend/menu/topbar.js
@@ -53,19 +53,31 @@ globalThis.createSMMMissionTopBar = createSMMMissionTopBar
 
 class SMMOrganizationTopBar extends React.Component {
   render() {
+    const links = [
+      <Nav.Link href="/organization/" key="orgList">
+        Organization List
+      </Nav.Link>,
+      <Nav.Link href={`/organization/${this.props.organizationId}/`} key="orgDetails">
+        Details
+      </Nav.Link>
+    ]
+    if (this.props.showRadioOperator) {
+      links.push(
+        <Nav.Link href={`/organization/${this.props.organizationId}/radio/operator/`} key="orgRadioOperator">
+          Radio Operator
+        </Nav.Link>
+      )
+    }
     return (
       <Navbar bg="secondary" data-bs-theme="dark">
-        <Nav>
-          <Nav.Link href="/organization/">Organization List</Nav.Link>
-          <Nav.Link href={`/organization/${this.props.organizationId}/`}>Details</Nav.Link>
-          <Nav.Link href={`/organization/${this.props.organizationId}/radio/operator/`}>Radio Operator</Nav.Link>
-        </Nav>
+        <Nav>{links}</Nav>
       </Navbar>
     )
   }
 }
 SMMOrganizationTopBar.propTypes = {
-  organizationId: PropTypes.number.isRequired
+  organizationId: PropTypes.number.isRequired,
+  showRadioOperator: PropTypes.bool
 }
 
 function createSMMOrganizationTopBar(elementId, organizationId) {

--- a/frontend/organization/details.js
+++ b/frontend/organization/details.js
@@ -427,6 +427,9 @@ class OrganizationDetailsPage extends React.Component {
         organizationDetails: data
       }
     })
+    if (this.props.updateRadioOperator) {
+      this.props.updateRadioOperator(data.role === 'Admin' || data.role == 'Radio Operator')
+    }
   }
 
   async updateData() {
@@ -469,6 +472,37 @@ class OrganizationDetailsPage extends React.Component {
 }
 OrganizationDetailsPage.propTypes = {
   organizationId: PropTypes.number.isRequired,
+  csrftoken: PropTypes.string.isRequired,
+  updateRadioOperator: PropTypes.func
+}
+
+class OrganizationPage extends React.Component {
+  constructor(props) {
+    super(props)
+    this.updateRadioOperator = this.updateRadioOperator.bind(this)
+
+    this.state = {
+      isRadioOperator: false
+    }
+  }
+
+  updateRadioOperator(radioOperator) {
+    this.setState({
+      isRadioOperator: radioOperator
+    })
+  }
+
+  render() {
+    return (
+      <>
+        <SMMOrganizationTopBar organizationId={this.props.organizationId} showRadioOperator={this.state.isRadioOperator} />
+        <OrganizationDetailsPage organizationId={this.props.organizationId} csrftoken={this.props.csrftoken} updateRadioOperator={this.updateRadioOperator} />
+      </>
+    )
+  }
+}
+OrganizationPage.propTypes = {
+  organizationId: PropTypes.number.isRequired,
   csrftoken: PropTypes.string.isRequired
 }
 
@@ -477,12 +511,7 @@ function createOrganizationDetails(elementId, organizationId) {
 
   const csrftoken = $('[name=csrfmiddlewaretoken]').val()
 
-  div.render(
-    <>
-      <SMMOrganizationTopBar organizationId={organizationId} />
-      <OrganizationDetailsPage organizationId={organizationId} csrftoken={csrftoken} />
-    </>
-  )
+  div.render(<OrganizationPage organizationId={organizationId} csrftoken={csrftoken} />)
 }
 
 globalThis.createOrganizationDetails = createOrganizationDetails

--- a/frontend/organization/radio-operator.js
+++ b/frontend/organization/radio-operator.js
@@ -97,7 +97,7 @@ function createRadioOperator(elementId, organizationId) {
 
   div.render(
     <>
-      <SMMOrganizationTopBar organizationId={organizationId} />
+      <SMMOrganizationTopBar organizationId={organizationId} showRadioOperator={true} />
       <OrganizationRadioOperatorPage organizationId={organizationId} csrftoken={csrftoken} />
     </>
   )


### PR DESCRIPTION
## Description

This resolves #385 by only showing the radio operator link when the user is allowed access to the radio operator page For other users, don't show the link at all.
This will also dynamically update if the users role is changed.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change