### PR TITLE
Replace jquery get/getJSON with helper

### DIFF
--- a/frontend/Admin/admin.js
+++ b/frontend/Admin/admin.js
@@ -1,6 +1,8 @@
 import $ from 'jquery'
 import L from 'leaflet'
 
+import { smmGet } from '../ajax'
+
 L.SMMAdmin = {}
 
 L.SMMAdmin.AssetCommand = function (map, missionId, csrftoken) {
@@ -58,7 +60,7 @@ L.SMMAdmin.AssetCommand = function (map, missionId, csrftoken) {
       $('#assetcommanddialog').html(data)
     })
   })
-  $.get(`/mission/${missionId}/assets/command/set/`, {}, function (data) {
+  smmGet(`/mission/${missionId}/assets/command/set/`, {}, function (data) {
     $('#assetcommanddialog').html(data)
     $('#id_command').on('change', changeSelectedCommand)
   })

--- a/frontend/SearchAdder/SearchAdder.js
+++ b/frontend/SearchAdder/SearchAdder.js
@@ -2,6 +2,8 @@ import $ from 'jquery'
 
 import L from 'leaflet'
 
+import { smmGet, smmGetJSON } from '../ajax'
+
 L.SearchAdder = function (map, csrftoken, objectType, objectID) {
   const RAND_NUM = Math.floor(Math.random() * 16536)
   let searchSelection = `<select class='form-control' id='SearchAdder-search-type-${RAND_NUM}'>`
@@ -21,7 +23,7 @@ L.SearchAdder = function (map, csrftoken, objectType, objectID) {
   }
   searchSelection += '</select>'
   const assetSelection = `<select class="form-control" id="SearchAdder-asset-type-${RAND_NUM}"></select>`
-  $.getJSON('/assets/assettypes/', function (data) {
+  smmGetJSON('/assets/assettypes/', {}, function (data) {
     $.each(data, function (index, json) {
       for (const assetType of json) {
         $(`#SearchAdder-asset-type-${RAND_NUM}`).append(`<option value='${assetType.id}'>${assetType.name}</option>`)
@@ -133,7 +135,7 @@ L.SearchAdder = function (map, csrftoken, objectType, objectID) {
   let onMap = null
 
   $(`#SearchAdder-preview-${RAND_NUM}`).on('click', function () {
-    $.get(getUrl(), getData(), function (data) {
+    smmGet(getUrl(), getData(), function (data) {
       if (onMap !== null) {
         onMap.remove()
       }

--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -1,0 +1,26 @@
+import $ from 'jquery'
+
+const AJAX_TIMEOUT = 2500
+
+function smmGet(url: string, data?: object, success?: (data: unknown) => void, error?: () => void) {
+  return $.ajax({
+    url,
+    data,
+    timeout: AJAX_TIMEOUT,
+    success: success,
+    error: error
+  })
+}
+
+function smmGetJSON(url: string, data?: object, success?: (data: unknown) => void, error?: () => void) {
+  return $.ajax({
+    url,
+    data,
+    dataType: 'json',
+    timeout: AJAX_TIMEOUT,
+    success: success,
+    error: error
+  })
+}
+
+export { smmGet, smmGetJSON }

--- a/frontend/asset/list.tsx
+++ b/frontend/asset/list.tsx
@@ -5,7 +5,7 @@ import { Table, Button, ButtonGroup } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
+import { smmGetJSON } from '../ajax'
 
 import { SMMTopBar } from '../menu/topbar'
 
@@ -88,7 +88,6 @@ class AssetListPage extends React.Component<object, AssetListPageState> {
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -99,7 +98,7 @@ class AssetListPage extends React.Component<object, AssetListPageState> {
   }
 
   async updateData() {
-    await $.getJSON('/assets/', this.updateAssets)
+    await smmGetJSON('/assets/', {}, this.updateAssets)
   }
 
   updateAssets(data: { assets: AssetData[] }) {

--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -11,6 +11,8 @@ import { ColorResult, CompactPicker } from 'react-color'
 import { cookieJar } from '../cookies'
 import { MissionAssetData, AssetPointTime } from './types'
 
+import { smmGetJSON } from '../ajax'
+
 interface AssetColorPickerProps {
   color: string
   updateColor: (color: string) => void
@@ -180,7 +182,7 @@ class SMMAssets extends SMMRealtime {
   }
 
   updateAssetNameMap() {
-    $.getJSON(`/mission/${this.missionId}/assets/?include_removed=true`, this.assetListCB)
+    smmGetJSON(`/mission/${this.missionId}/assets/?include_removed=true`, {}, this.assetListCB)
   }
 
   realtime() {

--- a/frontend/asset/type_list.tsx
+++ b/frontend/asset/type_list.tsx
@@ -5,7 +5,7 @@ import { Table } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
+import { smmGetJSON } from '../ajax'
 
 import { SMMTopBar } from '../menu/topbar'
 
@@ -68,7 +68,6 @@ class AssetTypeListPage extends React.Component<object, AssetTypeListPageState> 
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -79,7 +78,7 @@ class AssetTypeListPage extends React.Component<object, AssetTypeListPageState> 
   }
 
   async updateData() {
-    await $.getJSON('/assets/assettypes/', this.updateAssetTypes)
+    await smmGetJSON('/assets/assettypes/', {}, this.updateAssetTypes)
   }
 
   updateAssetTypes(data: { asset_types: AssetTypeData[] }) {

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
+import { smmGet, smmGetJSON } from '../ajax'
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { SMMTopBar } from '../menu/topbar'
 import { MissionAssetStatus } from '../mission/asset/status'
@@ -64,7 +65,7 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
     })
 
     if (this.state.tracking) {
-      $.get(`/data/assets/${this.props.asset}/position/add/`, data)
+      smmGet(`/data/assets/${this.props.asset}/position/add/`, data)
     }
   }
 
@@ -284,7 +285,7 @@ class AssetMissionDetails extends React.Component<AssetMissionDetailsProps, neve
           <td>
             <Button
               onClick={function () {
-                $.get(`/search/${details.current_search_id}/finished/?asset_id=${details.asset_id}`)
+                smmGet(`/search/${details.current_search_id}/finished/?asset_id=${details.asset_id}`)
               }}
             >
               Mark as Completed
@@ -319,7 +320,7 @@ class AssetMissionDetails extends React.Component<AssetMissionDetailsProps, neve
           <td key="begin">
             <Button
               onClick={function () {
-                $.get(`/search/${details.queued_search_id}/begin/?asset_id=${details.asset_id}`)
+                smmGet(`/search/${details.queued_search_id}/begin/?asset_id=${details.asset_id}`)
               }}
             >
               Begin Search
@@ -416,7 +417,6 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateStatusValues()
     this.timer = setInterval(() => this.updateStatusValues(), 10000)
   }
@@ -439,7 +439,7 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
   }
 
   async updateStatusValues() {
-    await $.get('/assets/status/values/', this.updateStatusValuesResponse)
+    await smmGet('/assets/status/values/', {}, this.updateStatusValuesResponse)
   }
 
   updateSelectedStateValue(event: React.ChangeEvent<HTMLSelectElement>) {
@@ -556,7 +556,6 @@ class AssetUI extends React.Component<AssetUIProps, AssetUIState> {
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -576,7 +575,7 @@ class AssetUI extends React.Component<AssetUIProps, AssetUIState> {
   }
 
   async updateData() {
-    await $.getJSON(`/assets/${this.props.asset}/`, this.updateDataResponse)
+    await smmGetJSON(`/assets/${this.props.asset}/`, {}, this.updateDataResponse)
   }
 
   render() {

--- a/frontend/icons/list.tsx
+++ b/frontend/icons/list.tsx
@@ -5,7 +5,7 @@ import { Table } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
+import { smmGetJSON } from '../ajax'
 
 import { SMMTopBar } from '../menu/topbar'
 
@@ -77,7 +77,6 @@ class IconListPage extends React.Component<object, IconListPageState> {
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -88,7 +87,7 @@ class IconListPage extends React.Component<object, IconListPageState> {
   }
 
   async updateData() {
-    await $.getJSON('/icons/', this.updateIcons)
+    await smmGetJSON('/icons/', {}, this.updateIcons)
   }
 
   updateIcons(data: { icons: IconData[] }) {

--- a/frontend/image/map.tsx
+++ b/frontend/image/map.tsx
@@ -1,11 +1,10 @@
 import L from 'leaflet'
 
-import $ from 'jquery'
-
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 
 import { SMMRealtime } from '../smmmap'
 import { SMMImageGeoJSON } from './types'
+import { smmGet } from '../ajax'
 
 abstract class SMMImage extends SMMRealtime {
   constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string) {
@@ -84,7 +83,7 @@ abstract class SMMImage extends SMMRealtime {
             {
               label: 'Deprioritize',
               onclick: function () {
-                $.get(`/image/${imageID}/priority/unset/`)
+                smmGet(`/image/${imageID}/priority/unset/`)
               },
               btnClass: 'btn-light'
             }
@@ -96,7 +95,7 @@ abstract class SMMImage extends SMMRealtime {
             {
               label: 'Prioritize',
               onclick: function () {
-                $.get(`/image/${imageID}/priority/set/`)
+                smmGet(`/image/${imageID}/priority/set/`)
               },
               btnClass: 'btn-light'
             }

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -35,6 +35,7 @@ import { SMMMarineVector } from './marine/vectors.js'
 import { SMMAssets } from './asset/map.js'
 import { SMMMissionTopBar } from './menu/topbar.js'
 import { SMMUserPositions } from './user/map.js'
+import { smmGet } from './ajax'
 
 class SMMMap {
   map: L.Map
@@ -91,10 +92,12 @@ class SMMMap {
         minZoom: number
         maxZoom: number
         subdomains?: string
+        referrerPolicy?: string
       } = {
         attribution: layer.attribution,
         minZoom: layer.minZoom,
-        maxZoom: layer.maxZoom
+        maxZoom: layer.maxZoom,
+        referrerPolicy: 'strict-origin'
       }
       if (layer.subdomains !== '') {
         options.subdomains = layer.subdomains
@@ -122,7 +125,7 @@ class SMMMap {
     L.Icon.Default.prototype.options.iconRetinaUrl = markerIcon2x
     L.Icon.Default.prototype.options.shadowUrl = markerIconShadow
 
-    $.get('/map/tile/layers/', this.mapLayersCallback)
+    smmGet('/map/tile/layers/', {}, this.mapLayersCallback)
 
     this.layerControl.addTo(this.map)
     this.layerControlMaps.addTo(this.map)

--- a/frontend/marine/vectors.tsx
+++ b/frontend/marine/vectors.tsx
@@ -1,7 +1,6 @@
-import $ from 'jquery'
-
 import { SMMRealtime } from '../smmmap'
 import { TotalDriftVectorData } from './types'
+import { smmGet } from '../ajax'
 
 class SMMMarineVector extends SMMRealtime {
   constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string) {
@@ -38,7 +37,7 @@ class SMMMarineVector extends SMMRealtime {
           {
             label: 'Delete',
             onclick: function () {
-              $.get(`/sar/marine/vectors/${tdvID}/delete/`)
+              smmGet(`/sar/marine/vectors/${tdvID}/delete/`)
             },
             btnClass: 'btn-danger'
           }

--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -5,7 +5,7 @@ import { Table, Button } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
+import { smmGetJSON } from '../../ajax'
 import { SMMTopBar } from '../../menu/topbar'
 
 interface MissionAssetStatusValue {
@@ -52,7 +52,6 @@ class MissionAssetStatusForm extends React.Component<MissionAssetStatusFormProps
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateStatusValues()
     this.timer = setInterval(() => this.updateStatusValues(), 10000)
   }
@@ -75,7 +74,7 @@ class MissionAssetStatusForm extends React.Component<MissionAssetStatusFormProps
   }
 
   async updateStatusValues() {
-    await $.getJSON('/mission/asset/status/values/', this.updateStatusValuesResponse)
+    await smmGetJSON('/mission/asset/status/values/', {}, this.updateStatusValuesResponse)
   }
 
   updateSelectedStateValue(event: React.ChangeEvent<HTMLSelectElement>) {
@@ -159,7 +158,6 @@ class MissionAssetStatus extends React.Component<MissionAssetStatusFormProps, Mi
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -178,7 +176,7 @@ class MissionAssetStatus extends React.Component<MissionAssetStatusFormProps, Mi
   }
 
   async updateData() {
-    await $.getJSON(`/mission/${this.props.mission}/assets/${this.props.asset}/status/`, this.updateDataResponse)
+    await smmGetJSON(`/mission/${this.props.mission}/assets/${this.props.asset}/status/`, {}, this.updateDataResponse)
   }
 
   render() {

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
+import { smmGet, smmGetJSON } from '../ajax'
 
 import { SMMMissionTopBar } from '../menu/topbar'
 
@@ -425,7 +426,6 @@ class MissionDetailsOrganizationAdd extends React.Component<MissionDetailsOrgani
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -448,7 +448,7 @@ class MissionDetailsOrganizationAdd extends React.Component<MissionDetailsOrgani
   }
 
   async updateData() {
-    await $.getJSON(`/mission/${this.props.mission}/organizations/?not_included=True`, this.updateDataResponse)
+    await smmGetJSON(`/mission/${this.props.mission}/organizations/?not_included=True`, {}, this.updateDataResponse)
   }
 
   updateSelectedOrg(event: React.ChangeEvent<HTMLSelectElement>) {
@@ -649,7 +649,6 @@ class MissionDetailsUserAdd extends React.Component<MissionDetailsUserAddProps, 
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -672,7 +671,7 @@ class MissionDetailsUserAdd extends React.Component<MissionDetailsUserAddProps, 
   }
 
   async updateData() {
-    await $.getJSON(`/mission/${this.props.mission}/users/?not_included=True`, this.updateDataResponse)
+    await smmGetJSON(`/mission/${this.props.mission}/users/?not_included=True`, {}, this.updateDataResponse)
   }
 
   updateSelectedUser(event: React.ChangeEvent<HTMLSelectElement>) {
@@ -726,7 +725,7 @@ class MissionDetailsAssetRow extends React.Component<MissionDetailsAssetRowProps
   }
 
   remove() {
-    $.get(`/mission/${this.props.missionAsset.mission}/assets/${this.props.missionAsset.asset.id}/remove/`)
+    smmGet(`/mission/${this.props.missionAsset.mission}/assets/${this.props.missionAsset.asset.id}/remove/`)
   }
 
   render() {
@@ -823,7 +822,6 @@ class MissionDetailsAssetAdd extends React.Component<MissionDetailsAssetAddProps
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -846,7 +844,7 @@ class MissionDetailsAssetAdd extends React.Component<MissionDetailsAssetAddProps
   }
 
   async updateData() {
-    await $.getJSON(`/mission/${this.props.mission}/assets/?not_included=True`, this.updateDataResponse)
+    await smmGetJSON(`/mission/${this.props.mission}/assets/?not_included=True`, {}, this.updateDataResponse)
   }
 
   updateSelectedAsset(event: React.ChangeEvent<HTMLSelectElement>) {
@@ -911,7 +909,6 @@ class MissionDetailPage extends React.Component<MissionDetailsPageProps, Mission
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -926,7 +923,7 @@ class MissionDetailPage extends React.Component<MissionDetailsPageProps, Mission
   }
 
   async updateData() {
-    await $.getJSON(`/mission/${this.props.missionId}/details/`, this.updateDataResponse)
+    await smmGetJSON(`/mission/${this.props.missionId}/details/`, {}, this.updateDataResponse)
   }
 
   render() {

--- a/frontend/mission/list.tsx
+++ b/frontend/mission/list.tsx
@@ -5,7 +5,7 @@ import { Table, Button, ButtonGroup } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
+import { smmGet } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { MissionData } from './types'
 
@@ -146,7 +146,6 @@ class MissionListPage extends React.Component<object, MissionListPageState> {
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -161,7 +160,7 @@ class MissionListPage extends React.Component<object, MissionListPageState> {
   }
 
   async updateData() {
-    await $.get('/mission/list/', this.updateDataResponse)
+    await smmGet('/mission/list/', {}, this.updateDataResponse)
   }
 
   updateMissions(missions: MissionData[]) {

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
+import { smmGetJSON } from '../ajax'
 
 import DateTimePicker from 'react-datetime-picker'
 import 'react-datetime-picker/dist/DateTimePicker.css'
@@ -181,7 +182,6 @@ export class MissionTimeLine extends React.Component<MissionTimeLineProps, Missi
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -200,7 +200,7 @@ export class MissionTimeLine extends React.Component<MissionTimeLineProps, Missi
   }
 
   async updateData() {
-    await $.getJSON(`/mission/${this.props.missionId}/timeline/`, this.updateDataResponse)
+    await smmGetJSON(`/mission/${this.props.missionId}/timeline/`, {}, this.updateDataResponse)
   }
 
   updateTimeline(timelineEntries: TimeLineEntry[]) {

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
+import { smmGetJSON } from '../ajax'
 
 import { OrganizationListRow } from './list'
 import { SMMOrganizationTopBar } from '../menu/topbar'
@@ -205,7 +206,6 @@ class OrganizationMemberAdd extends React.Component<OrganizationMemberAddProps, 
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -228,7 +228,7 @@ class OrganizationMemberAdd extends React.Component<OrganizationMemberAddProps, 
   }
 
   async updateData() {
-    await $.getJSON(`/organization/${this.props.organizationId}/users/notmember/`, this.updateDataResponse)
+    await smmGetJSON(`/organization/${this.props.organizationId}/users/notmember/`, {}, this.updateDataResponse)
   }
 
   updateSelectedUser(event: React.ChangeEvent<HTMLSelectElement>) {
@@ -334,7 +334,6 @@ class OrganizationAssetAdd extends React.Component<OrganizationAssetAddProps, Or
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -357,7 +356,7 @@ class OrganizationAssetAdd extends React.Component<OrganizationAssetAddProps, Or
   }
 
   async updateData() {
-    await $.getJSON('/assets/', this.updateDataResponse)
+    await smmGetJSON('/assets/', {}, this.updateDataResponse)
   }
 
   updateSelectedAsset(event: React.ChangeEvent<HTMLSelectElement>) {
@@ -433,7 +432,6 @@ class OrganizationDetailsPage extends React.Component<OrganizationDetailsPagePro
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -455,7 +453,7 @@ class OrganizationDetailsPage extends React.Component<OrganizationDetailsPagePro
   }
 
   async updateData() {
-    await $.getJSON(`/organization/${this.props.organizationId}/`, this.updateDataResponse)
+    await smmGetJSON(`/organization/${this.props.organizationId}/`, {}, this.updateDataResponse)
   }
 
   render() {

--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
+import { smmGetJSON } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { OrganizationData } from './types'
 
@@ -175,7 +176,6 @@ class OrganizationListPage extends React.Component<OrganizationListPageProps, Or
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -194,7 +194,7 @@ class OrganizationListPage extends React.Component<OrganizationListPageProps, Or
   }
 
   async updateData() {
-    await $.getJSON('/organization/', this.updateDataResponse)
+    await smmGetJSON('/organization/', {}, this.updateDataResponse)
   }
 
   render() {

--- a/frontend/organization/radio-operator.tsx
+++ b/frontend/organization/radio-operator.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
+import { smmGetJSON } from '../ajax'
 
 import { AssetCommandView, AssetMissionDetails, AssetUI } from '../asset/ui'
 import { MissionAssetStatus } from '../mission/asset/status'
@@ -64,7 +65,6 @@ class OrganizationRadioOperatorPage extends React.Component<OrganizationRadioOpe
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -83,7 +83,7 @@ class OrganizationRadioOperatorPage extends React.Component<OrganizationRadioOpe
   }
 
   async updateData() {
-    await $.getJSON(`/organization/${this.props.organizationId}/`, this.updateDataResponse)
+    await smmGetJSON(`/organization/${this.props.organizationId}/`, {}, this.updateDataResponse)
   }
 
   render() {

--- a/frontend/search/details.tsx
+++ b/frontend/search/details.tsx
@@ -6,7 +6,7 @@ import * as ReactDOM from 'react-dom/client'
 import Collapsible from 'react-collapsible'
 import { Button } from 'react-bootstrap'
 
-import $ from 'jquery'
+import { smmGetJSON } from '../ajax'
 
 import { SMMObjectDetails } from '../SMMObjects/details'
 import { GeometryPoints } from '../geometry/details'
@@ -147,7 +147,6 @@ class SearchDetailsPage extends React.Component<SearchDetailsPageProps, SearchDe
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -175,7 +174,7 @@ class SearchDetailsPage extends React.Component<SearchDetailsPageProps, SearchDe
   }
 
   async updateData() {
-    await $.getJSON(`/search/${this.props.searchId}/`, this.updateDataResponse)
+    await smmGetJSON(`/search/${this.props.searchId}/`, {}, this.updateDataResponse)
   }
 
   render() {

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -6,6 +6,7 @@ import $ from 'jquery'
 import { SMMRealtime } from '../smmmap'
 import { MissionAssetData } from '../asset/types'
 import { SMMSearchObjectDetailsData } from './types'
+import { smmGetJSON } from '../ajax'
 
 class SMMSearch {
   parent: SMMSearches
@@ -108,7 +109,7 @@ class SMMSearch {
     ].join('')
     this.QueueDialog = L.control.dialog({ initOpen: true }).setContent(contents).addTo(this.parent.map).hideClose()
     $(`#queue_${this.search.pk}_select_asset`).hide()
-    $.getJSON(`/mission/${this.parent.missionId}/assets/`, this.searchQueueAssetListCallback)
+    smmGetJSON(`/mission/${this.parent.missionId}/assets/`, {}, this.searchQueueAssetListCallback)
     $(`#queue_${this.search.pk}_select_type`).on('change', this.searchQueueUpdateSelectType)
     $(`#queue_${this.search.pk}_queue`).on('click', this.searchQueueSubmit)
     $(`#queue_${this.search.pk}_cancel`).on('click', this.searchQueueDestroy)

--- a/frontend/usergeo/details.tsx
+++ b/frontend/usergeo/details.tsx
@@ -4,7 +4,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
+import { smmGetJSON } from '../ajax'
 
 import { SMMObjectDetails } from '../SMMObjects/details'
 import { GeometryPoints } from '../geometry/details'
@@ -53,7 +53,6 @@ class UserGeoDetailsPage extends React.Component<UserGeoDetailsPageProps, UserGe
   }
 
   componentDidMount() {
-    $.ajaxSetup({ timeout: 2500 })
     this.updateData()
     this.timer = setInterval(() => this.updateData(), 10000)
   }
@@ -79,7 +78,7 @@ class UserGeoDetailsPage extends React.Component<UserGeoDetailsPageProps, UserGe
   }
 
   async updateData() {
-    await $.getJSON(`/data/usergeo/${this.props.userGeoId}/`, this.updateDataResponse)
+    await smmGetJSON(`/data/usergeo/${this.props.userGeoId}/`, {}, this.updateDataResponse)
   }
 
   render() {


### PR DESCRIPTION
## Description

This unifies the path for server queries so jquery can be removed in the future.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Unify frontend AJAX GET requests through shared helper functions and tighten map tile layer configuration.

Enhancements:
- Introduce shared smmGet and smmGetJSON helpers that centralize AJAX timeout and JSON handling.
- Replace scattered jQuery $.get/$.getJSON calls and per-component $.ajaxSetup usage with the new helper functions across mission, asset, organization, search, and admin UIs.
- Set a strict-origin referrer policy on Leaflet map tile layers for improved request privacy.