### PR TITLE
Replace jQuery $.ajax with native fetch in ajax.ts

### DIFF
--- a/frontend/Admin/admin.js
+++ b/frontend/Admin/admin.js
@@ -38,15 +38,15 @@ L.SMMAdmin.AssetCommand = function (map, missionId) {
     assetCommandDialog.destroy()
   })
   $('#command_create').on('click', function () {
-    const data = [
-      { name: 'asset', value: $('#id_asset').val() },
-      { name: 'reason', value: $('#id_reason').val() },
-      { name: 'command', value: $('#id_command').val() }
-    ]
+    const data = {
+      asset: $('#id_asset').val(),
+      reason: $('#id_reason').val(),
+      command: $('#id_command').val()
+    }
     if (gotoPoint != null) {
       const coords = gotoPoint.getLatLng()
-      data.push({ name: 'latitude', value: coords.lat })
-      data.push({ name: 'longitude', value: coords.lng })
+      data.latitude = coords.lat
+      data.longitude = coords.lng
     }
     smmPost(`/mission/${missionId}/assets/command/set/`, data, function (data) {
       if (data === 'Created') {

--- a/frontend/LineAdder/LineAdder.js
+++ b/frontend/LineAdder/LineAdder.js
@@ -70,14 +70,14 @@ L.LineAdder = function (map, missionId, currentPoints, replaces, label) {
   })
 
   $(`#lineadder-dialog-done-${RAND_NUM}`).on('click', function () {
-    const data = [
-      { name: 'label', value: $(`#lineadder-dialog-name-${RAND_NUM}`).val() },
-      { name: 'points', value: markers.length }
-    ]
+    const data = {
+      label: $(`#lineadder-dialog-name-${RAND_NUM}`).val(),
+      points: markers.length
+    }
     for (const i in markers) {
       const markerLatLng = markers[i].getMarker().getLatLng()
-      data.push({ name: `point${i}_lat`, value: markerLatLng.lat })
-      data.push({ name: `point${i}_lng`, value: markerLatLng.lng })
+      data[`point${i}_lat`] = markerLatLng.lat
+      data[`point${i}_lng`] = markerLatLng.lng
     }
 
     if (replaces !== -1) {

--- a/frontend/PolygonAdder/PolygonAdder.js
+++ b/frontend/PolygonAdder/PolygonAdder.js
@@ -69,14 +69,14 @@ L.PolygonAdder = function (map, missionId, currentPoints, replaces, label) {
   })
 
   $(`#polygonadder-dialog-done-${RAND_NUM}`).on('click', function () {
-    const data = [
-      { name: 'label', value: $(`#polygonadder-dialog-name-${RAND_NUM}`).val() },
-      { name: 'points', value: markers.length }
-    ]
+    const data = {
+      label: $(`#polygonadder-dialog-name-${RAND_NUM}`).val(),
+      points: markers.length
+    }
     for (const i in markers) {
       const markerLatLng = markers[i].getMarker().getLatLng()
-      data.push({ name: `point${i}_lat`, value: markerLatLng.lat })
-      data.push({ name: `point${i}_lng`, value: markerLatLng.lng })
+      data[`point${i}_lat`] = markerLatLng.lat
+      data[`point${i}_lng`] = markerLatLng.lng
     }
 
     if (replaces !== -1) {

--- a/frontend/SearchAdder/SearchAdder.js
+++ b/frontend/SearchAdder/SearchAdder.js
@@ -2,7 +2,7 @@ import $ from 'jquery'
 
 import L from 'leaflet'
 
-import { smmGet, smmGetJSON, smmPost } from '../ajax'
+import { smmGetJSON, smmPost } from '../ajax'
 
 L.SearchAdder = function (map, objectType, objectID) {
   const RAND_NUM = Math.floor(Math.random() * 16536)
@@ -108,22 +108,22 @@ L.SearchAdder = function (map, objectType, objectID) {
   }
 
   const getData = function () {
-    const data = [
-      { name: 'sweep_width', value: $(`#SearchAdder-sweep-width-${RAND_NUM}`).val() },
-      { name: 'asset_type_id', value: $(`#SearchAdder-asset-type-${RAND_NUM}`).val() },
-      { name: 'iterations', value: $(`#SearchAdder-iterations-${RAND_NUM}`).val() },
-      { name: 'first_bearing', value: $(`#SearchAdder-first-bearing-${RAND_NUM}`).val() },
-      { name: 'width', value: $(`#SearchAdder-width-${RAND_NUM}`).val() }
-    ]
+    const data = {
+      sweep_width: $(`#SearchAdder-sweep-width-${RAND_NUM}`).val(),
+      asset_type_id: $(`#SearchAdder-asset-type-${RAND_NUM}`).val(),
+      iterations: $(`#SearchAdder-iterations-${RAND_NUM}`).val(),
+      first_bearing: $(`#SearchAdder-first-bearing-${RAND_NUM}`).val(),
+      width: $(`#SearchAdder-width-${RAND_NUM}`).val()
+    }
     switch (objectType) {
       case 'point':
-        data.push({ name: 'poi_id', value: objectID })
+        data.poi_id = objectID
         break
       case 'line':
-        data.push({ name: 'line_id', value: objectID })
+        data.line_id = objectID
         break
       case 'polygon':
-        data.push({ name: 'poly_id', value: objectID })
+        data.poly_id = objectID
         break
     }
     return data
@@ -132,7 +132,7 @@ L.SearchAdder = function (map, objectType, objectID) {
   let onMap = null
 
   $(`#SearchAdder-preview-${RAND_NUM}`).on('click', function () {
-    smmGet(getUrl(), getData(), function (data) {
+    smmGetJSON(getUrl(), getData(), function (data) {
       if (onMap !== null) {
         onMap.remove()
       }

--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -1,73 +1,102 @@
-import $ from 'jquery'
-
 import { cookieJar } from './cookies'
 
 const AJAX_TIMEOUT = 2500
 
-function smmGet(url: string, data?: object, success?: (data: unknown) => void, error?: () => void) {
-  return $.ajax({
-    url,
-    data,
-    timeout: AJAX_TIMEOUT,
-    success: success,
-    error: error
-  })
+type RequestDataValue = string | number | boolean | null | undefined
+type RequestData = Record<string, RequestDataValue>
+
+function fetchWithTimeout(url: string, options: RequestInit = {}) {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), AJAX_TIMEOUT)
+  return fetch(url, { ...options, signal: controller.signal }).finally(() => clearTimeout(timeoutId))
 }
 
-function smmGetJSON(url: string, data?: object, success?: (data: unknown) => void, error?: () => void) {
-  return $.ajax({
-    url,
-    data,
-    dataType: 'json',
-    timeout: AJAX_TIMEOUT,
-    success: success,
-    error: error
-  })
+function buildSearchParams(data?: RequestData): URLSearchParams {
+  const params = new URLSearchParams()
+  if (!data) return params
+  for (const [key, value] of Object.entries(data)) {
+    if (value == null) continue
+    params.append(key, String(value))
+  }
+  return params
 }
 
-function smmPost(url: string, data: object, success?: (data: unknown) => void, error?: () => void) {
-  return $.ajax({
+function appendQueryString(url: string, data?: RequestData): string {
+  const params = buildSearchParams(data)
+  const qs = params.toString()
+  if (!qs) return url
+  return `${url}${url.includes('?') ? '&' : '?'}${qs}`
+}
+
+function request<T>(url: string, options: RequestInit, parse: (r: Response) => Promise<T>, success?: (data: T) => void, error?: () => void): Promise<T> {
+  return fetchWithTimeout(url, options)
+    .then((r) => {
+      if (!r.ok) throw r
+      return parse(r)
+    })
+    .then((data) => {
+      success?.(data)
+      return data
+    })
+    .catch((err) => {
+      error?.()
+      throw err
+    })
+}
+
+function smmGet(url: string, data?: RequestData, success?: (data: unknown) => void, error?: () => void) {
+  return request(appendQueryString(url, data), {}, (r) => r.text(), success, error)
+}
+
+function smmGetJSON(url: string, data?: RequestData, success?: (data: unknown) => void, error?: () => void) {
+  return request(appendQueryString(url, data), {}, (r) => r.json(), success, error)
+}
+
+function smmPost(url: string, data: RequestData, success?: (data: unknown) => void, error?: () => void) {
+  return request(
     url,
-    type: 'POST',
-    headers: {
-      'X-CSRFToken': cookieJar.get('csrftoken') ?? ''
+    {
+      method: 'POST',
+      headers: {
+        'X-CSRFToken': cookieJar.get('csrftoken') ?? ''
+      },
+      body: buildSearchParams(data)
     },
-    data: data,
-    timeout: AJAX_TIMEOUT,
-    success: success,
-    error: error
-  })
+    (r) => r.text(),
+    success,
+    error
+  )
 }
 
 function smmPostBody(url: string, body: FormData | URLSearchParams, success?: (data: unknown) => void, error?: () => void) {
-  return fetch(url, {
-    method: 'POST',
-    headers: {
-      'X-CSRFToken': cookieJar.get('csrftoken') ?? ''
+  return request(
+    url,
+    {
+      method: 'POST',
+      headers: {
+        'X-CSRFToken': cookieJar.get('csrftoken') ?? ''
+      },
+      body
     },
-    body: body,
-    timeout: AJAX_TIMEOUT
-  })
-    .then((response) => {
-      if (!response.ok) throw response
-      if (success) success(response.text())
-    })
-    .catch(() => {
-      if (error) error()
-    })
+    (r) => r.text(),
+    success,
+    error
+  )
 }
 
-function smmDelete(url: string, success?: (data: never) => void, error?: () => void) {
-  $.ajax({
-    url: url,
-    type: 'DELETE',
-    headers: {
-      'X-CSRFToken': cookieJar.get('csrftoken') ?? ''
+function smmDelete(url: string, success?: (data: void) => void, error?: () => void) {
+  return request<void>(
+    url,
+    {
+      method: 'DELETE',
+      headers: {
+        'X-CSRFToken': cookieJar.get('csrftoken') ?? ''
+      }
     },
-    timeout: AJAX_TIMEOUT,
-    success: success,
-    error: error
-  })
+    async () => {},
+    success,
+    error
+  )
 }
 
 export { smmGet, smmGetJSON, smmPost, smmPostBody, smmDelete }

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -435,7 +435,7 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
   }
 
   async updateStatusValues() {
-    await smmGet('/assets/status/values/', {}, this.updateStatusValuesResponse)
+    await smmGetJSON('/assets/status/values/', {}, this.updateStatusValuesResponse)
   }
 
   updateSelectedStateValue(event: React.ChangeEvent<HTMLSelectElement>) {

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -35,7 +35,7 @@ import { SMMMarineVector } from './marine/vectors.js'
 import { SMMAssets } from './asset/map.js'
 import { SMMMissionTopBar } from './menu/topbar.js'
 import { SMMUserPositions } from './user/map.js'
-import { smmGet } from './ajax'
+import { smmGetJSON } from './ajax'
 
 class SMMMap {
   map: L.Map
@@ -123,7 +123,7 @@ class SMMMap {
     L.Icon.Default.prototype.options.iconRetinaUrl = markerIcon2x
     L.Icon.Default.prototype.options.shadowUrl = markerIconShadow
 
-    smmGet('/map/tile/layers/', {}, this.mapLayersCallback)
+    smmGetJSON('/map/tile/layers/', {}, this.mapLayersCallback)
 
     this.layerControl.addTo(this.map)
     this.layerControlMaps.addTo(this.map)

--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -4,7 +4,7 @@ import L from 'leaflet'
 
 import { MarineVectors, MarineVectorsDisplay } from '@canterbury-air-patrol/marine-total-drift-vector'
 import { Button, ButtonGroup } from 'react-bootstrap'
-import { smmGet, smmPostBody } from '../ajax'
+import { smmGetJSON, smmPostBody } from '../ajax'
 
 interface CustomMarineVectorsProps {
   map: L.Map
@@ -86,7 +86,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
       this.props.map.removeLayer(this.onMap)
       this.onMap = undefined
     }
-    smmGet(
+    smmGetJSON(
       `/mission/${this.props.missionId}/sar/marine/vectors/create/`,
       this.getData(),
       (data) => {

--- a/frontend/mission/list.tsx
+++ b/frontend/mission/list.tsx
@@ -5,7 +5,7 @@ import { Table, Button, ButtonGroup } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import { smmGet } from '../ajax'
+import { smmGetJSON } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { MissionData } from './types'
 
@@ -160,7 +160,7 @@ class MissionListPage extends React.Component<object, MissionListPageState> {
   }
 
   async updateData() {
-    await smmGet('/mission/list/', {}, this.updateDataResponse)
+    await smmGetJSON('/mission/list/', {}, this.updateDataResponse)
   }
 
   updateMissions(missions: MissionData[]) {

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -70,12 +70,9 @@ class SMMSearch {
   }
 
   searchQueueSubmit() {
-    const data = []
+    const data: { asset?: string } = {}
     if ($(`#queue_${this.search.pk}_select_type`).val() === 'asset') {
-      data.push({
-        name: 'asset',
-        value: $(`#queue_${this.search.pk}_select_asset`).val() as string
-      })
+      data.asset = $(`#queue_${this.search.pk}_select_asset`).val() as string
     }
     smmPost(`/search/${this.search.pk}/queue/`, data, this.searchQueueDestroy)
   }


### PR DESCRIPTION
## Description

Rewrites smmGet, smmGetJSON, smmPost, and smmDelete to use fetch + AbortController instead of $.ajax, and updates affected callers:

- smmGet now resolves callbacks with response text; callers that expected parsed JSON (map layers, mission list, asset status values, search preview, marine vector preview) are switched to smmGetJSON.

## Summary by Sourcery

Replace legacy jQuery-based AJAX helpers with a shared fetch-based abstraction and update callers accordingly.

Enhancements:
- Introduce a fetch-based request helper with timeout and common error handling to replace $.ajax usage.
- Update smmGet, smmGetJSON, smmPost, smmPostBody, and smmDelete to use typed request data objects and consistent CSRF handling.
- Adjust frontend callers to pass plain objects instead of jQuery form arrays and to use smmGetJSON where JSON responses are expected.