### PR TITLE
Use uwsgi for docker

### DIFF
--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -20,5 +20,5 @@ else
     then
         ./manage.py createsuperuser --noinput
     fi
-    ./manage.py runserver 0.0.0.0:8080
+    uwsgi --http 0.0.0.0:8080 --module smm.wsgi --master --processes 4
 fi

--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -19,5 +19,5 @@ else
     then
         ./manage.py createsuperuser --noinput
     fi
-    uwsgi --http 0.0.0.0:8080 --module smm.wsgi --master --processes 4
+    uwsgi --http 0.0.0.0:8080 --module smm.wsgi --master --processes 4 --die-on-term --lazy-apps
 fi

--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -9,7 +9,6 @@ source /code/venv/bin/activate
 ./manage.py makemigrations
 ./manage.py migrate
 
-sed -i 's/DEBUG =.*/DEBUG = True/' smm/local_settings.py
 sed -i 's/HOSTNAME/${HOSTNAME}/' smm/local_settings.py
 
 if [ "$1" == "test" ]

--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -9,7 +9,6 @@ source /code/venv/bin/activate
 ./manage.py makemigrations
 ./manage.py migrate
 
-sed -i 's/HOSTNAME/${HOSTNAME}/' smm/local_settings.py
 
 if [ "$1" == "test" ]
 then

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,9 @@ haversine
 # uwsgi
 uwsgi
 
+# static file serving
+whitenoise
+
 # image support
 image
 

--- a/smm/local_settings.py.template
+++ b/smm/local_settings.py.template
@@ -2,11 +2,13 @@
 # Make changes as required and make sure to save
 # it as local_settings.py
 
+import os
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
 ALLOWED_HOSTS = ['*']
-CSRF_TRUSTED_ORIGINS = ['http://localhost:8080']
+CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS', 'http://localhost:8080').split(',')
 
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'

--- a/smm/settings.py
+++ b/smm/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/smm/settings.py
+++ b/smm/settings.py
@@ -110,6 +110,15 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 
+STORAGES = {
+    'default': {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    },
+    'staticfiles': {
+        'BACKEND': 'whitenoise.storage.CompressedManifestStaticFilesStorage',
+    },
+}
+
 LOGIN_REDIRECT_URL = '/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
## Summary by Sourcery

Serve the Django app with uWSGI in the Docker environment and enable static file handling.

New Features:
- Introduce uWSGI-based HTTP serving for the Django application in the Docker container.
- Add WhiteNoise middleware to handle static file serving.

Enhancements:
- Stop forcing DEBUG to True in local settings during container startup.