### PR TITLE
Use python3.13 in github workflows

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.13
       - name: Setup venv
         run:
           ./setup-venv.sh

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.13
       - name: Setup venv
         run: ./setup-venv.sh
         env:


### PR DESCRIPTION
## Description

django 6.0 requires a minimum of python3.12

## Checklist
- [x] I/we wrote this code my/ourself

## Summary by Sourcery

CI:
- Switch CI workflows to use Python 3.13 for code checks and test runs.