### PR TITLE
Move pylint config into pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,7 @@
+[MASTER]
+max-line-length=240
+ignore=migrations
+
+load-plugins=pylint_django
+django-settings-module=smm.settings
+

--- a/check-code.sh
+++ b/check-code.sh
@@ -4,6 +4,6 @@ source venv/bin/activate
 
 pycodestyle --ignore=E501 */*.py
 
-pylint --max-line-length=240 --load-plugins pylint_django --django-settings-module=smm.settings --ignore migrations map/ data/ assets/ search/ mission/ timeline/ images/ marinesar/
+pylint map/ data/ assets/ search/ mission/ timeline/ images/ marinesar/
 
 deactivate


### PR DESCRIPTION
## Description

Remove the duplication of pylintrc arguments by creating pylintrc

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Centralize pylint configuration into a .pylintrc file and simplify the linting script to rely on this shared config.

Enhancements:
- Simplify the check-code.sh pylint invocation by delegating configuration to a .pylintrc file.

Build:
- Introduce a project-level .pylintrc to hold pylint settings previously inlined in scripts.