### PR TITLE
Update django to 5.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==5.1.7
+django==5.2.1
 
 # Timezone support
 pytz


### PR DESCRIPTION
## Description

RelNotes: https://docs.djangoproject.com/en/5.2/releases/5.2/

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Chores:
- Bump Django version from 5.1.7 to 5.2.1 in requirements.txt