### PR TITLE
Rearrange the asset UI to make it take up less vertical space

### DIFF
--- a/frontend/asset/ui.js
+++ b/frontend/asset/ui.js
@@ -251,7 +251,7 @@ AssetCommandView.propTypes = {
   csrftoken: PropTypes.string.isRequired
 }
 
-class AssetDetails extends React.Component {
+class AssetMissionDetails extends React.Component {
   currentSearchRow(details) {
     if (Number.isInteger(details.current_search_id)) {
       return (
@@ -327,22 +327,6 @@ class AssetDetails extends React.Component {
   render() {
     const details = this.props.details
     const rows = []
-    if (details.status) {
-      rows.push(
-        <tr key="status_name">
-          <td>Status:</td>
-          <td>{details.status.status}</td>
-          <td>Since:</td>
-          <td>{details.status.since === undefined ? '' : new Date(details.status.since).toLocaleString()}</td>
-        </tr>
-      )
-      rows.push(
-        <tr key="status_notes">
-          <td>Status Notes:</td>
-          <td colSpan={3}>{details.status.notes}</td>
-        </tr>
-      )
-    }
 
     if (Number.isInteger(details.mission_id)) {
       rows.push(
@@ -379,11 +363,11 @@ class AssetDetails extends React.Component {
     )
   }
 }
-AssetDetails.propTypes = {
+AssetMissionDetails.propTypes = {
   details: PropTypes.object.isRequired
 }
 
-class AssetStatusSet extends React.Component {
+class AssetStatus extends React.Component {
   constructor(props) {
     super(props)
 
@@ -461,6 +445,25 @@ class AssetStatusSet extends React.Component {
   }
 
   render() {
+    const details = this.props.details
+
+    const rows = []
+    if (details.status) {
+      rows.push(
+        <tr key="status_name">
+          <td>Status:</td>
+          <td>{details.status.status}</td>
+          <td>Since:</td>
+          <td>{details.status.since === undefined ? '' : new Date(details.status.since).toLocaleString()}</td>
+        </tr>
+      )
+      rows.push(
+        <tr key="status_notes">
+          <td>Status Notes:</td>
+          <td colSpan={3}>{details.status.notes}</td>
+        </tr>
+      )
+    }
     const statusValues = this.state.statusValues.map((v) => (
       <option key={v.id} value={v.id}>
         {v.name}
@@ -469,33 +472,34 @@ class AssetStatusSet extends React.Component {
     return (
       <Table responsive>
         <thead>
+          {rows}
           <tr>
             <td>Status:</td>
-            <td>Notes:</td>
-          </tr>
-          <tr>
             <td>
               <select onChange={this.updateSelectedStateValue} defaultValue={this.state.selectedValueId}>
                 {statusValues}
               </select>
             </td>
+            <td>
+              <Button onClick={this.setStatus}>Set Status</Button>
+            </td>
+          </tr>
+          <tr>
+            <td>Notes:</td>
             <td colSpan={2}>
               <textarea onChange={this.updateNotes} value={this.state.notesText}></textarea>
             </td>
           </tr>
-          <tr>
-            <td colSpan={3}>
-              <Button onClick={this.setStatus}>Set Status</Button>
-            </td>
-          </tr>
+          <tr></tr>
         </thead>
       </Table>
     )
   }
 }
-AssetStatusSet.propTypes = {
+AssetStatus.propTypes = {
   asset: PropTypes.string.isRequired,
-  csrftoken: PropTypes.string.isRequired
+  csrftoken: PropTypes.string.isRequired,
+  details: PropTypes.object.isRequired
 }
 
 class AssetUI extends React.Component {
@@ -552,11 +556,11 @@ class AssetUI extends React.Component {
         <div style={{ fontWeight: 'bold', textAlign: 'center' }} className="bg-info">
           {this.state.details.name}
         </div>
-        <AssetDetails details={this.state.details} />
+        <AssetMissionDetails details={this.state.details} />
         <AssetCommandView lastCommand={this.state.lastCommand} asset={this.props.asset} csrftoken={this.props.csrftoken} />
         {missionStatus}
         <AssetTrackAs asset={this.props.asset} />
-        <AssetStatusSet asset={this.props.asset} csrftoken={this.props.csrftoken} />
+        <AssetStatus asset={this.props.asset} csrftoken={this.props.csrftoken} details={this.state.details} />
       </div>
     )
   }
@@ -581,4 +585,4 @@ function createAssetUI(elementId, assetId) {
 
 globalThis.createAssetUI = createAssetUI
 
-export { AssetCommandView, AssetDetails, AssetUI }
+export { AssetCommandView, AssetMissionDetails, AssetUI }

--- a/frontend/asset/ui.js
+++ b/frontend/asset/ui.js
@@ -1,6 +1,6 @@
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
-import { Table, Button, ButtonGroup } from 'react-bootstrap'
+import { Table, Button } from 'react-bootstrap'
 
 import React from 'react'
 import PropTypes from 'prop-types'
@@ -261,18 +261,18 @@ class AssetDetails extends React.Component {
       return (
         <tr key="current_search">
           <td>Current Search</td>
+          <td>({details.current_search_id})</td>
           <td>
-            ({details.current_search_id})
-            <ButtonGroup>
-              <Button href={`/search/${details.current_search_id}/`}>Details</Button>
-              <Button
-                onClick={function () {
-                  $.get(`/search/${details.current_search_id}/finished/?asset_id=${details.asset_id}`)
-                }}
-              >
-                Mark as Completed
-              </Button>
-            </ButtonGroup>
+            <Button href={`/search/${details.current_search_id}/`}>Details</Button>
+          </td>
+          <td>
+            <Button
+              onClick={function () {
+                $.get(`/search/${details.current_search_id}/finished/?asset_id=${details.asset_id}`)
+              }}
+            >
+              Mark as Completed
+            </Button>
           </td>
         </tr>
       )
@@ -283,45 +283,46 @@ class AssetDetails extends React.Component {
           <td>
             <b>None</b>
           </td>
+          <td></td>
+          <td></td>
         </tr>
       )
     }
   }
 
   queuedSearchRow(details) {
+    const data = [<td key="title">Queued Search</td>, <td key="id">{details.queued_search_id}</td>]
     if (Number.isInteger(details.queued_search_id)) {
-      const buttons = [
-        <Button key="details" href={`/search/${details.queued_search_id}/`}>
-          Details
-        </Button>
-      ]
-      if (!Number.isInteger(details.current_search_id)) {
-        buttons.push(
-          <Button
-            key="begin"
-            onClick={function () {
-              $.get(`/search/${details.queued_search_id}/begin/?asset_id=${details.asset_id}`)
-            }}
-          >
-            Begin Search
-          </Button>
-        )
-      }
-      return (
-        <tr key="queued_search">
-          <td>Queued Search</td>
-          <td>
-            ({details.queued_search_id})<ButtonGroup>{buttons}</ButtonGroup>
-          </td>
-        </tr>
+      data.push(
+        <td key="details">
+          <Button href={`/search/${details.queued_search_id}/`}>Details</Button>
+        </td>
       )
+      if (!Number.isInteger(details.current_search_id)) {
+        data.push(
+          <td key="begin">
+            <Button
+              onClick={function () {
+                $.get(`/search/${details.queued_search_id}/begin/?asset_id=${details.asset_id}`)
+              }}
+            >
+              Begin Search
+            </Button>
+          </td>
+        )
+      } else {
+        data.push(<td key="no_begin"></td>)
+      }
+      return <tr key={`queued_search_${details.queued_search_id}`}>{data}</tr>
     } else {
       return (
-        <tr key="queued_search">
+        <tr key="queued_search_none">
           <td>Queued Search</td>
           <td>
             <b>None</b>
           </td>
+          <td></td>
+          <td></td>
         </tr>
       )
     }
@@ -329,29 +330,12 @@ class AssetDetails extends React.Component {
 
   render() {
     const details = this.props.details
-    const rows = [
-      <tr key="asset_name">
-        <td>Asset</td>
-        <td>{details.name}</td>
-      </tr>,
-      <tr key="asset_type">
-        <td>Type</td>
-        <td>{details.asset_type}</td>
-      </tr>,
-      <tr key="asset_owner">
-        <td>Owner</td>
-        <td>{details.owner}</td>
-      </tr>
-    ]
+    const rows = []
     if (details.status) {
       rows.push(
         <tr key="status_name">
           <td>Status:</td>
           <td>{details.status.status}</td>
-        </tr>
-      )
-      rows.push(
-        <tr key="status_since">
           <td>Since:</td>
           <td>{details.status.since === undefined ? '' : new Date(details.status.since).toLocaleString()}</td>
         </tr>
@@ -359,7 +343,7 @@ class AssetDetails extends React.Component {
       rows.push(
         <tr key="status_notes">
           <td>Status Notes:</td>
-          <td>{details.status.notes}</td>
+          <td colSpan={3}>{details.status.notes}</td>
         </tr>
       )
     }
@@ -368,8 +352,12 @@ class AssetDetails extends React.Component {
       rows.push(
         <tr key="current_mission">
           <td>Current Mission</td>
+          <td>{details.mission_name}</td>
           <td>
-            {details.mission_name} <Button href={`/mission/${details.mission_id}/details/`}>Details</Button>
+            <Button href={`/mission/${details.mission_id}/details/`}>Details</Button>
+          </td>
+          <td>
+            <Button href={`/mission/${details.mission_id}/map/`}>Map</Button>
           </td>
         </tr>
       )
@@ -382,6 +370,8 @@ class AssetDetails extends React.Component {
           <td>
             <b>None</b>
           </td>
+          <td></td>
+          <td></td>
         </tr>
       )
     }

--- a/frontend/asset/ui.js
+++ b/frontend/asset/ui.js
@@ -172,76 +172,72 @@ class AssetCommandView extends React.Component {
     if (this.props.lastCommand.response !== undefined) {
       if (this.props.lastCommand.response.set !== null) {
         responseData.push(
-          <tr key="response_type">
-            <td>Response:</td>
-            <td>{this.props.lastCommand.response.type}</td>
-          </tr>
-        )
-        responseData.push(
-          <tr key="response_at">
-            <td>At:</td>
-            <td>{new Date(this.props.lastCommand.response.set).toLocaleString()}</td>
-          </tr>
-        )
-        responseData.push(
-          <tr key="response_by">
-            <td>By:</td>
-            <td>{this.props.lastCommand.response.by}</td>
+          <tr key="response">
+            <td>
+              <i>{this.props.lastCommand.response.type}</i>
+            </td>
+            <td>At: {new Date(this.props.lastCommand.response.set).toLocaleString()}</td>
+            <td>By: {this.props.lastCommand.response.by}</td>
           </tr>
         )
         responseData.push(
           <tr key="message">
             <td>Message:</td>
-            <td>{this.props.lastCommand.response.message}</td>
+            <td colSpan={2}>{this.props.lastCommand.response.message}</td>
           </tr>
         )
       } else {
         responseData.push(
-          <tr key="response_form_type">
-            <td>Type:</td>
+          <tr key="response_form">
             <td>
+              Response:
+              <br />
               <select onChange={this.updateSelectedType} defaultValue={this.state.type}>
                 <option value="Accepted">Accept</option>
                 <option value="More Info">More Info</option>
                 <option value="Unable">Unable</option>
               </select>
             </td>
-          </tr>
-        )
-        responseData.push(
-          <tr key="response_form_message">
-            <td colSpan={2}>
-              <textarea onChange={this.updateMessage}></textarea>
+            <td>
+              Message:
+              <br /> <input type="text" onChange={this.updateMessage}></input>
             </td>
-          </tr>
-        )
-        responseData.push(
-          <tr key="response_buttons">
-            <td colSpan={2}>
+            <td>
               <Button onClick={this.submitResponse}>Respond</Button>
             </td>
           </tr>
         )
       }
     }
+    const gotoRow = []
+    if (this.props.lastCommand.latitude || this.props.lastCommand.longitude) {
+      gotoRow.push(
+        <tr key="goto_pos">
+          <td>
+            <b>{this.props.lastCommand.latitude ? degreesToDM(this.props.lastCommand.latitude, true) : ''}</b>
+          </td>
+          <td>
+            <b>{this.props.lastCommand.longitude ? degreesToDM(this.props.lastCommand.longitude, false) : ''}</b>
+          </td>
+          <td></td>
+        </tr>
+      )
+    }
+
     return (
       <Table responsive>
         <thead>
           <tr>
-            <td>Issued:</td>
-            <td>{this.props.lastCommand.issued === undefined ? '' : new Date(this.props.lastCommand.issued).toLocaleString()}</td>
+            <td>
+              <b>{this.props.lastCommand.action_txt}</b>
+            </td>
+            <td>Issued: {this.props.lastCommand.issued === undefined ? '' : new Date(this.props.lastCommand.issued).toLocaleString()}</td>
+            <td>By: {this.props.lastCommand.issued_by}</td>
           </tr>
+          {gotoRow}
           <tr>
-            <td>Instruction Type:</td>
-            <td>{this.props.lastCommand.action_txt}</td>
-          </tr>
-          <tr>
-            <td>Reason/Details:</td>
-            <td>{this.props.lastCommand.reason}</td>
-          </tr>
-          <tr>
-            <td>{this.props.lastCommand.latitude ? degreesToDM(this.props.lastCommand.latitude, true) : ''}</td>
-            <td>{this.props.lastCommand.longitude ? degreesToDM(this.props.lastCommand.longitude, false) : ''}</td>
+            <td>Message:</td>
+            <td colSpan={2}>{this.props.lastCommand.reason}</td>
           </tr>
           {responseData}
         </thead>

--- a/frontend/mission/asset/status.js
+++ b/frontend/mission/asset/status.js
@@ -173,7 +173,7 @@ class MissionAssetStatus extends React.Component {
             </tr>
             <tr>
               <td>Since</td>
-              <td>{this.state.statusData.since}</td>
+              <td>{this.state.statusData.since === undefined ? '' : new Date(this.state.statusData.since).toLocaleString()}</td>
             </tr>
             <tr>
               <td>Notes</td>

--- a/frontend/mission/asset/status.js
+++ b/frontend/mission/asset/status.js
@@ -93,29 +93,20 @@ class MissionAssetStatusForm extends React.Component {
       </option>
     ))
     return (
-      <Table>
-        <thead>
-          <tr>
-            <td>Mission Status:</td>
-            <td>Notes:</td>
-          </tr>
-          <tr>
-            <td>
-              <select onChange={this.updateSelectedStateValue} defaultValue={this.state.selectedValueId}>
-                {statusValues}
-              </select>
-            </td>
-            <td colSpan={2}>
-              <textarea onChange={this.updateNotes} value={this.state.notesText}></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td colSpan={3}>
-              <Button onClick={this.setStatus}>Set Status</Button>
-            </td>
-          </tr>
-        </thead>
-      </Table>
+      <tr>
+        <td>
+          <select onChange={this.updateSelectedStateValue} defaultValue={this.state.selectedValueId}>
+            {statusValues}
+          </select>
+        </td>
+        <td></td>
+        <td>
+          <textarea onChange={this.updateNotes} value={this.state.notesText}></textarea>
+        </td>
+        <td>
+          <Button onClick={this.setStatus}>Set Status</Button>
+        </td>
+      </tr>
     )
   }
 }
@@ -165,23 +156,21 @@ class MissionAssetStatus extends React.Component {
           <thead>
             <tr>
               <td>Mission Status</td>
-              <td>{this.state.statusData.status}</td>
-            </tr>
-            <tr>
               <td>Description</td>
-              <td>{this.state.statusData.status_description}</td>
-            </tr>
-            <tr>
-              <td>Since</td>
-              <td>{this.state.statusData.since === undefined ? '' : new Date(this.state.statusData.since).toLocaleString()}</td>
-            </tr>
-            <tr>
               <td>Notes</td>
-              <td>{this.state.statusData.notes}</td>
+              <td>Since</td>
             </tr>
           </thead>
+          <tbody>
+            <tr>
+              <td>{this.state.statusData.status}</td>
+              <td>{this.state.statusData.status_description}</td>
+              <td>{this.state.statusData.notes}</td>
+              <td>{this.state.statusData.since === undefined ? '' : new Date(this.state.statusData.since).toLocaleString()}</td>
+            </tr>
+            <MissionAssetStatusForm asset={this.props.asset} mission={this.props.mission} csrftoken={this.props.csrftoken} />
+          </tbody>
         </Table>
-        <MissionAssetStatusForm asset={this.props.asset} mission={this.props.mission} csrftoken={this.props.csrftoken} />
       </div>
     )
   }

--- a/frontend/organization/radio-operator.js
+++ b/frontend/organization/radio-operator.js
@@ -23,7 +23,7 @@ class RadioOperatorAsset extends AssetUI {
         <thead>
           <tr>
             <td colSpan={2} align="center" style={{ fontWeight: 'bold' }} className="bg-info">
-              {this.state.details.name}
+              {this.state.details.name} ({this.state.details.asset_type})
             </td>
           </tr>
         </thead>

--- a/frontend/organization/radio-operator.js
+++ b/frontend/organization/radio-operator.js
@@ -8,7 +8,7 @@ import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
 
-import { AssetCommandView, AssetDetails, AssetUI } from '../asset/ui'
+import { AssetCommandView, AssetMissionDetails, AssetUI } from '../asset/ui'
 import { MissionAssetStatus } from '../mission/asset/status'
 import { SMMOrganizationTopBar } from '../menu/topbar'
 
@@ -30,7 +30,7 @@ class RadioOperatorAsset extends AssetUI {
         <tbody>
           <tr>
             <td>
-              <AssetDetails details={this.state.details} />
+              <AssetMissionDetails details={this.state.details} />
             </td>
             <td>
               <AssetCommandView asset={this.props.asset} lastCommand={this.state.lastCommand} csrftoken={this.props.csrftoken} />


### PR DESCRIPTION
## Description

When using a phone or tablet to view the asset interface it required a lot of scrolling to access the most likely parts of the interface. Most sections have been changed to make more use of the horizontal space to reduce the vertical space usage.

Also, some information was duplicated or not required and has been removed.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Enhancements:
- Reorganize the asset UI to utilize horizontal space more effectively, reducing vertical space usage.