### PR TITLE
fix moving of POIs

### DIFF
--- a/frontend/usergeo/poi.tsx
+++ b/frontend/usergeo/poi.tsx
@@ -26,7 +26,7 @@ class SMMPOI {
   }
 
   editCallback() {
-    L.POIAdder(this.parent.map, this.parent.missionId, this.parent.csrftoken, L.latLng(this.coords[1], this.coords[0]), this.poiID, this.POILabel)
+    L.POIAdder(this.parent.map, this.parent.missionId, this.parent.csrftoken, L.latLng(this.coords[1], this.coords[0]), this.data.pk, this.data.label)
   }
 
   setXHR(xhr: XMLHttpRequest) {
@@ -46,7 +46,7 @@ class SMMPOI {
   }
 
   calculateTDVCallback() {
-    MarineVectorsLeaflet(this.parent.map, this.parent.missionId, this.parent.csrftoken, this.data.label, L.latLng(this.coords[1], this.coords[0]), this.poiID)
+    MarineVectorsLeaflet(this.parent.map, this.parent.missionId, this.parent.csrftoken, this.data.label, L.latLng(this.coords[1], this.coords[0]), this.data.pk)
   }
 
   createPopup(layer: L.Layer) {


### PR DESCRIPTION
## Description

Update poiID to data.pk and POILabel to data.label
Fixes: 4c314ac Convert usergeo/poi to typescript
which had missed some variables

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Bug Fixes:
- Use the POI data primary key and label fields when invoking POI editing and MarineVectorsLeaflet callbacks to fix incorrect POI references.