### PR TITLE
frontend: fix usage of locate control from 0.82.0 update

### DIFF
--- a/frontend/map.js
+++ b/frontend/map.js
@@ -15,7 +15,8 @@ import markerIconShadow from 'leaflet/dist/images/marker-shadow.png'
 import 'leaflet-realtime'
 import '@canterbury-air-patrol/leaflet-dialog'
 import '@canterbury-air-patrol/leaflet-dialog/Leaflet.Dialog.css'
-import 'leaflet.locatecontrol'
+import { LocateControl } from 'leaflet.locatecontrol'
+import 'leaflet.locatecontrol/dist/L.Control.Locate.min.css'
 import Cookies from 'universal-cookie'
 
 import './Admin/admin.js'
@@ -114,13 +115,11 @@ class SMMMap {
       L.control.poiadder({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
       L.control.polygonadder({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
       L.control.lineadder({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
-      L.control
-        .locate({
-          setView: 'untilPan',
-          keepCurrentZoomLevel: true,
-          locateOptions: { enableHighAccuracy: true }
-        })
-        .addTo(this.map)
+      new LocateControl({
+        setView: 'untilPan',
+        keepCurrentZoomLevel: true,
+        locateOptions: { enableHighAccuracy: true }
+      }).addTo(this.map)
       L.control.imageuploader({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
     }
     L.control.smmadmin({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)


### PR DESCRIPTION
## Description

See: https://github.com/domoritz/leaflet-locatecontrol/commit/b20d77e4184fdfc59ff0037f8d95471a49af6f81#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60

Upgrading to 0.82.0 broke loading the map

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change