### PR TITLE
Require login for tile_layer_list

### DIFF
--- a/map/views.py
+++ b/map/views.py
@@ -37,6 +37,7 @@ def map_main_current(request):
     return render(request, 'map_main.html', {'mission': 'current'})
 
 
+@login_required
 def tile_layer_list(request):
     """
     List the tile layers that are currently active


### PR DESCRIPTION
## Description

The endpoint was publicly accessible, potentially exposing internal or licensed tile server URLs to unauthenticated users.

## Summary by Sourcery

Bug Fixes:
- Protect the tile_layer_list view with login enforcement to avoid exposing internal or licensed tile server URLs to unauthenticated users.