### PR TITLE
frontend: replace for in with for of where possible

### DIFF
--- a/frontend/SearchAdder/SearchAdder.js
+++ b/frontend/SearchAdder/SearchAdder.js
@@ -23,21 +23,21 @@ L.SearchAdder = function (map, csrftoken, objectType, objectID) {
   const assetSelection = `<select class="form-control" id="SearchAdder-asset-type-${RAND_NUM}"></select>`
   $.getJSON('/assets/assettypes/', function (data) {
     $.each(data, function (index, json) {
-      for (const at in json) {
-        $(`#SearchAdder-asset-type-${RAND_NUM}`).append(`<option value='${json[at].id}'>${json[at].name}</option>`)
+      for (const assetType of json) {
+        $(`#SearchAdder-asset-type-${RAND_NUM}`).append(`<option value='${assetType.id}'>${assetType.name}</option>`)
       }
     })
   })
   const generateInputs = function (inputs) {
     let res = ''
-    for (const i in inputs) {
-      res += `<div class="input-group input-group-sm mb-3" id="SearchAdder-${inputs[i].id}-${RAND_NUM}">`
+    for (const input of inputs) {
+      res += `<div class="input-group input-group-sm mb-3" id="SearchAdder-${input.id}-${RAND_NUM}">`
       res += '<div class="input-group-prepend">'
       res += '<span class="input-group-text">'
-      res += inputs[i].label
+      res += input.label
       res += '</span>'
       res += '</div>'
-      res += inputs[i].input_html
+      res += input.input_html
       res += '</div>'
     }
     return res

--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -109,11 +109,11 @@ class SMMAsset {
   }
 
   updateNewRoute(route: { features: Array<{ geometry: { coordinates: Array<number> }; properties: AssetPointTime }> }) {
-    for (const f in route.features) {
-      const lon = route.features[f].geometry.coordinates[0]
-      const lat = route.features[f].geometry.coordinates[1]
+    for (const feature of route.features) {
+      const lon = feature.geometry.coordinates[0]
+      const lat = feature.geometry.coordinates[1]
       this.path.push(L.latLng(lat, lon))
-      this.lastUpdate = route.features[f].properties.created_at
+      this.lastUpdate = feature.properties.created_at
     }
     this.polyline.setLatLngs(this.path)
     this.updating = false
@@ -169,8 +169,7 @@ class SMMAssets extends SMMRealtime {
   }
 
   assetListCB(data: { assets: Array<MissionAssetData> }) {
-    for (const assetIdx in data.assets) {
-      const asset = data.assets[assetIdx]
+    for (const asset of data.assets) {
       this.assetNameMap[asset.id] = asset.name
       if (asset.status) {
         this.assetStatusMap[asset.id] = asset.status
@@ -250,14 +249,14 @@ class SMMAssets extends SMMRealtime {
     const dl = document.createElement('dl')
     dl.className = 'row'
 
-    for (const d in data) {
+    for (const d of data) {
       const dt = document.createElement('dt')
       dt.className = 'asset-label col-sm-3'
-      dt.textContent = data[d].label
+      dt.textContent = d.label
       dl.appendChild(dt)
       const dd = document.createElement('dd')
       dd.className = 'asset-name col-sm-9'
-      dd.textContent = data[d].value
+      dd.textContent = d.value
       dl.appendChild(dd)
     }
 

--- a/frontend/image/map.tsx
+++ b/frontend/image/map.tsx
@@ -56,14 +56,14 @@ abstract class SMMImage extends SMMRealtime {
       ['Long', degreesToDM(coords[0], false)]
     ]
 
-    for (const d in data) {
+    for (const d of data) {
       const dt = document.createElement('dt')
       dt.className = 'image-label col-sm-2'
-      dt.textContent = data[d][0]
+      dt.textContent = d[0]
       dl.appendChild(dt)
       const dd = document.createElement('dd')
       dd.className = 'image-name col-sm-10'
-      dd.textContent = data[d][1]
+      dd.textContent = d[1]
       dl.appendChild(dd)
     }
 

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -86,8 +86,7 @@ class SMMMap {
     layers: Array<{ name: string; url: string; base: boolean; attribution: string; minZoom: number; maxZoom: number; subdomains?: string; active: boolean; relativeOrder: number }>
   }) {
     let baseSelected = false
-    for (const d in data.layers) {
-      const layer = data.layers[d]
+    for (const layer of data.layers) {
       const options: {
         attribution: string
         minZoom: number

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -46,14 +46,14 @@ class SMMSearch {
     const dl = document.createElement('dl')
     dl.className = 'search-data row'
 
-    for (const d in data) {
+    for (const d of data) {
       const dt = document.createElement('dt')
-      dt.className = `search-${data[d].css}-label col-sm-6`
-      dt.textContent = data[d].label
+      dt.className = `search-${d.css}-label col-sm-6`
+      dt.textContent = d.label
       dl.appendChild(dt)
       const dd = document.createElement('dd')
-      dd.className = `search-${data[d].css}-value col-sm-6`
-      dd.textContent = data[d].value
+      dd.className = `search-${d.css}-value col-sm-6`
+      dd.textContent = d.value
       dl.appendChild(dd)
     }
 
@@ -62,9 +62,9 @@ class SMMSearch {
 
   searchQueueAssetListCallback(data: { assets: Array<MissionAssetData> }) {
     if ('assets' in data) {
-      for (const at in data.assets) {
-        if (data.assets[at].type_name === this.search.created_for) {
-          $(`#queue_${this.search.pk}_select_asset`).append(`<option value='${data.assets[at].id}'>${data.assets[at].name}</option>`)
+      for (const asset of data.assets) {
+        if (asset.type_name === this.search.created_for) {
+          $(`#queue_${this.search.pk}_select_asset`).append(`<option value='${asset.id}'>${asset.name}</option>`)
         }
       }
     }

--- a/frontend/smmmap.tsx
+++ b/frontend/smmmap.tsx
@@ -47,8 +47,7 @@ abstract class SMMRealtime {
     const btngroup = document.createElement('div')
     btngroup.className = 'btn-group'
 
-    for (const d in data) {
-      const btnData = data[d]
+    for (const btnData of data) {
       const btn = document.createElement('button')
       btn.className = `btn ${btnData['btnClass']}`
       if (btnData.onclick !== undefined) {

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -77,11 +77,11 @@ class SMMUserPosition {
   }
 
   updateNewPosition(route: { features: Array<SMMMissionUserPointTimeGeoJSON> }) {
-    for (const f in route.features) {
-      const lon = route.features[f].geometry.coordinates[0]
-      const lat = route.features[f].geometry.coordinates[1]
+    for (const feature of route.features) {
+      const lon = feature.geometry.coordinates[0]
+      const lat = feature.geometry.coordinates[1]
       this.path.push(L.latLng(lat, lon))
-      this.lastUpdate = route.features[f].properties.created_at
+      this.lastUpdate = feature.properties.created_at
     }
     this.polyline.setLatLngs(this.path)
     this.updating = false
@@ -189,14 +189,14 @@ class SMMUserPositions extends SMMRealtime {
     const dl = document.createElement('dl')
     dl.className = 'row'
 
-    for (const d in data) {
+    for (const d of data) {
       const dt = document.createElement('dt')
       dt.className = 'user-label col-sm-3'
-      dt.textContent = data[d].label
+      dt.textContent = d.label
       dl.appendChild(dt)
       const dd = document.createElement('dd')
       dd.className = 'user-name col-sm-9'
-      dd.textContent = data[d].value
+      dd.textContent = d.value
       dl.appendChild(dd)
     }
 

--- a/frontend/usergeo/poi.tsx
+++ b/frontend/usergeo/poi.tsx
@@ -58,17 +58,17 @@ class SMMPOI {
       ['Long', degreesToDM(this.coords[0], false)]
     ]
 
-    for (const d in data) {
+    for (const d of data) {
       const dl = document.createElement('dl')
       dl.className = 'poi row'
 
       const dt = document.createElement('dt')
       dt.className = 'asset-label col-sm-2'
-      dt.textContent = data[d][0]
+      dt.textContent = d[0]
       dl.appendChild(dt)
       const dd = document.createElement('dd')
       dd.className = 'asset-name col-sm-10'
-      dd.textContent = data[d][1]
+      dd.textContent = d[1]
       dl.appendChild(dd)
 
       popupContent.appendChild(dl)


### PR DESCRIPTION
## Description

Replaces usage of for in with for of, except the 2 places where this isn't currently possible.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Replace for-in loops with for-of when iterating over arrays in frontend code for improved consistency and correctness.

Enhancements:
- Use for-of loops instead of for-in for array iteration across multiple frontend components
- Retain two existing for-in loops where conversion to for-of is not yet feasible