### PR TITLE
Use node 24 to build the frontend

### DIFF
--- a/build-frontend-docker.sh
+++ b/build-frontend-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker run --mount type=bind,source=$(pwd),target=/usr/src node:20-slim /bin/bash -c "cd /usr/src; USERID=$(id -u) GROUPID=$(id -g) ./build-frontend.sh"
+docker run --mount type=bind,source=$(pwd),target=/usr/src node:24-slim /bin/bash -c "cd /usr/src; USERID=$(id -u) GROUPID=$(id -g) ./build-frontend.sh"


### PR DESCRIPTION
## Description


## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Build:
- Switch the Docker image used in the frontend build script from node:20-slim to node:24-slim.