### PR TITLE
Post delete via common ajax helper

### DIFF
--- a/frontend/Admin/admin.js
+++ b/frontend/Admin/admin.js
@@ -5,7 +5,7 @@ import { smmGet, smmPost } from '../ajax'
 
 L.SMMAdmin = {}
 
-L.SMMAdmin.AssetCommand = function (map, missionId, csrftoken) {
+L.SMMAdmin.AssetCommand = function (map, missionId) {
   const contents = [
     '<div id="assetcommanddialog"></div>',
     '<div><button class="btn btn-primary" id="command_create">Set</button>',
@@ -39,7 +39,6 @@ L.SMMAdmin.AssetCommand = function (map, missionId, csrftoken) {
   })
   $('#command_create').on('click', function () {
     const data = [
-      { name: 'csrfmiddlewaretoken', value: csrftoken },
       { name: 'asset', value: $('#id_asset').val() },
       { name: 'reason', value: $('#id_reason').val() },
       { name: 'command', value: $('#id_command').val() }
@@ -76,7 +75,7 @@ L.Control.SMMAdmin = L.Control.extend({
   },
 
   onCommand: function () {
-    L.SMMAdmin.AssetCommand(this.map, this.options.missionId, this.options.csrftoken)
+    L.SMMAdmin.AssetCommand(this.map, this.options.missionId)
   },
 
   onCancel: function () {

--- a/frontend/Admin/admin.js
+++ b/frontend/Admin/admin.js
@@ -1,7 +1,7 @@
 import $ from 'jquery'
 import L from 'leaflet'
 
-import { smmGet } from '../ajax'
+import { smmGet, smmPost } from '../ajax'
 
 L.SMMAdmin = {}
 
@@ -49,7 +49,7 @@ L.SMMAdmin.AssetCommand = function (map, missionId, csrftoken) {
       data.push({ name: 'latitude', value: coords.lat })
       data.push({ name: 'longitude', value: coords.lng })
     }
-    $.post(`/mission/${missionId}/assets/command/set/`, data, function (data) {
+    smmPost(`/mission/${missionId}/assets/command/set/`, data, function (data) {
       if (data === 'Created') {
         if (gotoPoint != null) {
           map.removeLayer(gotoPoint)

--- a/frontend/ImageUploader/ImageUploader.js
+++ b/frontend/ImageUploader/ImageUploader.js
@@ -23,7 +23,6 @@ L.Control.ImageUploader = L.Control.extend({
     const latLng = marker.getLatLng()
 
     const formData = new FormData()
-    formData.append('csrfmiddlewaretoken', this.options.csrftoken)
     const desc = $('#image_upload_description')
     formData.append('description', desc[0].val())
     formData.append('latitude', latLng.lat)

--- a/frontend/ImageUploader/ImageUploader.js
+++ b/frontend/ImageUploader/ImageUploader.js
@@ -2,6 +2,7 @@ import $ from 'jquery'
 import L from 'leaflet'
 
 import { MappedMarker } from '../smmleaflet'
+import { smmPostBody } from '../ajax'
 
 L.Control.ImageUploader = L.Control.extend({
   options: {
@@ -30,10 +31,7 @@ L.Control.ImageUploader = L.Control.extend({
     const file = $('#image_upload_file')
     formData.append('file', file[0].files[0])
 
-    fetch(`/mission/${this.options.missionId}/image/upload/`, {
-      method: 'POST',
-      body: formData
-    })
+    smmPostBody(`/mission/${this.options.missionId}/image/upload/`, formData)
 
     this.map.removeLayer(this.mappedMarker.getMarker())
     this.imageUploadDialog.destroy()

--- a/frontend/LineAdder/LineAdder.js
+++ b/frontend/LineAdder/LineAdder.js
@@ -4,7 +4,7 @@ import { MappedMarker } from '../smmleaflet'
 
 import { smmPost } from '../ajax'
 
-L.LineAdder = function (map, missionId, csrftoken, currentPoints, replaces, label) {
+L.LineAdder = function (map, missionId, currentPoints, replaces, label) {
   const RAND_NUM = Math.floor(Math.random() * 16536)
   const markers = []
   const line = L.polyline(currentPoints, { color: 'yellow' }).addTo(map)
@@ -113,7 +113,7 @@ L.Control.LineAdder = L.Control.extend({
   },
 
   onClick: function () {
-    L.LineAdder(this.map, this.options.missionId, this.options.csrftoken, [this.map.getCenter()], -1, '')
+    L.LineAdder(this.map, this.options.missionId, [this.map.getCenter()], -1, '')
   },
 
   onAdd: function (map) {

--- a/frontend/LineAdder/LineAdder.js
+++ b/frontend/LineAdder/LineAdder.js
@@ -2,6 +2,8 @@ import $ from 'jquery'
 import L from 'leaflet'
 import { MappedMarker } from '../smmleaflet'
 
+import { smmPost } from '../ajax'
+
 L.LineAdder = function (map, missionId, csrftoken, currentPoints, replaces, label) {
   const RAND_NUM = Math.floor(Math.random() * 16536)
   const markers = []
@@ -80,9 +82,9 @@ L.LineAdder = function (map, missionId, csrftoken, currentPoints, replaces, labe
     }
 
     if (replaces !== -1) {
-      $.post(`/data/userlines/${replaces}/replace/`, data)
+      smmPost(`/data/userlines/${replaces}/replace/`, data)
     } else {
-      $.post(`/mission/${missionId}/data/userlines/create/`, data)
+      smmPost(`/mission/${missionId}/data/userlines/create/`, data)
     }
     removeAllMarkers()
     map.removeLayer(line)

--- a/frontend/LineAdder/LineAdder.js
+++ b/frontend/LineAdder/LineAdder.js
@@ -72,7 +72,6 @@ L.LineAdder = function (map, missionId, csrftoken, currentPoints, replaces, labe
   $(`#lineadder-dialog-done-${RAND_NUM}`).on('click', function () {
     const data = [
       { name: 'label', value: $(`#lineadder-dialog-name-${RAND_NUM}`).val() },
-      { name: 'csrfmiddlewaretoken', value: csrftoken },
       { name: 'points', value: markers.length }
     ]
     for (const i in markers) {

--- a/frontend/POIAdder/POIAdder.js
+++ b/frontend/POIAdder/POIAdder.js
@@ -31,8 +31,7 @@ L.POIAdder = function (map, missionId, csrftoken, pos, replaces, label) {
     const data = {
       lat: latLng.lat,
       lon: latLng.lng,
-      label: $(`#poi-dialog-label-${RAND_NUM}`).val(),
-      csrfmiddlewaretoken: csrftoken
+      label: $(`#poi-dialog-label-${RAND_NUM}`).val()
     }
     if (replaces === -1) {
       smmPost(`/mission/${missionId}/data/pois/create/`, data)

--- a/frontend/POIAdder/POIAdder.js
+++ b/frontend/POIAdder/POIAdder.js
@@ -5,6 +5,8 @@ import markerIcon from 'leaflet/dist/images/marker-icon.png'
 
 import { MappedMarker } from '../smmleaflet'
 
+import { smmPost } from '../ajax'
+
 L.POIAdder = function (map, missionId, csrftoken, pos, replaces, label) {
   const RAND_NUM = Math.floor(Math.random() * 16536)
   const contents = [
@@ -33,9 +35,9 @@ L.POIAdder = function (map, missionId, csrftoken, pos, replaces, label) {
       csrfmiddlewaretoken: csrftoken
     }
     if (replaces === -1) {
-      $.post(`/mission/${missionId}/data/pois/create/`, data)
+      smmPost(`/mission/${missionId}/data/pois/create/`, data)
     } else {
-      $.post(`/data/pois/${replaces}/replace/`, data)
+      smmPost(`/data/pois/${replaces}/replace/`, data)
     }
     map.removeLayer(marker)
     markerDialog.destroy()

--- a/frontend/POIAdder/POIAdder.js
+++ b/frontend/POIAdder/POIAdder.js
@@ -7,7 +7,7 @@ import { MappedMarker } from '../smmleaflet'
 
 import { smmPost } from '../ajax'
 
-L.POIAdder = function (map, missionId, csrftoken, pos, replaces, label) {
+L.POIAdder = function (map, missionId, pos, replaces, label) {
   const RAND_NUM = Math.floor(Math.random() * 16536)
   const contents = [
     '<div class="input-group input-group-sm mb-3"><div class="input-group-prepend"><span class="input-group-text">Name</span></div>',
@@ -59,7 +59,7 @@ L.Control.POIAdder = L.Control.extend({
   },
 
   onClick: function () {
-    L.POIAdder(this.map, this.options.missionId, this.options.csrftoken, this.map.getCenter(), -1, '')
+    L.POIAdder(this.map, this.options.missionId, this.map.getCenter(), -1, '')
   },
 
   onAdd: function (map) {

--- a/frontend/PolygonAdder/PolygonAdder.js
+++ b/frontend/PolygonAdder/PolygonAdder.js
@@ -1,6 +1,7 @@
 import $ from 'jquery'
 import L from 'leaflet'
 import { MappedMarker } from '../smmleaflet'
+import { smmPost } from '../ajax'
 
 L.PolygonAdder = function (map, missionId, csrftoken, currentPoints, replaces, label) {
   const RAND_NUM = Math.floor(Math.random() * 16536)
@@ -80,9 +81,9 @@ L.PolygonAdder = function (map, missionId, csrftoken, currentPoints, replaces, l
     }
 
     if (replaces !== -1) {
-      $.post(`/data/userpolygons/${replaces}/replace/`, data)
+      smmPost(`/data/userpolygons/${replaces}/replace/`, data)
     } else {
-      $.post(`/mission/${missionId}/data/userpolygons/create/`, data)
+      smmPost(`/mission/${missionId}/data/userpolygons/create/`, data)
     }
     removeAllMarkers()
     map.removeLayer(polygon)

--- a/frontend/PolygonAdder/PolygonAdder.js
+++ b/frontend/PolygonAdder/PolygonAdder.js
@@ -71,7 +71,6 @@ L.PolygonAdder = function (map, missionId, csrftoken, currentPoints, replaces, l
   $(`#polygonadder-dialog-done-${RAND_NUM}`).on('click', function () {
     const data = [
       { name: 'label', value: $(`#polygonadder-dialog-name-${RAND_NUM}`).val() },
-      { name: 'csrfmiddlewaretoken', value: csrftoken },
       { name: 'points', value: markers.length }
     ]
     for (const i in markers) {

--- a/frontend/PolygonAdder/PolygonAdder.js
+++ b/frontend/PolygonAdder/PolygonAdder.js
@@ -3,7 +3,7 @@ import L from 'leaflet'
 import { MappedMarker } from '../smmleaflet'
 import { smmPost } from '../ajax'
 
-L.PolygonAdder = function (map, missionId, csrftoken, currentPoints, replaces, label) {
+L.PolygonAdder = function (map, missionId, currentPoints, replaces, label) {
   const RAND_NUM = Math.floor(Math.random() * 16536)
   const markers = []
   const polygon = L.polygon(currentPoints, { color: 'yellow' }).addTo(map)
@@ -112,7 +112,7 @@ L.Control.PolygonAdder = L.Control.extend({
   },
 
   onClick: function () {
-    L.PolygonAdder(this.map, this.options.missionId, this.options.csrftoken, [this.map.getCenter()], -1, '')
+    L.PolygonAdder(this.map, this.options.missionId, [this.map.getCenter()], -1, '')
   },
 
   onAdd: function (map) {

--- a/frontend/SearchAdder/SearchAdder.js
+++ b/frontend/SearchAdder/SearchAdder.js
@@ -4,7 +4,7 @@ import L from 'leaflet'
 
 import { smmGet, smmGetJSON, smmPost } from '../ajax'
 
-L.SearchAdder = function (map, csrftoken, objectType, objectID) {
+L.SearchAdder = function (map, objectType, objectID) {
   const RAND_NUM = Math.floor(Math.random() * 16536)
   let searchSelection = `<select class='form-control' id='SearchAdder-search-type-${RAND_NUM}'>`
   switch (objectType) {

--- a/frontend/SearchAdder/SearchAdder.js
+++ b/frontend/SearchAdder/SearchAdder.js
@@ -2,7 +2,7 @@ import $ from 'jquery'
 
 import L from 'leaflet'
 
-import { smmGet, smmGetJSON } from '../ajax'
+import { smmGet, smmGetJSON, smmPost } from '../ajax'
 
 L.SearchAdder = function (map, csrftoken, objectType, objectID) {
   const RAND_NUM = Math.floor(Math.random() * 16536)
@@ -148,7 +148,7 @@ L.SearchAdder = function (map, csrftoken, objectType, objectID) {
     if (onMap !== null) {
       onMap.remove()
     }
-    $.post(getUrl(), getData(true))
+    smmPost(getUrl(), getData(true))
     dialog.destroy()
   })
 

--- a/frontend/SearchAdder/SearchAdder.js
+++ b/frontend/SearchAdder/SearchAdder.js
@@ -107,7 +107,7 @@ L.SearchAdder = function (map, csrftoken, objectType, objectID) {
     }
   }
 
-  const getData = function (includeCSRF) {
+  const getData = function () {
     const data = [
       { name: 'sweep_width', value: $(`#SearchAdder-sweep-width-${RAND_NUM}`).val() },
       { name: 'asset_type_id', value: $(`#SearchAdder-asset-type-${RAND_NUM}`).val() },
@@ -125,9 +125,6 @@ L.SearchAdder = function (map, csrftoken, objectType, objectID) {
       case 'polygon':
         data.push({ name: 'poly_id', value: objectID })
         break
-    }
-    if (includeCSRF) {
-      data.push({ name: 'csrfmiddlewaretoken', value: csrftoken })
     }
     return data
   }
@@ -148,7 +145,7 @@ L.SearchAdder = function (map, csrftoken, objectType, objectID) {
     if (onMap !== null) {
       onMap.remove()
     }
-    smmPost(getUrl(), getData(true))
+    smmPost(getUrl(), getData())
     dialog.destroy()
   })
 

--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -39,6 +39,24 @@ function smmPost(url: string, data: object, success?: (data: unknown) => void, e
   })
 }
 
+function smmPostBody(url: string, body: FormData | URLSearchParams, success?: (data: unknown) => void, error?: () => void) {
+  return fetch(url, {
+    method: 'POST',
+    headers: {
+      'X-CSRFToken': cookieJar.get('csrftoken') ?? ''
+    },
+    body: body,
+    timeout: AJAX_TIMEOUT
+  })
+    .then((response) => {
+      if (!response.ok) throw response
+      if (success) success(response.text())
+    })
+    .catch(() => {
+      if (error) error()
+    })
+}
+
 function smmDelete(url: string, success?: (data: never) => void, error?: () => void) {
   $.ajax({
     url: url,
@@ -52,4 +70,4 @@ function smmDelete(url: string, success?: (data: never) => void, error?: () => v
   })
 }
 
-export { smmGet, smmGetJSON, smmPost, smmDelete }
+export { smmGet, smmGetJSON, smmPost, smmPostBody, smmDelete }

--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -23,4 +23,15 @@ function smmGetJSON(url: string, data?: object, success?: (data: unknown) => voi
   })
 }
 
-export { smmGet, smmGetJSON }
+function smmPost(url: string, data: object, success?: (data: unknown) => void, error?: () => void) {
+  return $.ajax({
+    url,
+    type: 'POST',
+    data: data,
+    timeout: AJAX_TIMEOUT,
+    success: success,
+    error: error
+  })
+}
+
+export { smmGet, smmGetJSON, smmPost }

--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -39,4 +39,17 @@ function smmPost(url: string, data: object, success?: (data: unknown) => void, e
   })
 }
 
-export { smmGet, smmGetJSON, smmPost }
+function smmDelete(url: string, success?: (data: never) => void, error?: () => void) {
+  $.ajax({
+    url: url,
+    type: 'DELETE',
+    headers: {
+      'X-CSRFToken': cookieJar.get('csrftoken') ?? ''
+    },
+    timeout: AJAX_TIMEOUT,
+    success: success,
+    error: error
+  })
+}
+
+export { smmGet, smmGetJSON, smmPost, smmDelete }

--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -1,5 +1,7 @@
 import $ from 'jquery'
 
+import { cookieJar } from './cookies'
+
 const AJAX_TIMEOUT = 2500
 
 function smmGet(url: string, data?: object, success?: (data: unknown) => void, error?: () => void) {
@@ -27,6 +29,9 @@ function smmPost(url: string, data: object, success?: (data: unknown) => void, e
   return $.ajax({
     url,
     type: 'POST',
+    headers: {
+      'X-CSRFToken': cookieJar.get('csrftoken') ?? ''
+    },
     data: data,
     timeout: AJAX_TIMEOUT,
     success: success,

--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -150,8 +150,8 @@ class SMMAssets extends SMMRealtime {
   assetNameMap: { [key: number]: string }
   assetIconMap: { [key: number]: string }
   assetStatusMap: { [key: number]: { status: string; notes: string } }
-  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string, overlayAdd: (name: string, overlay: L.Layer) => void) {
-    super(map, csrftoken, missionId, interval, color)
+  constructor(map: L.Map, missionId: number | string, interval: number, color: string, overlayAdd: (name: string, overlay: L.Layer) => void) {
+    super(map, missionId, interval, color)
     this.overlayAdd = overlayAdd
     this.assetObjects = {}
     this.createPopup = this.createPopup.bind(this)

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
-import { smmGet, smmGetJSON } from '../ajax'
+import { smmGet, smmGetJSON, smmPost } from '../ajax'
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { SMMTopBar } from '../menu/topbar'
 import { MissionAssetStatus } from '../mission/asset/status'
@@ -180,7 +180,7 @@ class AssetCommandView extends React.Component<AssetCommandViewProps, AssetComma
 
   submitResponse() {
     if (this.props.lastCommand !== undefined) {
-      $.post(`/assets/${this.props.asset}/command/`, {
+      smmPost(`/assets/${this.props.asset}/command/`, {
         command_id: this.props.lastCommand.id,
         message: this.state.message,
         type: this.state.type,
@@ -462,7 +462,7 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
   }
 
   setStatus() {
-    $.post(
+    smmPost(
       `/assets/${this.props.asset}/status/`,
       {
         value_id: this.state.selectedValueId,

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -183,8 +183,7 @@ class AssetCommandView extends React.Component<AssetCommandViewProps, AssetComma
       smmPost(`/assets/${this.props.asset}/command/`, {
         command_id: this.props.lastCommand.id,
         message: this.state.message,
-        type: this.state.type,
-        csrfmiddlewaretoken: this.props.csrftoken
+        type: this.state.type
       })
     }
   }
@@ -466,8 +465,7 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
       `/assets/${this.props.asset}/status/`,
       {
         value_id: this.state.selectedValueId,
-        notes: this.state.notes,
-        csrfmiddlewaretoken: this.props.csrftoken
+        notes: this.state.notes
       },
       this.resetForm
     )

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -5,7 +5,6 @@ import { Table, Button } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
 import { smmGet, smmGetJSON, smmPost } from '../ajax'
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { SMMTopBar } from '../menu/topbar'
@@ -144,7 +143,6 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
 interface AssetCommandViewProps {
   asset: number
   lastCommand?: AssetCommandData
-  csrftoken: string
 }
 
 interface AssetCommandViewState {
@@ -386,7 +384,6 @@ class AssetMissionDetails extends React.Component<AssetMissionDetailsProps, neve
 
 interface AssetStatusProps {
   asset: number
-  csrftoken: string
   details?: AssetFullStatusData
 }
 
@@ -526,7 +523,6 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
 
 interface AssetUIProps {
   asset: number
-  csrftoken: string
 }
 
 interface AssetUIState {
@@ -579,7 +575,7 @@ class AssetUI extends React.Component<AssetUIProps, AssetUIState> {
   render() {
     let missionStatus
     if (this.state.details?.mission_id !== undefined) {
-      missionStatus = <MissionAssetStatus mission={this.state.details.mission_id} asset={this.props.asset} csrftoken={this.props.csrftoken} />
+      missionStatus = <MissionAssetStatus mission={this.state.details.mission_id} asset={this.props.asset} />
     }
     return (
       <div>
@@ -587,10 +583,10 @@ class AssetUI extends React.Component<AssetUIProps, AssetUIState> {
           {this.state.details?.name}
         </div>
         <AssetMissionDetails details={this.state.details} />
-        <AssetCommandView lastCommand={this.state.lastCommand} asset={this.props.asset} csrftoken={this.props.csrftoken} />
+        <AssetCommandView lastCommand={this.state.lastCommand} asset={this.props.asset} />
         {missionStatus}
         <AssetTrackAs asset={this.props.asset} />
-        <AssetStatus asset={this.props.asset} csrftoken={this.props.csrftoken} details={this.state.details} />
+        <AssetStatus asset={this.props.asset} details={this.state.details} />
       </div>
     )
   }
@@ -599,12 +595,10 @@ class AssetUI extends React.Component<AssetUIProps, AssetUIState> {
 function createAssetUI(elementId: string, assetId: number) {
   const div = ReactDOM.createRoot(document.getElementById(elementId)!)
 
-  const csrftoken = $('[name=csrfmiddlewaretoken]').val()
-
   div.render(
     <>
       <SMMTopBar />
-      <AssetUI asset={assetId} csrftoken={csrftoken as string} />
+      <AssetUI asset={assetId} />
     </>
   )
 }

--- a/frontend/image/map.tsx
+++ b/frontend/image/map.tsx
@@ -7,8 +7,8 @@ import { SMMImageGeoJSON } from './types'
 import { smmGet } from '../ajax'
 
 abstract class SMMImage extends SMMRealtime {
-  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string) {
-    super(map, csrftoken, missionId, interval, color)
+  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+    super(map, missionId, interval, color)
 
     this.createPopup = this.createPopup.bind(this)
   }
@@ -109,8 +109,8 @@ abstract class SMMImage extends SMMRealtime {
 }
 
 class SMMImageAll extends SMMImage {
-  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string) {
-    super(map, csrftoken, missionId, interval, color)
+  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+    super(map, missionId, interval, color)
     this.getUrl = this.getUrl.bind(this)
   }
 
@@ -120,8 +120,8 @@ class SMMImageAll extends SMMImage {
 }
 
 class SMMImageImportant extends SMMImage {
-  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string) {
-    super(map, csrftoken, missionId, interval, color)
+  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+    super(map, missionId, interval, color)
     this.getUrl = this.getUrl.bind(this)
   }
 

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -44,7 +44,6 @@ class SMMMap {
   layerControlAssets: L.Control.Layers
   layerControlUsers: L.Control.Layers
   missionId: number | string
-  csrftoken: string
   assets?: SMMAssets
   users?: SMMUserPositions
   POIs?: SMMPOIs
@@ -57,14 +56,13 @@ class SMMMap {
   importantImages?: SMMImageImportant
   marineVectors?: SMMMarineVector
 
-  constructor(mapElem: string | HTMLElement, missionId: number | string, csrftoken: string) {
+  constructor(mapElem: string | HTMLElement, missionId: number | string) {
     this.map = L.map(mapElem)
     this.layerControl = L.control.layers({}, {})
     this.layerControlMaps = L.control.layers({}, {})
     this.layerControlAssets = L.control.layers({}, {})
     this.layerControlUsers = L.control.layers({}, {})
     this.missionId = missionId
-    this.csrftoken = csrftoken
     this.overlayAdd = this.overlayAdd.bind(this)
     this.overlayAddAsset = this.overlayAddAsset.bind(this)
     this.overlayAddUser = this.overlayAddUser.bind(this)
@@ -137,17 +135,17 @@ class SMMMap {
     this.map.locate({ setView: true, maxZoom: 16 })
 
     if (this.missionId !== 'current' && this.missionId !== 'all') {
-      L.control.poiadder({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
-      L.control.polygonadder({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
-      L.control.lineadder({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
+      L.control.poiadder({ missionId: this.missionId }).addTo(this.map)
+      L.control.polygonadder({ missionId: this.missionId }).addTo(this.map)
+      L.control.lineadder({ missionId: this.missionId }).addTo(this.map)
       new LocateControl({
         setView: 'untilPan',
         keepCurrentZoomLevel: true,
         locateOptions: { enableHighAccuracy: true }
       }).addTo(this.map)
-      L.control.imageuploader({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
+      L.control.imageuploader({ missionId: this.missionId }).addTo(this.map)
     }
-    L.control.smmadmin({ missionId: this.missionId, csrftoken: this.csrftoken }).addTo(this.map)
+    L.control.smmadmin({ missionId: this.missionId }).addTo(this.map)
 
     const assetUpdateFreq = 3 * 1000
     const userUpdateFreq = 3 * 1000
@@ -160,36 +158,36 @@ class SMMMap {
     // Default leaflet path color
     const defaultColor = '#3388ff'
 
-    this.assets = new SMMAssets(this.map, this.csrftoken, this.missionId, assetUpdateFreq, 'red', this.overlayAddAsset)
+    this.assets = new SMMAssets(this.map, this.missionId, assetUpdateFreq, 'red', this.overlayAddAsset)
     this.overlayAdd('Assets', this.assets.realtime().addTo(this.map))
 
-    this.users = new SMMUserPositions(this.map, this.csrftoken, this.missionId, userUpdateFreq, 'red', this.overlayAddUser)
+    this.users = new SMMUserPositions(this.map, this.missionId, userUpdateFreq, 'red', this.overlayAddUser)
     this.overlayAdd('Users', this.users.realtime().addTo(this.map))
 
-    this.POIs = new SMMPOIs(this.map, this.csrftoken, this.missionId, userDataUpdateFreq, defaultColor)
+    this.POIs = new SMMPOIs(this.map, this.missionId, userDataUpdateFreq, defaultColor)
     this.overlayAdd('POIs', this.POIs.realtime().addTo(this.map))
 
-    this.polygons = new SMMPolygons(this.map, this.csrftoken, this.missionId, userDataUpdateFreq, defaultColor)
+    this.polygons = new SMMPolygons(this.map, this.missionId, userDataUpdateFreq, defaultColor)
     this.overlayAdd('Polygons', this.polygons.realtime().addTo(this.map))
 
-    this.lines = new SMMLines(this.map, this.csrftoken, this.missionId, userDataUpdateFreq, defaultColor)
+    this.lines = new SMMLines(this.map, this.missionId, userDataUpdateFreq, defaultColor)
     this.overlayAdd('Lines', this.lines.realtime().addTo(this.map))
 
-    this.notStartedSearches = new SMMSearchesNotStarted(this.map, this.csrftoken, this.missionId, searchIncompleteUpdateFreq, 'orange')
-    this.inprogressSearches = new SMMSearchesInprogress(this.map, this.csrftoken, this.missionId, searchIncompleteUpdateFreq, 'orange')
-    this.completeSearches = new SMMSearchesComplete(this.map, this.csrftoken, this.missionId, searchCompleteUpdateFreq, defaultColor)
+    this.notStartedSearches = new SMMSearchesNotStarted(this.map, this.missionId, searchIncompleteUpdateFreq, 'orange')
+    this.inprogressSearches = new SMMSearchesInprogress(this.map, this.missionId, searchIncompleteUpdateFreq, 'orange')
+    this.completeSearches = new SMMSearchesComplete(this.map, this.missionId, searchCompleteUpdateFreq, defaultColor)
 
     this.overlayAdd('Pending Searches', this.notStartedSearches.realtime().addTo(this.map))
     this.overlayAdd('Inprogress Searches', this.inprogressSearches.realtime().addTo(this.map))
     this.overlayAdd('Completed Searches', this.completeSearches.realtime())
 
-    this.allImages = new SMMImageAll(this.map, this.csrftoken, this.missionId, imageAllUpdateFreq, defaultColor)
-    this.importantImages = new SMMImageImportant(this.map, this.csrftoken, this.missionId, imageAllUpdateFreq, defaultColor)
+    this.allImages = new SMMImageAll(this.map, this.missionId, imageAllUpdateFreq, defaultColor)
+    this.importantImages = new SMMImageImportant(this.map, this.missionId, imageAllUpdateFreq, defaultColor)
 
     this.overlayAdd('Images (all)', this.allImages.realtime())
     this.overlayAdd('Images (prioritized)', this.importantImages.realtime().addTo(this.map))
 
-    this.marineVectors = new SMMMarineVector(this.map, this.csrftoken, this.missionId, marineDataUpdateFreq, 'black')
+    this.marineVectors = new SMMMarineVector(this.map, this.missionId, marineDataUpdateFreq, 'black')
     this.overlayAdd('Marine - Total Drift Vectors', this.marineVectors.realtime())
   }
 
@@ -225,9 +223,7 @@ function mapInit() {
   mapEl.setAttribute('style', 'flex: 1 1 auto;')
   wrapperEl.appendChild(mapEl)
 
-  const csrftoken = $('[name=csrfmiddlewaretoken]').val()
-
-  return new SMMMap(mapEl, missionId, csrftoken as string)
+  return new SMMMap(mapEl, missionId)
 }
 
 mapInit()

--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -9,7 +9,6 @@ import { smmGet, smmPostBody } from '../ajax'
 interface CustomMarineVectorsProps {
   map: L.Map
   missionId: number
-  csrftoken: string
   posName: string
   pos: L.LatLng
   poiId: number
@@ -139,12 +138,10 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   }
 }
 
-const MarineVectorsLeaflet = function (map: L.Map, missionId: number, csrftoken: string, posName, pos, poiId: number) {
+const MarineVectorsLeaflet = function (map: L.Map, missionId: number, posName, pos, poiId: number) {
   const container = document.createElement('div')
   const dialog = L.control.dialog({ initOpen: true, size: [1000, 500] })
-  ReactDOM.createRoot(container).render(
-    <CustomMarineVectors map={map} missionId={missionId} csrftoken={csrftoken} posName={posName} pos={pos} poiId={Number(poiId)} dialog={dialog} />
-  )
+  ReactDOM.createRoot(container).render(<CustomMarineVectors map={map} missionId={missionId} posName={posName} pos={pos} poiId={Number(poiId)} dialog={dialog} />)
   dialog.setContent(container).addTo(map).hideClose()
 }
 

--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -4,6 +4,7 @@ import L from 'leaflet'
 
 import { MarineVectors, MarineVectorsDisplay } from '@canterbury-air-patrol/marine-total-drift-vector'
 import { Button, ButtonGroup } from 'react-bootstrap'
+import { smmGet, smmPostBody } from '../ajax'
 
 interface CustomMarineVectorsProps {
   map: L.Map
@@ -65,24 +66,20 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   }
 
   add() {
-    fetch(`/mission/${this.props.missionId}/sar/marine/vectors/create/`, {
-      method: 'POST',
-      headers: {
-        'X-CSRFToken': this.props.csrftoken
-      },
-      mode: 'same-origin',
-      body: new URLSearchParams(this.getData())
-    }).then((response) => {
-      if (response.ok) {
+    smmPostBody(
+      `/mission/${this.props.missionId}/sar/marine/vectors/create/`,
+      URLSearchParams(this.getData()),
+      () => {
         if (this.onMap) {
           this.props.map.removeLayer(this.onMap)
           this.onMap = undefined
         }
         this.props.dialog.remove()
-      } else {
-        console.error('Error fetching data:', response.statusText)
+      },
+      () => {
+        console.error('Error fetching data:')
       }
-    })
+    )
   }
 
   preview() {
@@ -90,16 +87,17 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
       this.props.map.removeLayer(this.onMap)
       this.onMap = undefined
     }
-    fetch(`/mission/${this.props.missionId}/sar/marine/vectors/create/?${new URLSearchParams(this.getData()).toString()}`).then((response) => {
-      if (response.ok) {
-        response.json().then((data) => {
-          this.onMap = L.geoJSON(data, { color: 'yellow' })
-          this.onMap.addTo(this.props.map)
-        })
-      } else {
-        console.error('Error fetching data:', response.statusText)
+    smmGet(
+      `/mission/${this.props.missionId}/sar/marine/vectors/create/`,
+      this.getData(),
+      (data) => {
+        this.onMap = L.geoJSON(data, { color: 'yellow' })
+        this.onMap.addTo(this.props.map)
+      },
+      () => {
+        console.error('Error fetching data:')
       }
-    })
+    )
   }
 
   cancel() {

--- a/frontend/marine/vectors.tsx
+++ b/frontend/marine/vectors.tsx
@@ -3,8 +3,8 @@ import { TotalDriftVectorData } from './types'
 import { smmGet } from '../ajax'
 
 class SMMMarineVector extends SMMRealtime {
-  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string) {
-    super(map, csrftoken, missionId, interval, color)
+  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+    super(map, missionId, interval, color)
 
     this.createPopup = this.createPopup.bind(this)
   }

--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -103,8 +103,7 @@ class MissionAssetStatusForm extends React.Component<MissionAssetStatusFormProps
       `/mission/${this.props.mission}/assets/${this.props.asset}/status/`,
       {
         value_id: this.state.selectedValueId,
-        notes: this.state.notes,
-        csrfmiddlewaretoken: this.props.csrftoken
+        notes: this.state.notes
       },
       this.resetForm
     )

--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -5,7 +5,7 @@ import { Table, Button } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import { smmGetJSON } from '../../ajax'
+import { smmGetJSON, smmPost } from '../../ajax'
 import { SMMTopBar } from '../../menu/topbar'
 
 interface MissionAssetStatusValue {
@@ -99,7 +99,7 @@ class MissionAssetStatusForm extends React.Component<MissionAssetStatusFormProps
   }
 
   setStatus() {
-    $.post(
+    smmPost(
       `/mission/${this.props.mission}/assets/${this.props.asset}/status/`,
       {
         value_id: this.state.selectedValueId,

--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -23,7 +23,6 @@ interface MissionAssetStatusData {
 interface MissionAssetStatusFormProps {
   asset: number
   mission: number
-  csrftoken: string
 }
 
 interface MissionAssetStatusFormState {
@@ -137,7 +136,6 @@ class MissionAssetStatusForm extends React.Component<MissionAssetStatusFormProps
 interface MissionAssetStatusProps {
   asset: number
   mission: number
-  csrftoken: string
 }
 
 interface MissionAssetStatusState {
@@ -197,7 +195,7 @@ class MissionAssetStatus extends React.Component<MissionAssetStatusFormProps, Mi
               <td>{this.state.statusData?.notes}</td>
               <td>{this.state.statusData?.since === undefined ? '' : new Date(this.state.statusData.since).toLocaleString()}</td>
             </tr>
-            <MissionAssetStatusForm asset={this.props.asset} mission={this.props.mission} csrftoken={this.props.csrftoken} />
+            <MissionAssetStatusForm asset={this.props.asset} mission={this.props.mission} />
           </tbody>
         </Table>
       </div>
@@ -208,12 +206,10 @@ class MissionAssetStatus extends React.Component<MissionAssetStatusFormProps, Mi
 function createMissionAssetStatus(elementId: string, asset: number, mission: number) {
   const div = ReactDOM.createRoot(document.getElementById(elementId)!)
 
-  const csrftoken = $('[name=csrfmiddlewaretoken]').val()
-
   div.render(
     <>
       <SMMTopBar />
-      <MissionAssetStatus asset={asset} mission={mission} csrftoken={csrftoken as string} />
+      <MissionAssetStatus asset={asset} mission={mission} />
     </>
   )
 }

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
-import { smmGet, smmGetJSON } from '../ajax'
+import { smmGet, smmGetJSON, smmPost } from '../ajax'
 
 import { SMMMissionTopBar } from '../menu/topbar'
 
@@ -124,7 +124,7 @@ class MissionDetailsExternalReferencesRow extends React.Component<MissionDetails
 
   update() {
     const extRef = this.props.ExternalReference
-    $.post(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`, {
+    smmPost(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`, {
       csrfmiddlewaretoken: this.props.csrftoken,
       ...this.state.values
     })
@@ -226,7 +226,7 @@ class MissionDetailsExternalReferenceAdd extends React.Component<MissionDetailsE
 
   add() {
     if (this.state.name) {
-      $.post(
+      smmPost(
         `/mission/${this.props.mission}/externalreferences/`,
         {
           name: this.state.name,
@@ -310,19 +310,19 @@ class MissionDetailsOrganizationsRow extends React.Component<MissionDetailsOrgan
   }
 
   disableOrgAdd() {
-    $.post(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_organization: false, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_organization: false, csrfmiddlewaretoken: this.props.csrftoken })
   }
 
   enableOrgAdd() {
-    $.post(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_organization: true, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_organization: true, csrfmiddlewaretoken: this.props.csrftoken })
   }
 
   disableUserAdd() {
-    $.post(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_user: false, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_user: false, csrfmiddlewaretoken: this.props.csrftoken })
   }
 
   enableUserAdd() {
-    $.post(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_user: true, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_user: true, csrfmiddlewaretoken: this.props.csrftoken })
   }
 
   render() {
@@ -458,7 +458,7 @@ class MissionDetailsOrganizationAdd extends React.Component<MissionDetailsOrgani
 
   add() {
     if (this.state.selectedOrg) {
-      $.post(`/mission/${this.props.mission}/organizations/`, { organization: this.state.selectedOrg, csrfmiddlewaretoken: this.props.csrftoken })
+      smmPost(`/mission/${this.props.mission}/organizations/`, { organization: this.state.selectedOrg, csrfmiddlewaretoken: this.props.csrftoken })
     }
   }
 
@@ -510,27 +510,27 @@ class MissionDetailsUserRow extends React.Component<MissionDetailsUserRowProps, 
   }
 
   removeAdmin() {
-    $.post(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: false, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: false, csrfmiddlewaretoken: this.props.csrftoken })
   }
 
   makeAdmin() {
-    $.post(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: true, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: true, csrfmiddlewaretoken: this.props.csrftoken })
   }
 
   disableOrgAdd() {
-    $.post(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: false, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: false, csrfmiddlewaretoken: this.props.csrftoken })
   }
 
   enableOrgAdd() {
-    $.post(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: true, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: true, csrfmiddlewaretoken: this.props.csrftoken })
   }
 
   disableUserAdd() {
-    $.post(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: false, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: false, csrfmiddlewaretoken: this.props.csrftoken })
   }
 
   enableUserAdd() {
-    $.post(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: true, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: true, csrfmiddlewaretoken: this.props.csrftoken })
   }
 
   render() {
@@ -681,7 +681,7 @@ class MissionDetailsUserAdd extends React.Component<MissionDetailsUserAddProps, 
 
   add() {
     if (this.state.selectedUser) {
-      $.post(`/mission/${this.props.mission}/users/`, { user: this.state.selectedUser, csrfmiddlewaretoken: this.props.csrftoken })
+      smmPost(`/mission/${this.props.mission}/users/`, { user: this.state.selectedUser, csrfmiddlewaretoken: this.props.csrftoken })
     }
   }
 
@@ -854,7 +854,7 @@ class MissionDetailsAssetAdd extends React.Component<MissionDetailsAssetAddProps
 
   add() {
     if (this.state.selectedAsset) {
-      $.post(`/mission/${this.props.mission}/assets/`, { asset: this.state.selectedAsset, csrfmiddlewaretoken: this.props.csrftoken })
+      smmPost(`/mission/${this.props.mission}/assets/`, { asset: this.state.selectedAsset, csrfmiddlewaretoken: this.props.csrftoken })
     }
   }
 

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
-import { smmGet, smmGetJSON, smmPost } from '../ajax'
+import { smmGet, smmGetJSON, smmPost, smmDelete } from '../ajax'
 
 import { SMMMissionTopBar } from '../menu/topbar'
 
@@ -129,13 +129,7 @@ class MissionDetailsExternalReferencesRow extends React.Component<MissionDetails
 
   delete() {
     const extRef = this.props.ExternalReference
-    $.ajax({
-      url: `/mission/${extRef.mission}/externalreferences/${extRef.id}/`,
-      type: 'DELETE',
-      beforeSend: (xhr) => {
-        xhr.setRequestHeader('X-CSRFToken', this.props.csrftoken)
-      }
-    })
+    smmDelete(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`)
   }
 
   renderField(field: string, displayValue?: string) {

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -124,10 +124,7 @@ class MissionDetailsExternalReferencesRow extends React.Component<MissionDetails
 
   update() {
     const extRef = this.props.ExternalReference
-    smmPost(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`, {
-      csrfmiddlewaretoken: this.props.csrftoken,
-      ...this.state.values
-    })
+    smmPost(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`, this.state.values)
   }
 
   delete() {
@@ -232,8 +229,7 @@ class MissionDetailsExternalReferenceAdd extends React.Component<MissionDetailsE
           name: this.state.name,
           code: this.state.code,
           url: this.state.url,
-          notes: this.state.notes,
-          csrfmiddlewaretoken: this.props.csrftoken
+          notes: this.state.notes
         },
         this.addSuccess
       )
@@ -310,19 +306,19 @@ class MissionDetailsOrganizationsRow extends React.Component<MissionDetailsOrgan
   }
 
   disableOrgAdd() {
-    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_organization: false, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_organization: false })
   }
 
   enableOrgAdd() {
-    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_organization: true, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_organization: true })
   }
 
   disableUserAdd() {
-    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_user: false, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_user: false })
   }
 
   enableUserAdd() {
-    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_user: true, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/organizations/${this.props.missionOrg.organization.id}/`, { add_user: true })
   }
 
   render() {
@@ -458,7 +454,7 @@ class MissionDetailsOrganizationAdd extends React.Component<MissionDetailsOrgani
 
   add() {
     if (this.state.selectedOrg) {
-      smmPost(`/mission/${this.props.mission}/organizations/`, { organization: this.state.selectedOrg, csrfmiddlewaretoken: this.props.csrftoken })
+      smmPost(`/mission/${this.props.mission}/organizations/`, { organization: this.state.selectedOrg })
     }
   }
 
@@ -510,27 +506,27 @@ class MissionDetailsUserRow extends React.Component<MissionDetailsUserRowProps, 
   }
 
   removeAdmin() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: false, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: false })
   }
 
   makeAdmin() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: true, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: true })
   }
 
   disableOrgAdd() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: false, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: false })
   }
 
   enableOrgAdd() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: true, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: true })
   }
 
   disableUserAdd() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: false, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: false })
   }
 
   enableUserAdd() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: true, csrfmiddlewaretoken: this.props.csrftoken })
+    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: true })
   }
 
   render() {
@@ -681,7 +677,7 @@ class MissionDetailsUserAdd extends React.Component<MissionDetailsUserAddProps, 
 
   add() {
     if (this.state.selectedUser) {
-      smmPost(`/mission/${this.props.mission}/users/`, { user: this.state.selectedUser, csrfmiddlewaretoken: this.props.csrftoken })
+      smmPost(`/mission/${this.props.mission}/users/`, { user: this.state.selectedUser })
     }
   }
 
@@ -854,7 +850,7 @@ class MissionDetailsAssetAdd extends React.Component<MissionDetailsAssetAddProps
 
   add() {
     if (this.state.selectedAsset) {
-      smmPost(`/mission/${this.props.mission}/assets/`, { asset: this.state.selectedAsset, csrfmiddlewaretoken: this.props.csrftoken })
+      smmPost(`/mission/${this.props.mission}/assets/`, { asset: this.state.selectedAsset })
     }
   }
 

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -5,7 +5,6 @@ import { Table, Button, ButtonGroup } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
 import { smmGet, smmGetJSON, smmPost, smmDelete } from '../ajax'
 
 import { SMMMissionTopBar } from '../menu/topbar'
@@ -59,7 +58,6 @@ const MissionDetails: React.FC<MissionDetailsProps> = (props) => {
 
 interface MissionDetailsExternalReferencesRowProps {
   ExternalReference: MissionExternalReferenceData
-  csrftoken: string
 }
 
 interface MissionDetailsExternalReferencesRowState {
@@ -178,7 +176,6 @@ class MissionDetailsExternalReferencesRow extends React.Component<MissionDetails
 
 interface MissionDetailsExternalReferenceAddProps {
   mission: number
-  csrftoken: string
 }
 
 interface MissionDetailsExternalReferenceAddState {
@@ -255,13 +252,12 @@ class MissionDetailsExternalReferenceAdd extends React.Component<MissionDetailsE
 
 interface MissionDetailsExternalReferencesListProps {
   ExternalReferences: Array<MissionExternalReferenceData>
-  csrftoken: string
   mission: number
 }
 
 class MissionDetailsExternalReferencesList extends React.Component<MissionDetailsExternalReferencesListProps, never> {
   render() {
-    const rows = this.props.ExternalReferences.map((extRef) => <MissionDetailsExternalReferencesRow key={extRef.id} ExternalReference={extRef} csrftoken={this.props.csrftoken} />)
+    const rows = this.props.ExternalReferences.map((extRef) => <MissionDetailsExternalReferencesRow key={extRef.id} ExternalReference={extRef} />)
     return (
       <Table>
         <thead>
@@ -275,7 +271,7 @@ class MissionDetailsExternalReferencesList extends React.Component<MissionDetail
         </thead>
         <tbody>
           {rows}
-          <MissionDetailsExternalReferenceAdd mission={this.props.mission} csrftoken={this.props.csrftoken} />
+          <MissionDetailsExternalReferenceAdd mission={this.props.mission} />
         </tbody>
       </Table>
     )
@@ -286,7 +282,6 @@ interface MissionDetailsOrganizationsRowProps {
   mission: number
   missionOrg: MissionOrganizationData
   showButtons: boolean
-  csrftoken: string
 }
 
 class MissionDetailsOrganizationsRow extends React.Component<MissionDetailsOrganizationsRowProps, never> {
@@ -361,19 +356,12 @@ interface MissionDetailsOrganizationsListProps {
   missionOrganizations: Array<MissionOrganizationData>
   mission: number
   isAdmin: boolean
-  csrftoken: string
 }
 
 class MissionDetailsOrganizationsList extends React.Component<MissionDetailsOrganizationsListProps, never> {
   render() {
     const org_list = this.props.missionOrganizations.map((missionOrg) => (
-      <MissionDetailsOrganizationsRow
-        key={missionOrg.organization.id}
-        mission={this.props.mission}
-        missionOrg={missionOrg}
-        showButtons={this.props.isAdmin}
-        csrftoken={this.props.csrftoken}
-      />
+      <MissionDetailsOrganizationsRow key={missionOrg.organization.id} mission={this.props.mission} missionOrg={missionOrg} showButtons={this.props.isAdmin} />
     ))
     return (
       <Table>
@@ -391,7 +379,6 @@ class MissionDetailsOrganizationsList extends React.Component<MissionDetailsOrga
 
 interface MissionDetailsOrganizationAddProps {
   mission: number
-  csrftoken: string
 }
 
 interface MissionDetailsOrganizationAddState {
@@ -483,7 +470,6 @@ class MissionDetailsOrganizationAdd extends React.Component<MissionDetailsOrgani
 interface MissionDetailsUserRowProps {
   mission: number
   missionUser: MissionUserData
-  csrftoken: string
   showButtons: boolean
 }
 
@@ -583,19 +569,12 @@ interface MissionDetailsUsersListProps {
   isAdmin: boolean
   me: string
   mission: number
-  csrftoken: string
 }
 
 class MissionDetailsUsersList extends React.Component<MissionDetailsUsersListProps, never> {
   render() {
     const user_list = this.props.missionUsers.map((missionUser) => (
-      <MissionDetailsUserRow
-        key={missionUser.id}
-        mission={this.props.mission}
-        missionUser={missionUser}
-        showButtons={this.props.isAdmin && this.props.me !== missionUser.user}
-        csrftoken={this.props.csrftoken}
-      />
+      <MissionDetailsUserRow key={missionUser.id} mission={this.props.mission} missionUser={missionUser} showButtons={this.props.isAdmin && this.props.me !== missionUser.user} />
     ))
 
     return (
@@ -614,7 +593,6 @@ class MissionDetailsUsersList extends React.Component<MissionDetailsUsersListPro
 
 interface MissionDetailsUserAddProps {
   mission: number
-  csrftoken: string
 }
 
 interface MissionDetailsUserAddState {
@@ -761,7 +739,6 @@ class MissionDetailsAssetRow extends React.Component<MissionDetailsAssetRowProps
 
 interface MissionDetailsAssetListProps {
   missionAssets: Array<MissionAssetData>
-  csrftoken: string
 }
 
 class MissionDetailsAssetList extends React.Component<MissionDetailsAssetListProps, never> {
@@ -788,7 +765,6 @@ class MissionDetailsAssetList extends React.Component<MissionDetailsAssetListPro
 
 interface MissionDetailsAssetAddProps {
   mission: number
-  csrftoken: string
 }
 
 interface MissionDetailsAssetAddState {
@@ -878,7 +854,6 @@ class MissionDetailsAssetAdd extends React.Component<MissionDetailsAssetAddProps
 
 interface MissionDetailsPageProps {
   missionId: number
-  csrftoken: string
 }
 
 interface MissionDetailsPageState {
@@ -922,26 +897,21 @@ class MissionDetailPage extends React.Component<MissionDetailsPageProps, Mission
     } else {
       let orgAdd
       let userAdd
-      const assetAdd = <MissionDetailsAssetAdd mission={this.props.missionId} csrftoken={this.props.csrftoken} />
+      const assetAdd = <MissionDetailsAssetAdd mission={this.props.missionId} />
       if (this.state.missionDetails.can_add_organizations) {
-        orgAdd = <MissionDetailsOrganizationAdd mission={this.props.missionId} csrftoken={this.props.csrftoken} />
+        orgAdd = <MissionDetailsOrganizationAdd mission={this.props.missionId} />
       }
       if (this.state.missionDetails.can_add_users) {
-        userAdd = <MissionDetailsUserAdd mission={this.props.missionId} csrftoken={this.props.csrftoken} />
+        userAdd = <MissionDetailsUserAdd mission={this.props.missionId} />
       }
       return (
         <>
           <MissionDetails mission={this.state.missionDetails.mission} />
-          <MissionDetailsExternalReferencesList
-            mission={this.props.missionId}
-            ExternalReferences={this.state.missionDetails.external_references}
-            csrftoken={this.props.csrftoken}
-          />
+          <MissionDetailsExternalReferencesList mission={this.props.missionId} ExternalReferences={this.state.missionDetails.external_references} />
           <MissionDetailsOrganizationsList
             mission={this.props.missionId}
             missionOrganizations={this.state.missionDetails.mission_organizations}
             isAdmin={this.state.missionDetails.admin}
-            csrftoken={this.props.csrftoken}
           />
           {orgAdd}
           <MissionDetailsUsersList
@@ -949,10 +919,9 @@ class MissionDetailPage extends React.Component<MissionDetailsPageProps, Mission
             me={this.state.missionDetails.me}
             missionUsers={this.state.missionDetails.mission_users}
             isAdmin={this.state.missionDetails.admin}
-            csrftoken={this.props.csrftoken}
           />
           {userAdd}
-          <MissionDetailsAssetList missionAssets={this.state.missionDetails.mission_assets} csrftoken={this.props.csrftoken} />
+          <MissionDetailsAssetList missionAssets={this.state.missionDetails.mission_assets} />
           {assetAdd}
         </>
       )
@@ -962,12 +931,11 @@ class MissionDetailPage extends React.Component<MissionDetailsPageProps, Mission
 
 function createMissionDetails(elementId: string, missionId: number) {
   const div = ReactDOM.createRoot(document.getElementById(elementId)!)
-  const csrftoken = $('[name=csrfmiddlewaretoken]').val()
 
   div.render(
     <>
       <SMMMissionTopBar missionId={missionId} />
-      <MissionDetailPage missionId={missionId} csrftoken={csrftoken as string} />
+      <MissionDetailPage missionId={missionId} />
     </>
   )
 }

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -5,7 +5,6 @@ import { Table, Button } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
 import { smmGetJSON, smmPost } from '../ajax'
 
 import DateTimePicker from 'react-datetime-picker'
@@ -17,7 +16,6 @@ import { MissionData } from './types'
 
 interface MissionTimeLineEntryAddProps {
   missionId: number
-  csrftoken: string
 }
 
 interface MissionTimeLineEntryAddState {
@@ -157,7 +155,6 @@ class MissionTimelineEntry extends React.Component<MissionTimelineEntryProps, ne
 
 interface MissionTimeLineProps {
   missionId: number
-  csrftoken: string
 }
 
 interface MissionTimelineState {
@@ -234,7 +231,7 @@ export class MissionTimeLine extends React.Component<MissionTimeLineProps, Missi
     if (this.state.missionData !== undefined) {
       missionData = <MissionHeader key="missionHeader" mission={this.state.missionData} />
       if (this.state.missionClosed !== null) {
-        timelineAdd = <MissionTimeLineEntryAdd missionId={this.props.missionId} csrftoken={this.props.csrftoken} />
+        timelineAdd = <MissionTimeLineEntryAdd missionId={this.props.missionId} />
       }
     }
 
@@ -266,12 +263,11 @@ export class MissionTimeLine extends React.Component<MissionTimeLineProps, Missi
 
 export function createMissionTimeline(elementId: string, missionId: number) {
   const div = ReactDOM.createRoot(document.getElementById(elementId)!)
-  const csrftoken = $('[name=csrfmiddlewaretoken]').val()
 
   div.render(
     <>
       <SMMMissionTopBar missionId={missionId} />
-      <MissionTimeLine missionId={missionId} csrftoken={csrftoken as string} />
+      <MissionTimeLine missionId={missionId} />
     </>
   )
 }

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -81,7 +81,6 @@ class MissionTimeLineEntryAdd extends React.Component<MissionTimeLineEntryAddPro
       timestamp = new Date()
     }
     smmPost(`/mission/${this.props.missionId}/timeline/`, {
-      csrfmiddlewaretoken: this.props.csrftoken,
       timestamp: timestamp.toISOString(),
       message: this.state.message,
       url: this.state.url

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
-import { smmGetJSON } from '../ajax'
+import { smmGetJSON, smmPost } from '../ajax'
 
 import DateTimePicker from 'react-datetime-picker'
 import 'react-datetime-picker/dist/DateTimePicker.css'
@@ -80,7 +80,7 @@ class MissionTimeLineEntryAdd extends React.Component<MissionTimeLineEntryAddPro
     if (this.state.timeNow) {
       timestamp = new Date()
     }
-    $.post(`/mission/${this.props.missionId}/timeline/`, {
+    smmPost(`/mission/${this.props.missionId}/timeline/`, {
       csrfmiddlewaretoken: this.props.csrftoken,
       timestamp: timestamp.toISOString(),
       message: this.state.message,

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
-import { smmGetJSON } from '../ajax'
+import { smmGetJSON, smmPost } from '../ajax'
 
 import { OrganizationListRow } from './list'
 import { SMMOrganizationTopBar } from '../menu/topbar'
@@ -74,7 +74,7 @@ class OrganizationMemberRow extends React.Component<OrganizationMemberRowProps, 
 
   saveChanges() {
     const { user } = this.props.organization_member
-    $.post(`/organization/${this.props.organizationId}/user/${user}/`, { csrfmiddlewaretoken: this.props.csrftoken, role: this.state.selectedRole }, function () {})
+    smmPost(`/organization/${this.props.organizationId}/user/${user}/`, { csrfmiddlewaretoken: this.props.csrftoken, role: this.state.selectedRole })
   }
 
   render() {
@@ -243,7 +243,7 @@ class OrganizationMemberAdd extends React.Component<OrganizationMemberAddProps, 
 
   addOrganizationMember() {
     const user = this.state.userList.find((user) => user.id === this.state.userId)
-    $.post(`/organization/${this.props.organizationId}/user/${user?.username}/`, { csrfmiddlewaretoken: this.props.csrftoken }, this.addOrgMemberCallback)
+    smmPost(`/organization/${this.props.organizationId}/user/${user?.username}/`, { csrfmiddlewaretoken: this.props.csrftoken }, this.addOrgMemberCallback)
   }
 
   render() {
@@ -370,7 +370,7 @@ class OrganizationAssetAdd extends React.Component<OrganizationAssetAddProps, Or
   }
 
   addOrganizationAsset() {
-    $.post(`/organization/${this.props.organizationId}/assets/${this.state.assetId}/`, { csrfmiddlewaretoken: this.props.csrftoken }, this.addOrgAssetCallback)
+    smmPost(`/organization/${this.props.organizationId}/assets/${this.state.assetId}/`, { csrfmiddlewaretoken: this.props.csrftoken }, this.addOrgAssetCallback)
   }
 
   render() {

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -5,7 +5,6 @@ import { Table, Button, ButtonGroup } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
 import { smmGetJSON, smmPost, smmDelete } from '../ajax'
 
 import { OrganizationListRow } from './list'
@@ -14,7 +13,6 @@ import { OrganizationAssetData, OrganizationData, OrganizationMemberData } from 
 import { AssetData } from '../asset/types'
 
 interface OrganizationMemberRowProps {
-  csrftoken: string
   organizationId: number
   organization_member: OrganizationMemberData
   showButtons: boolean
@@ -134,20 +132,13 @@ class OrganizationAssetRow extends React.Component<OrganizationAssetRowProps, ne
 interface OrganizationMemberListProps {
   organizationId: number
   organization_members?: OrganizationMemberData[]
-  csrftoken: string
   showButtons: boolean
 }
 
 class OrganizationMemberList extends React.Component<OrganizationMemberListProps, never> {
   render() {
     const organizationMemberRows = this.props.organization_members?.map((organizationMember) => (
-      <OrganizationMemberRow
-        key={organizationMember.id}
-        organizationId={this.props.organizationId}
-        organization_member={organizationMember}
-        csrftoken={this.props.csrftoken}
-        showButtons={this.props.showButtons}
-      />
+      <OrganizationMemberRow key={organizationMember.id} organizationId={this.props.organizationId} organization_member={organizationMember} showButtons={this.props.showButtons} />
     ))
     return (
       <Table responsive>
@@ -172,7 +163,6 @@ class OrganizationMemberList extends React.Component<OrganizationMemberListProps
 
 interface OrganizationMemberAddProps {
   organizationId: number
-  csrftoken: string
 }
 
 interface OrganizationMemberAddState {
@@ -299,7 +289,6 @@ class OrganizationAssetList extends React.Component<OrganizationAssetListProps, 
 
 interface OrganizationAssetAddProps {
   organizationId: number
-  csrftoken: string
 }
 
 interface OrganizationAssetAddState {
@@ -395,7 +384,6 @@ class OrganizationAssetAdd extends React.Component<OrganizationAssetAddProps, Or
 
 interface OrganizationDetailsPageProps {
   organizationId: number
-  csrftoken: string
   updateRadioOperator: (show: boolean) => void
 }
 
@@ -468,15 +456,14 @@ class OrganizationDetailsPage extends React.Component<OrganizationDetailsPagePro
         key="org_members"
         organizationId={this.props.organizationId}
         organization_members={this.state.organizationDetails.members}
-        csrftoken={this.props.csrftoken}
         showButtons={this.state.organizationDetails.role === 'Admin'}
       />
     )
     if (this.state.organizationDetails.role === 'Admin') {
-      organizationSections.push(<OrganizationMemberAdd key="org_add_member" organizationId={this.props.organizationId} csrftoken={this.props.csrftoken} />)
+      organizationSections.push(<OrganizationMemberAdd key="org_add_member" organizationId={this.props.organizationId} />)
     }
     organizationSections.push(<OrganizationAssetList key="org_assets" organization_assets={this.state.organizationDetails.assets} />)
-    organizationSections.push(<OrganizationAssetAdd key="org_asset_add" organizationId={this.props.organizationId} csrftoken={this.props.csrftoken} />)
+    organizationSections.push(<OrganizationAssetAdd key="org_asset_add" organizationId={this.props.organizationId} />)
 
     return <div>{organizationSections}</div>
   }
@@ -484,7 +471,6 @@ class OrganizationDetailsPage extends React.Component<OrganizationDetailsPagePro
 
 interface OrganizationPageProps {
   organizationId: number
-  csrftoken: string
 }
 
 interface OrganizationPageState {
@@ -511,7 +497,7 @@ class OrganizationPage extends React.Component<OrganizationPageProps, Organizati
     return (
       <>
         <SMMOrganizationTopBar organizationId={this.props.organizationId} showRadioOperator={this.state.isRadioOperator} />
-        <OrganizationDetailsPage organizationId={this.props.organizationId} csrftoken={this.props.csrftoken} updateRadioOperator={this.updateRadioOperator} />
+        <OrganizationDetailsPage organizationId={this.props.organizationId} updateRadioOperator={this.updateRadioOperator} />
       </>
     )
   }
@@ -520,9 +506,7 @@ class OrganizationPage extends React.Component<OrganizationPageProps, Organizati
 function createOrganizationDetails(elementId: string, organizationId: number) {
   const div = ReactDOM.createRoot(document.getElementById(elementId)!)
 
-  const csrftoken = $('[name=csrfmiddlewaretoken]').val()
-
-  div.render(<OrganizationPage organizationId={organizationId} csrftoken={csrftoken as string} />)
+  div.render(<OrganizationPage organizationId={organizationId} />)
 }
 
 // @ts-expect-error: globalThis has not definition

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -74,7 +74,7 @@ class OrganizationMemberRow extends React.Component<OrganizationMemberRowProps, 
 
   saveChanges() {
     const { user } = this.props.organization_member
-    smmPost(`/organization/${this.props.organizationId}/user/${user}/`, { csrfmiddlewaretoken: this.props.csrftoken, role: this.state.selectedRole })
+    smmPost(`/organization/${this.props.organizationId}/user/${user}/`, { role: this.state.selectedRole })
   }
 
   render() {
@@ -243,7 +243,7 @@ class OrganizationMemberAdd extends React.Component<OrganizationMemberAddProps, 
 
   addOrganizationMember() {
     const user = this.state.userList.find((user) => user.id === this.state.userId)
-    smmPost(`/organization/${this.props.organizationId}/user/${user?.username}/`, { csrfmiddlewaretoken: this.props.csrftoken }, this.addOrgMemberCallback)
+    smmPost(`/organization/${this.props.organizationId}/user/${user?.username}/`, {}, this.addOrgMemberCallback)
   }
 
   render() {
@@ -370,7 +370,7 @@ class OrganizationAssetAdd extends React.Component<OrganizationAssetAddProps, Or
   }
 
   addOrganizationAsset() {
-    smmPost(`/organization/${this.props.organizationId}/assets/${this.state.assetId}/`, { csrfmiddlewaretoken: this.props.csrftoken }, this.addOrgAssetCallback)
+    smmPost(`/organization/${this.props.organizationId}/assets/${this.state.assetId}/`, {}, this.addOrgAssetCallback)
   }
 
   render() {

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
-import { smmGetJSON, smmPost } from '../ajax'
+import { smmGetJSON, smmPost, smmDelete } from '../ajax'
 
 import { OrganizationListRow } from './list'
 import { SMMOrganizationTopBar } from '../menu/topbar'
@@ -30,20 +30,11 @@ class OrganizationMemberRow extends React.Component<OrganizationMemberRowProps, 
     this.delete = this.delete.bind(this)
     this.updateSelectedRole = this.updateSelectedRole.bind(this)
     this.saveChanges = this.saveChanges.bind(this)
-    this.setXHR = this.setXHR.bind(this)
-  }
-
-  setXHR(xhr: JQuery.jqXHR) {
-    xhr.setRequestHeader('X-CSRFToken', this.props.csrftoken)
   }
 
   delete() {
     const organizationMember = this.props.organization_member
-    $.ajax({
-      url: `/organization/${this.props.organizationId}/user/${organizationMember.user}/`,
-      type: 'DELETE',
-      beforeSend: this.setXHR
-    })
+    smmDelete(`/organization/${this.props.organizationId}/user/${organizationMember.user}/`)
   }
 
   updateSelectedRole(event: React.ChangeEvent<HTMLSelectElement>) {

--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -128,7 +128,7 @@ class OrganizationAdd extends React.Component<OrganizationAddProps, Organization
   }
 
   createOrganization() {
-    smmPost('/organization/', { name: this.state.organizationName, csrfmiddlewaretoken: this.props.csrftoken }, this.createOrgCallback)
+    smmPost('/organization/', { name: this.state.organizationName }, this.createOrgCallback)
   }
 
   render() {

--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import $ from 'jquery'
-import { smmGetJSON } from '../ajax'
+import { smmGetJSON, smmPost } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { OrganizationData } from './types'
 
@@ -128,7 +128,7 @@ class OrganizationAdd extends React.Component<OrganizationAddProps, Organization
   }
 
   createOrganization() {
-    $.post('/organization/', { name: this.state.organizationName, csrfmiddlewaretoken: this.props.csrftoken }, this.createOrgCallback)
+    smmPost('/organization/', { name: this.state.organizationName, csrfmiddlewaretoken: this.props.csrftoken }, this.createOrgCallback)
   }
 
   render() {

--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -5,7 +5,6 @@ import { Table, Button, ButtonGroup } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
 import { smmGetJSON, smmPost } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { OrganizationData } from './types'
@@ -96,16 +95,12 @@ class OrganizationList extends React.Component<OrganizationListProps, never> {
   }
 }
 
-interface OrganizationAddProps {
-  csrftoken: string
-}
-
 interface OrganizationAddState {
   organizationName: string
 }
 
-class OrganizationAdd extends React.Component<OrganizationAddProps, OrganizationAddState> {
-  constructor(props: OrganizationAddProps) {
+class OrganizationAdd extends React.Component<never, OrganizationAddState> {
+  constructor(props: never) {
     super(props)
 
     this.state = {
@@ -155,17 +150,13 @@ class OrganizationAdd extends React.Component<OrganizationAddProps, Organization
   }
 }
 
-interface OrganizationListPageProps {
-  csrftoken: string
-}
-
 interface OrganizationListPageState {
   knownOrganizations: OrganizationData[]
 }
 
-class OrganizationListPage extends React.Component<OrganizationListPageProps, OrganizationListPageState> {
+class OrganizationListPage extends React.Component<never, OrganizationListPageState> {
   timer?: number
-  constructor(props: OrganizationListPageProps) {
+  constructor(props: never) {
     super(props)
 
     this.state = {
@@ -201,7 +192,7 @@ class OrganizationListPage extends React.Component<OrganizationListPageProps, Or
     return (
       <div>
         <OrganizationList organizations={this.state.knownOrganizations} showButtons={true} />
-        <OrganizationAdd csrftoken={this.props.csrftoken} />
+        <OrganizationAdd />
       </div>
     )
   }
@@ -210,12 +201,10 @@ class OrganizationListPage extends React.Component<OrganizationListPageProps, Or
 function createOrganizationList(elementId: string) {
   const div = ReactDOM.createRoot(document.getElementById(elementId)!)
 
-  const csrftoken = $('[name=csrfmiddlewaretoken]').val()
-
   div.render(
     <>
       <SMMTopBar />
-      <OrganizationListPage csrftoken={csrftoken as string} />
+      <OrganizationListPage />
     </>
   )
 }

--- a/frontend/organization/radio-operator.tsx
+++ b/frontend/organization/radio-operator.tsx
@@ -5,7 +5,6 @@ import { Table } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import $ from 'jquery'
 import { smmGetJSON } from '../ajax'
 
 import { AssetCommandView, AssetMissionDetails, AssetUI } from '../asset/ui'
@@ -17,7 +16,7 @@ class RadioOperatorAsset extends AssetUI {
   render() {
     let missionStatus
     if (this.state.details && this.state.details.mission_id) {
-      missionStatus = <MissionAssetStatus mission={this.state.details.mission_id} asset={this.props.asset} csrftoken={this.props.csrftoken} />
+      missionStatus = <MissionAssetStatus mission={this.state.details.mission_id} asset={this.props.asset} />
     }
     return (
       <>
@@ -34,7 +33,7 @@ class RadioOperatorAsset extends AssetUI {
               <AssetMissionDetails details={this.state.details} />
             </td>
             <td>
-              <AssetCommandView asset={this.props.asset} lastCommand={this.state.lastCommand} csrftoken={this.props.csrftoken} />
+              <AssetCommandView asset={this.props.asset} lastCommand={this.state.lastCommand} />
               {missionStatus}
             </td>
           </tr>
@@ -46,7 +45,6 @@ class RadioOperatorAsset extends AssetUI {
 
 interface OrganizationRadioOperatorPageProps {
   organizationId: number
-  csrftoken: string
 }
 
 interface OrganizationRadioOperatorPageState {
@@ -87,7 +85,7 @@ class OrganizationRadioOperatorPage extends React.Component<OrganizationRadioOpe
   }
 
   render() {
-    const assets = this.state.organizationAssets.map((asset) => <RadioOperatorAsset key={asset.id} asset={asset.asset.id} csrftoken={this.props.csrftoken} />)
+    const assets = this.state.organizationAssets.map((asset) => <RadioOperatorAsset key={asset.id} asset={asset.asset.id} />)
     return <Table responsive>{assets}</Table>
   }
 }
@@ -95,12 +93,10 @@ class OrganizationRadioOperatorPage extends React.Component<OrganizationRadioOpe
 function createRadioOperator(elementId: string, organizationId: number) {
   const div = ReactDOM.createRoot(document.getElementById(elementId)!)
 
-  const csrftoken = $('[name=csrfmiddlewaretoken]').val()
-
   div.render(
     <>
       <SMMOrganizationTopBar organizationId={organizationId} showRadioOperator={true} />
-      <OrganizationRadioOperatorPage organizationId={organizationId} csrftoken={csrftoken as string} />
+      <OrganizationRadioOperatorPage organizationId={organizationId} />
     </>
   )
 }

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -6,7 +6,7 @@ import $ from 'jquery'
 import { SMMRealtime } from '../smmmap'
 import { MissionAssetData } from '../asset/types'
 import { SMMSearchObjectDetailsData } from './types'
-import { smmGetJSON, smmPost } from '../ajax'
+import { smmGetJSON, smmPost, smmDelete } from '../ajax'
 
 class SMMSearch {
   parent: SMMSearches
@@ -25,14 +25,7 @@ class SMMSearch {
   }
 
   deleteCallback() {
-    const { csrftoken } = this.parent
-    $.ajax({
-      url: `/search/${this.search.pk}/`,
-      method: 'DELETE',
-      beforeSend: function (xhr) {
-        xhr.setRequestHeader('X-CSRFToken', csrftoken)
-      }
-    })
+    smmDelete(`/search/${this.search.pk}/`)
   }
 
   createDetailsButton() {

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -6,7 +6,7 @@ import $ from 'jquery'
 import { SMMRealtime } from '../smmmap'
 import { MissionAssetData } from '../asset/types'
 import { SMMSearchObjectDetailsData } from './types'
-import { smmGetJSON } from '../ajax'
+import { smmGetJSON, smmPost } from '../ajax'
 
 class SMMSearch {
   parent: SMMSearches
@@ -89,7 +89,7 @@ class SMMSearch {
         value: $(`#queue_${this.search.pk}_select_asset`).val() as string
       })
     }
-    $.post(`/search/${this.search.pk}/queue/`, data, this.searchQueueDestroy)
+    smmPost(`/search/${this.search.pk}/queue/`, data, this.searchQueueDestroy)
   }
 
   searchQueueUpdateSelectType() {

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -77,12 +77,7 @@ class SMMSearch {
   }
 
   searchQueueSubmit() {
-    const data = [
-      {
-        name: 'csrfmiddlewaretoken',
-        value: this.parent.csrftoken
-      }
-    ]
+    const data = []
     if ($(`#queue_${this.search.pk}_select_type`).val() === 'asset') {
       data.push({
         name: 'asset',

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -167,8 +167,8 @@ class SMMSearch {
 
 abstract class SMMSearches extends SMMRealtime {
   searchObjects: { [key: number]: SMMSearch }
-  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string) {
-    super(map, csrftoken, missionId, interval, color)
+  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+    super(map, missionId, interval, color)
 
     this.searchObjects = {}
     this.createPopup = this.createPopup.bind(this)

--- a/frontend/smmmap.tsx
+++ b/frontend/smmmap.tsx
@@ -10,14 +10,12 @@ interface SMMRealtimeButtons {
 
 abstract class SMMRealtime {
   map: L.Map
-  csrftoken: string
   missionId: number | string
   interval: number
   color: string
 
-  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string) {
+  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
     this.map = map
-    this.csrftoken = csrftoken
     this.missionId = missionId
     this.interval = interval
     this.color = color

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -113,8 +113,8 @@ class SMMUserPosition {
 class SMMUserPositions extends SMMRealtime {
   userObjects: { [key: string]: SMMUserPosition }
   overlayAdd: (name: string, overlay: L.Layer) => void
-  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string, overlayAdd: (name: string, overlay: L.Layer) => void) {
-    super(map, csrftoken, missionId, interval, color)
+  constructor(map: L.Map, missionId: number | string, interval: number, color: string, overlayAdd: (name: string, overlay: L.Layer) => void) {
+    super(map, missionId, interval, color)
     this.overlayAdd = overlayAdd
     this.userObjects = {}
     this.createPopup = this.createPopup.bind(this)

--- a/frontend/usergeo/line.tsx
+++ b/frontend/usergeo/line.tsx
@@ -1,9 +1,8 @@
 import L from 'leaflet'
 
-import $ from 'jquery'
-
 import { SMMRealtime } from '../smmmap'
 import { SMMUserGeoLabelData, SMMUserGeoLineGeoJSON } from './types'
+import { smmDelete } from '../ajax'
 
 class SMMLine {
   parent: SMMLines
@@ -13,7 +12,6 @@ class SMMLine {
     this.parent = parent
     this.coords = line.geometry.coordinates
     this.data = line.properties
-    this.setXHR = this.setXHR.bind(this)
     this.editCallback = this.editCallback.bind(this)
     this.deleteCallback = this.deleteCallback.bind(this)
     this.createSearchCallback = this.createSearchCallback.bind(this)
@@ -30,16 +28,8 @@ class SMMLine {
     )
   }
 
-  setXHR(xhr: XMLHttpRequest) {
-    xhr.setRequestHeader('X-CSRFToken', this.parent.csrftoken)
-  }
-
   deleteCallback() {
-    $.ajax({
-      url: `/data/usergeo/${this.data.pk}/`,
-      type: 'DELETE',
-      beforeSend: this.setXHR
-    })
+    smmDelete(`/data/usergeo/${this.data.pk}/`)
   }
 
   createSearchCallback() {

--- a/frontend/usergeo/line.tsx
+++ b/frontend/usergeo/line.tsx
@@ -21,7 +21,6 @@ class SMMLine {
     L.LineAdder(
       this.parent.map,
       this.parent.missionId,
-      this.parent.csrftoken,
       this.coords.map((x) => L.latLng(x[1], x[0])),
       this.data.pk,
       this.data.label
@@ -33,7 +32,7 @@ class SMMLine {
   }
 
   createSearchCallback() {
-    L.SearchAdder(this.parent.map, this.parent.csrftoken, 'line', this.data.pk)
+    L.SearchAdder(this.parent.map, 'line', this.data.pk)
   }
 
   createPopup(layer: L.Layer) {
@@ -83,8 +82,8 @@ class SMMLine {
 
 class SMMLines extends SMMRealtime {
   lineObjects: { [key: number]: SMMLine }
-  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: hex) {
-    super(map, csrftoken, missionId, interval, color)
+  constructor(map: L.Map, missionId: number | string, interval: number, color: hex) {
+    super(map, missionId, interval, color)
     this.lineObjects = {}
     this.createPopup = this.createPopup.bind(this)
   }

--- a/frontend/usergeo/poi.tsx
+++ b/frontend/usergeo/poi.tsx
@@ -1,9 +1,9 @@
 import L from 'leaflet'
 import '@canterbury-air-patrol/leaflet-dialog'
 
-import $ from 'jquery'
-
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
+
+import { smmDelete } from '../ajax'
 
 import { SMMRealtime } from '../smmmap'
 
@@ -19,7 +19,6 @@ class SMMPOI {
     this.coords = poi.geometry.coordinates
     this.data = poi.properties
     this.editCallback = this.editCallback.bind(this)
-    this.setXHR = this.setXHR.bind(this)
     this.deleteCallback = this.deleteCallback.bind(this)
     this.createSearchCallback = this.createSearchCallback.bind(this)
     this.calculateTDVCallback = this.calculateTDVCallback.bind(this)
@@ -29,16 +28,8 @@ class SMMPOI {
     L.POIAdder(this.parent.map, this.parent.missionId, this.parent.csrftoken, L.latLng(this.coords[1], this.coords[0]), this.data.pk, this.data.label)
   }
 
-  setXHR(xhr: XMLHttpRequest) {
-    xhr.setRequestHeader('X-CSRFToken', this.parent.csrftoken)
-  }
-
   deleteCallback() {
-    $.ajax({
-      url: `/data/usergeo/${this.data.pk}/`,
-      type: 'DELETE',
-      beforeSend: this.setXHR
-    })
+    smmDelete(`/data/usergeo/${this.data.pk}/`)
   }
 
   createSearchCallback() {

--- a/frontend/usergeo/poi.tsx
+++ b/frontend/usergeo/poi.tsx
@@ -25,7 +25,7 @@ class SMMPOI {
   }
 
   editCallback() {
-    L.POIAdder(this.parent.map, this.parent.missionId, this.parent.csrftoken, L.latLng(this.coords[1], this.coords[0]), this.data.pk, this.data.label)
+    L.POIAdder(this.parent.map, this.parent.missionId, L.latLng(this.coords[1], this.coords[0]), this.data.pk, this.data.label)
   }
 
   deleteCallback() {
@@ -33,11 +33,11 @@ class SMMPOI {
   }
 
   createSearchCallback() {
-    L.SearchAdder(this.parent.map, this.parent.csrftoken, 'point', this.data.pk)
+    L.SearchAdder(this.parent.map, 'point', this.data.pk)
   }
 
   calculateTDVCallback() {
-    MarineVectorsLeaflet(this.parent.map, this.parent.missionId, this.parent.csrftoken, this.data.label, L.latLng(this.coords[1], this.coords[0]), this.data.pk)
+    MarineVectorsLeaflet(this.parent.map, this.parent.missionId, this.data.label, L.latLng(this.coords[1], this.coords[0]), this.data.pk)
   }
 
   createPopup(layer: L.Layer) {
@@ -103,8 +103,8 @@ class SMMPOI {
 
 class SMMPOIs extends SMMRealtime {
   poiObjects: { [key: string]: SMMPOI }
-  constructor(map: L.Map, csrftoken: string, missionId: string | number, interval: number, color: string) {
-    super(map, csrftoken, missionId, interval, color)
+  constructor(map: L.Map, missionId: string | number, interval: number, color: string) {
+    super(map, missionId, interval, color)
     this.poiObjects = {}
     this.createPopup = this.createPopup.bind(this)
   }

--- a/frontend/usergeo/polygon.tsx
+++ b/frontend/usergeo/polygon.tsx
@@ -22,7 +22,6 @@ class SMMPolygon {
     L.PolygonAdder(
       this.parent.map,
       this.parent.missionId,
-      this.parent.csrftoken,
       this.coords[0].map((x) => L.latLng(x[1], x[0])),
       this.data.pk,
       this.data.label
@@ -34,7 +33,7 @@ class SMMPolygon {
   }
 
   createSearchCallback() {
-    L.SearchAdder(this.parent.map, this.parent.csrftoken, 'polygon', this.data.pk)
+    L.SearchAdder(this.parent.map, 'polygon', this.data.pk)
   }
 
   createPopup(layer: L.Layer) {
@@ -84,8 +83,8 @@ class SMMPolygon {
 
 class SMMPolygons extends SMMRealtime {
   polygonObjects: { [key: number]: SMMPolygon }
-  constructor(map: L.Map, csrftoken: string, missionId: number | string, interval: number, color: string) {
-    super(map, csrftoken, missionId, interval, color)
+  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+    super(map, missionId, interval, color)
     this.polygonObjects = {}
     this.createPopup = this.createPopup.bind(this)
   }

--- a/frontend/usergeo/polygon.tsx
+++ b/frontend/usergeo/polygon.tsx
@@ -1,6 +1,6 @@
 import L from 'leaflet'
 
-import $ from 'jquery'
+import { smmDelete } from '../ajax'
 
 import { SMMRealtime } from '../smmmap'
 import { SMMUserGeoLabelData, SMMUserGeoPolygonGeoJSON } from './types'
@@ -14,7 +14,6 @@ class SMMPolygon {
     this.data = polygon.properties
     this.coords = polygon.geometry.coordinates
     this.editCallback = this.editCallback.bind(this)
-    this.setXHR = this.setXHR.bind(this)
     this.deleteCallback = this.deleteCallback.bind(this)
     this.createSearchCallback = this.createSearchCallback.bind(this)
   }
@@ -30,16 +29,8 @@ class SMMPolygon {
     )
   }
 
-  setXHR(xhr: XMLHttpRequest) {
-    xhr.setRequestHeader('X-CSRFToken', this.parent.csrftoken)
-  }
-
   deleteCallback() {
-    $.ajax({
-      url: `/data/usergeo/${this.data.pk}/`,
-      type: 'DELETE',
-      beforeSend: this.setXHR
-    })
+    smmDelete(`/data/usergeo/${this.data.pk}/`)
   }
 
   createSearchCallback() {


### PR DESCRIPTION
## Description

Replace all jquery and fetch calls with a common helper

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Unify frontend AJAX interactions under shared helpers and remove explicit CSRF token plumbing from React and Leaflet components.

Enhancements:
- Replace direct jQuery and fetch POST/DELETE calls with centralized smmPost, smmPostBody, and smmDelete helpers that inject CSRF headers.
- Stop threading csrftoken props through React components and Leaflet controls by reading the token from cookies in the shared AJAX layer.
- Simplify SMMRealtime-derived classes and map-related utilities by removing CSRFTOKEN dependencies while preserving existing mission functionality.