### PR TITLE
Fixup timer usage

### DIFF
--- a/frontend/asset/list.js
+++ b/frontend/asset/list.js
@@ -90,7 +90,7 @@ class AssetListPage extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   async updateData() {

--- a/frontend/asset/type_list.js
+++ b/frontend/asset/type_list.js
@@ -70,7 +70,7 @@ class AssetTypeListPage extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   async updateData() {

--- a/frontend/asset/ui.js
+++ b/frontend/asset/ui.js
@@ -392,7 +392,7 @@ class AssetStatus extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateStatusValuesResponse(data) {
@@ -530,7 +530,7 @@ class AssetUI extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateDataResponse(data) {

--- a/frontend/icons/list.js
+++ b/frontend/icons/list.js
@@ -76,7 +76,7 @@ class IconListPage extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   async updateData() {

--- a/frontend/mission/list.js
+++ b/frontend/mission/list.js
@@ -151,7 +151,7 @@ class MissionListPage extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateDataResponse(data) {

--- a/frontend/mission/timeline.js
+++ b/frontend/mission/timeline.js
@@ -155,7 +155,7 @@ export class MissionTimeLine extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateDataResponse(data) {

--- a/frontend/organization/details.js
+++ b/frontend/organization/details.js
@@ -198,7 +198,7 @@ class OrganizationMemberAdd extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateDataResponse(data) {
@@ -325,7 +325,7 @@ class OrganizationAssetAdd extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateDataResponse(data) {
@@ -418,7 +418,7 @@ class OrganizationDetailsPage extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateDataResponse(data) {

--- a/frontend/organization/list.js
+++ b/frontend/organization/list.js
@@ -160,7 +160,7 @@ class OrganizationListPage extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateDataResponse(data) {

--- a/frontend/organization/radio-operator.js
+++ b/frontend/organization/radio-operator.js
@@ -65,7 +65,7 @@ class OrganizationRadioOperatorPage extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateDataResponse(data) {

--- a/frontend/search/details.js
+++ b/frontend/search/details.js
@@ -140,7 +140,7 @@ class SearchDetailsPage extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateDataResponse(data) {

--- a/frontend/usergeo/details.js
+++ b/frontend/usergeo/details.js
@@ -42,7 +42,7 @@ class UserGeoDetailsPage extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
-    this.timer = null
+    this.timer = undefined
   }
 
   updateDataResponse(data) {


### PR DESCRIPTION
## Description

The null here should be undefined to return it to the initial state

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Bug Fixes:
- Replace 'null' with 'undefined' for timer reset in componentWillUnmount across multiple React components to ensure proper state reset.