### PR TITLE
Fix inverted asset icon logic

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -224,9 +224,7 @@ class SMMAssets extends SMMRealtime {
   }
 
   getAssetIcon(assetId: number) {
-    if (!(assetId in this.assetIconMap)) {
-      return this.assetIconMap[assetId]
-    }
+    return this.assetIconMap[assetId]
   }
 
   createPopup(asset: { properties: { asset: number } }, layer: L.Layer) {


### PR DESCRIPTION
## Description

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Bug Fixes:
- Return the stored asset icon for a given asset ID without incorrectly gating it behind an inverted existence check.