### PR TITLE
mission: remove unused mission_details

### DIFF
--- a/mission/views.py
+++ b/mission/views.py
@@ -31,32 +31,6 @@ from .forms import MissionForm, MissionUserForm, MissionAssetForm, MissionOrgani
 from .decorators import get_user_from_id, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin
 
 
-@login_required
-@mission_is_member
-def mission_details(request, mission_user):
-    """
-    Missions details and management.
-    """
-    latest_status_subquery = MissionAssetStatus.objects.filter(mission_asset=OuterRef('pk')).order_by('-since').values('status__name')[:1]
-    latest_since_subquery = MissionAssetStatus.objects.filter(mission_asset=OuterRef('pk')).order_by('-since').values('since')[:1]
-    mission_assets = MissionAsset.objects.filter(mission=mission_user.mission).annotate(status=Subquery(latest_status_subquery), status_since=Subquery(latest_since_subquery))
-    data = {
-        'mission': mission_user.mission,
-        'me': request.user,
-        'admin': mission_user.is_admin(),
-        'can_add_organizations': mission_user.can_add_organization(),
-        'can_add_users': mission_user.can_add_user(),
-        'mission_organizations': MissionOrganization.objects.filter(mission=mission_user.mission).order_by('pk'),
-        'mission_assets': mission_assets,
-        'mission_users': MissionUser.objects.filter(mission=mission_user.mission),
-        'mission_asset_types': MissionAssetType.objects.filter(mission=mission_user.mission),
-        'mission_organization_add': MissionOrganizationForm(),
-        'mission_user_add': MissionUserForm(),
-        'mission_asset_add': MissionAssetForm(user=request.user, mission=mission_user.mission),
-    }
-    return render(request, 'mission_details.html', data)
-
-
 @method_decorator(login_required, name="dispatch")
 @method_decorator(mission_is_member, name="dispatch")
 class MissionDetailsView(View):


### PR DESCRIPTION
## Description

This has been replaced by MissionDetailsView

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Chores:
- Remove unused mission_details function and its decorators from mission/views.py