### PR TITLE
Fix typo in image label

### DIFF
--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -186,7 +186,7 @@ class SMMMap {
     this.importantImages = new SMMImageImportant(this.map, this.csrftoken, this.missionId, imageAllUpdateFreq, defaultColor)
 
     this.overlayAdd('Images (all)', this.allImages.realtime())
-    this.overlayAdd('Images (prioritized', this.importantImages.realtime().addTo(this.map))
+    this.overlayAdd('Images (prioritized)', this.importantImages.realtime().addTo(this.map))
 
     this.marineVectors = new SMMMarineVector(this.map, this.csrftoken, this.missionId, marineDataUpdateFreq, 'black')
     this.overlayAdd('Marine - Total Drift Vectors', this.marineVectors.realtime())


### PR DESCRIPTION
## Description

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Bug Fixes:
- Correct the display text for the prioritized images map overlay by adding the missing closing parenthesis.