### PR TITLE
Use a common cookie jar

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -8,7 +8,7 @@ import '@canterbury-air-patrol/leaflet-dialog'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { ColorResult, CompactPicker } from 'react-color'
-import Cookies from 'universal-cookie'
+import { cookieJar } from '../cookies'
 import { MissionAssetData, AssetPointTime } from './types'
 
 interface AssetColorPickerProps {
@@ -72,7 +72,6 @@ class SMMAsset {
   }
 
   updateColor(color: string) {
-    const cookieJar = new Cookies(null, { path: '/', maxAge: 31536000, sameSite: 'strict' })
     cookieJar.set(`asset_${this.assetId}_track_color`, color)
     this.color = color
     this.polyline.setStyle({
@@ -208,7 +207,6 @@ class SMMAssets extends SMMRealtime {
     }
     if (!(assetId in this.assetObjects)) {
       /* Create an overlay for this object */
-      const cookieJar = new Cookies(null, { path: '/', maxAge: 31536000 })
       const color = cookieJar.get(`asset_${assetId}_track_color`)
       const assetObject = new SMMAsset(this.map, this.missionId, assetId, this.assetNameMap[assetId], color !== undefined ? color : this.color)
       this.assetObjects[assetId] = assetObject

--- a/frontend/cookies.ts
+++ b/frontend/cookies.ts
@@ -1,0 +1,5 @@
+import Cookies from 'universal-cookie'
+
+const cookieJar = new Cookies(null, { path: '/', maxAge: 31536000, sameSite: 'strict' })
+
+export { cookieJar }

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -17,7 +17,7 @@ import '@canterbury-air-patrol/leaflet-dialog'
 import '@canterbury-air-patrol/leaflet-dialog/Leaflet.Dialog.css'
 import { LocateControl } from 'leaflet.locatecontrol'
 import 'leaflet.locatecontrol/dist/L.Control.Locate.min.css'
-import Cookies from 'universal-cookie'
+import { cookieJar } from './cookies'
 
 import './Admin/admin.js'
 import './POIAdder/POIAdder.js'
@@ -78,7 +78,6 @@ class SMMMap {
 
   layerStateChanged(e: L.LayerEvent) {
     const layer = this.layerControlMaps._getLayer(Util.stamp(e.target))
-    const cookieJar = new Cookies(null, { path: '/', maxAge: 31536000, sameSite: 'strict' })
     cookieJar.set(`layer_${this.convertCookieName(layer.name)}_on_map`, e.type === 'add')
   }
 
@@ -109,7 +108,6 @@ class SMMMap {
         }
       } else {
         this.layerControlMaps.addOverlay(tileLayer, layer.name)
-        const cookieJar = new Cookies(null, { path: '/', maxAge: 31536000, sameSite: 'strict' })
         const layerEnabled = cookieJar.get(`layer_${this.convertCookieName(layer.name)}_on_map`)
         if (layerEnabled === true) {
           tileLayer.addTo(this.map)

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -7,7 +7,7 @@ import { SMMRealtime } from '../smmmap'
 import { AssetColorPicker } from '../asset/map'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
-import Cookies from 'universal-cookie'
+import { cookieJar } from '../cookies'
 import { SMMMissionUserPointTimeGeoJSON } from './types'
 
 class SMMUserPosition {
@@ -40,7 +40,6 @@ class SMMUserPosition {
   }
 
   updateColor(color: string) {
-    const cookieJar = new Cookies(null, { path: '/', maxAge: 31536000, sameSite: 'strict' })
     cookieJar.set(`user_${this.userName}_track_color`, color)
     this.color = color
     this.polyline.setStyle({
@@ -148,7 +147,6 @@ class SMMUserPositions extends SMMRealtime {
   createUser(userName: string) {
     if (!(userName in this.userObjects)) {
       /* Create an overlay for this object */
-      const cookieJar = new Cookies(null, { path: '/', maxAge: 31536000 })
       const color = cookieJar.get(`user_${userName}_track_color`)
       const userObject = new SMMUserPosition(this.map, this.missionId, userName, color !== undefined ? color : this.color)
       this.userObjects[userName] = userObject


### PR DESCRIPTION
## Description

Use a common cookie jar, instead of creating multiple (different) instances.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Centralize frontend cookie handling by introducing a shared cookie jar and using it across map-related components.

Enhancements:
- Introduce a shared cookie jar module in the frontend to standardize cookie configuration and reuse.
- Refactor asset, user, and map components to use the common cookie jar for persisting track colors and layer visibility.