### PR TITLE
mission: fix external references list

### DIFF
--- a/mission/views.py
+++ b/mission/views.py
@@ -687,7 +687,7 @@ class MissionExternalReferencesView(View):
 
         data = {
             'mission': mission_user.mission.as_object(mission_user.is_admin()),
-            'external_references': [external_reference.as_object() for external_reference in external_references],
+            'external_references': [external_reference.as_json() for external_reference in external_references],
         }
         return JsonResponse(data)
 


### PR DESCRIPTION
## Description

Fixes the call to as_object to be as_json which makes the external reference list work correctly

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Bug Fixes:
- Fix the external reference list generation by calling `as_json()` instead of `as_object()` on external reference objects.