### PR TITLE
Convert marine sac/vectors to typescript

### DIFF
--- a/esbuild.config.json
+++ b/esbuild.config.json
@@ -1,7 +1,7 @@
 {
     "entry": [
         "frontend/map.tsx",
-        "frontend/marinesac.js",
+        "frontend/marinesac.tsx",
         "frontend/marinevectors.tsx",
         "frontend/pretty.tsx",
         "frontend/asset/ui.tsx",

--- a/frontend/marine/types.ts
+++ b/frontend/marine/types.ts
@@ -1,0 +1,9 @@
+interface TotalDriftVectorData {
+  pk: number
+  created_at: string
+  datum: number
+  leeway_multiplier: number
+  leeway_modifier: number
+}
+
+export { TotalDriftVectorData }

--- a/frontend/marine/vectors.tsx
+++ b/frontend/marine/vectors.tsx
@@ -1,9 +1,10 @@
 import $ from 'jquery'
 
 import { SMMRealtime } from '../smmmap'
+import { TotalDriftVectorData } from './types'
 
 class SMMMarineVector extends SMMRealtime {
-  constructor(map, csrftoken, missionId, interval, color) {
+  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string) {
     super(map, csrftoken, missionId, interval, color)
 
     this.createPopup = this.createPopup.bind(this)
@@ -13,7 +14,7 @@ class SMMMarineVector extends SMMRealtime {
     return `/mission/${this.missionId}/sar/marine/vectors/current/`
   }
 
-  createPopup(tdv, layer) {
+  createPopup(tdv: { properties: TotalDriftVectorData }, layer: L.Layer) {
     const tdvID = tdv.properties.pk
 
     const popupContent = document.createElement('div')
@@ -28,7 +29,7 @@ class SMMMarineVector extends SMMRealtime {
 
     const dd = document.createElement('dd')
     dd.className = 'image-name col-sm-10'
-    dd.textContent = tdvID
+    dd.textContent = tdvID.toString()
     dl.appendChild(dd)
 
     if (this.missionId !== 'current' && this.missionId !== 'all') {

--- a/frontend/marinesac.tsx
+++ b/frontend/marinesac.tsx
@@ -6,8 +6,8 @@ import * as ReactDOM from 'react-dom/client'
 import { MarineSACTable } from '@canterbury-air-patrol/marine-search-area-coverage'
 import { SMMMissionTopBar } from './menu/topbar'
 
-export function createMarineSACTable(elementId, missionId) {
-  const div = ReactDOM.createRoot(document.getElementById(elementId))
+export function createMarineSACTable(elementId: string, missionId: number) {
+  const div = ReactDOM.createRoot(document.getElementById(elementId)!)
 
   div.render(
     <>
@@ -17,4 +17,5 @@ export function createMarineSACTable(elementId, missionId) {
   )
 }
 
+// @ts-expect-error: globalThis has no defintion
 globalThis.createMarineSACTable = createMarineSACTable


### PR DESCRIPTION
## Description


## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Migrate marine SAC and vector frontend modules from JavaScript to TypeScript with type definitions and annotations for improved type safety

Enhancements:
- Migrate SMMMarineVector and createMarineSACTable modules to TypeScript (.tsx)
- Introduce TotalDriftVectorData interface in a new types.ts file
- Add explicit type annotations for map, CSRF token, missionId, interval, color, TDV data, and layer parameters
- Apply non-null assertion on React root initialization and convert numeric IDs to strings for textContent