### PR TITLE
mission: add closed time/by to mission details page

### DIFF
--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -17,32 +17,43 @@ interface MissionDetailsProps {
   mission: MissionData
 }
 
-class MissionDetails extends React.Component<MissionDetailsProps, never> {
-  render() {
-    const { mission } = this.props
-    return (
-      <Table>
-        <tbody>
+const MissionDetails: React.FC<MissionDetailsProps> = (props) => {
+  const { mission } = props
+
+  return (
+    <Table>
+      <tbody>
+        <tr>
+          <td>Name</td>
+          <td>{mission.name}</td>
+        </tr>
+        <tr>
+          <td>Started</td>
+          <td>{new Date(mission.started).toLocaleString()}</td>
+        </tr>
+        <tr>
+          <td>Creator</td>
+          <td>{mission.creator}</td>
+        </tr>
+        <tr>
+          <td>Description</td>
+          <td>{mission.description}</td>
+        </tr>
+        {mission.closed && (
           <tr>
-            <td>Name</td>
-            <td>{mission.name}</td>
+            <td>Closed</td>
+            <td>{new Date(mission.closed).toLocaleString()}</td>
           </tr>
+        )}
+        {mission.closed_by && (
           <tr>
-            <td>Started</td>
-            <td>{new Date(mission.started).toLocaleString()}</td>
+            <td>Closed By</td>
+            <td>{mission.closed_by}</td>
           </tr>
-          <tr>
-            <td>Creator</td>
-            <td>{mission.creator}</td>
-          </tr>
-          <tr>
-            <td>Description</td>
-            <td>{mission.description}</td>
-          </tr>
-        </tbody>
-      </Table>
-    )
-  }
+        )}
+      </tbody>
+    </Table>
+  )
 }
 
 interface MissionDetailsExternalReferencesRowProps {


### PR DESCRIPTION
## Description
This helps to make it clearer the mission has been closed.
Also, convert the mission details view to a functional component

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Add closed time and closed by information to the mission details page and refactor the component to a functional component.

New Features:
- Display the closed time and closed by information on the mission details page to indicate when a mission has been closed.

Enhancements:
- Convert the mission details view from a class component to a functional component for improved code readability and maintainability.