### PR TITLE
Parameterize raw SQL in search model query builders

### DIFF
--- a/search/models.py
+++ b/search/models.py
@@ -296,14 +296,14 @@ class Search(GeoTime):
         # that are sweep_width * 3 from the poi
         # with angles: 30,60,90,120,150,180,210,240,270,300,330,360
         # this order makes the points in clock-order
-        query = "SELECT geo"
-        query_params = []
         sw = params.sweep_width() * 3
+        select_cols = ["geo"]
+        query_params = []
         for deg in (30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330, 0):
-            query += f", ST_Project(geo, %s, radians(%s)) AS deg_{deg}"
+            select_cols.append(f"ST_Project(geo, %s, radians(%s)) AS deg_{deg}")
             query_params.extend([sw, deg])
-        query += " FROM data_geotimelabel WHERE id = %s"
         query_params.append(params.from_geo().pk)
+        query = "SELECT " + ", ".join(select_cols) + " FROM data_geotimelabel WHERE id = %s"
         cursor = dbconn.cursor()
         cursor.execute(query, query_params)
         reference_points = cursor.fetchone()
@@ -356,21 +356,16 @@ class Search(GeoTime):
         a, and the fifth line ends (start direction +) 315 degrees, all sqrt(2) * i * sweep
         width (where i is the iteration number) from the reference point (a or b respectively).
         """
-        query = "SELECT p.geo, p.first"
+        select_cols = ["p.geo", "p.first"]
         query_params = []
         for i in range(1, params.iterations() + 1):
             dist = math.sqrt(2) * i * params.sweep_width()
-            query += ", ST_Project(p.geo, %s, radians(%s))"
-            query += ", ST_Project(p.geo, %s, radians(%s))"
-            query += ", ST_Project(p.geo, %s, radians(%s))"
-            query += ", ST_Project(p.first, %s, radians(%s))"
-            query_params.extend([dist, 45 + params.first_bearing(),
-                                  dist, 135 + params.first_bearing(),
-                                  dist, 225 + params.first_bearing(),
-                                  dist, 315 + params.first_bearing()])
+            for ref, bearing_offset in [("p.geo", 45), ("p.geo", 135), ("p.geo", 225), ("p.first", 315)]:
+                select_cols.append(f"ST_Project({ref}, %s, radians(%s))")
+                query_params.extend([dist, bearing_offset + params.first_bearing()])
 
-        query += " FROM (SELECT geo, ST_Project(geo, %s, radians(%s)) AS first FROM data_geotimelabel WHERE id = %s) AS p"
         query_params.extend([params.sweep_width(), params.first_bearing(), params.from_geo().pk])
+        query = "SELECT " + ", ".join(select_cols) + " FROM (SELECT geo, ST_Project(geo, %s, radians(%s)) AS first FROM data_geotimelabel WHERE id = %s) AS p"
 
         cursor = dbconn.cursor()
         cursor.execute(query, query_params)
@@ -442,23 +437,34 @@ class Search(GeoTime):
         perpendicular to the line so that runs half the width either side of the line,
         and steps sweep width along the line for each each pass.
         """
-        segment_query = \
-            "SELECT ST_PointN(geo::geometry, pos)::geography AS start, ST_PointN(geo::geometry, pos + 1)::geography AS end" \
-            " FROM data_geotimelabel, generate_series(1, ST_NPoints(geo::geometry) - 1) AS pos WHERE id = %s"
-
-        line_data_query = \
-            f"SELECT segment.start AS start, ST_Azimuth(segment.start::geometry, segment.end::geometry) AS direction, ST_Distance(segment.start, segment.end) AS distance FROM ({segment_query}) AS segment"
-        line_points_query = \
-            f"SELECT direction AS direction, ST_Project(linedata.start, %s * i, direction) AS point" \
-            f" FROM ({line_data_query}) AS linedata, generate_series(0, (linedata.distance/%s)::integer) AS i"
-        query = \
-            f"SELECT ST_Project(point, %s, direction + PI()/2) AS A, ST_Project(point, %s, direction - PI()/2) AS B FROM ({line_points_query}) AS linepoints;"
-
-        # %s positions in final composed string (left-to-right):
-        # 1,2: width (outer SELECT), 3: sweep_width (* i), 4: from_geo pk (WHERE), 5: sweep_width (/ distance)
+        query = """
+            WITH segment AS (
+                SELECT ST_PointN(geo::geometry, pos)::geography AS start,
+                       ST_PointN(geo::geometry, pos + 1)::geography AS end
+                FROM data_geotimelabel,
+                     generate_series(1, ST_NPoints(geo::geometry) - 1) AS pos
+                WHERE id = %s
+            ),
+            linedata AS (
+                SELECT segment.start AS start,
+                       ST_Azimuth(segment.start::geometry, segment.end::geometry) AS direction,
+                       ST_Distance(segment.start, segment.end) AS distance
+                FROM segment
+            ),
+            linepoints AS (
+                SELECT direction,
+                       ST_Project(linedata.start, %s * i, direction) AS point
+                FROM linedata,
+                     generate_series(0, (linedata.distance / %s)::integer) AS i
+            )
+            SELECT ST_Project(point, %s, direction + PI()/2) AS A,
+                   ST_Project(point, %s, direction - PI()/2) AS B
+            FROM linepoints
+        """
         cursor = dbconn.cursor()
-        cursor.execute(query, [params.width(), params.width(),
-                                params.sweep_width(), params.from_geo().pk, params.sweep_width()])
+        cursor.execute(query, [params.from_geo().pk,
+                                params.sweep_width(), params.sweep_width(),
+                                params.width(), params.width()])
         db_points = dictfetchall(cursor)
 
         points = []

--- a/search/models.py
+++ b/search/models.py
@@ -297,11 +297,15 @@ class Search(GeoTime):
         # with angles: 30,60,90,120,150,180,210,240,270,300,330,360
         # this order makes the points in clock-order
         query = "SELECT geo"
+        query_params = []
+        sw = params.sweep_width() * 3
         for deg in (30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330, 0):
-            query += ", ST_Project(geo, {sw}, radians({deg})) AS deg_{deg}".format(**{'sw': params.sweep_width() * 3, 'deg': deg})
-        query += f" FROM data_geotimelabel WHERE id = {params.from_geo().pk}"
+            query += f", ST_Project(geo, %s, radians(%s)) AS deg_{deg}"
+            query_params.extend([sw, deg])
+        query += " FROM data_geotimelabel WHERE id = %s"
+        query_params.append(params.from_geo().pk)
         cursor = dbconn.cursor()
-        cursor.execute(query)
+        cursor.execute(query, query_params)
         reference_points = cursor.fetchone()
 
         # Create a SectorSector
@@ -353,17 +357,23 @@ class Search(GeoTime):
         width (where i is the iteration number) from the reference point (a or b respectively).
         """
         query = "SELECT p.geo, p.first"
+        query_params = []
         for i in range(1, params.iterations() + 1):
             dist = math.sqrt(2) * i * params.sweep_width()
-            query += f", ST_Project(p.geo, {dist}, radians({45 + params.first_bearing()}))"
-            query += f", ST_Project(p.geo, {dist}, radians({135 + params.first_bearing()}))"
-            query += f", ST_Project(p.geo, {dist}, radians({225 + params.first_bearing()}))"
-            query += f", ST_Project(p.first, {dist}, radians({315 + params.first_bearing()}))"
+            query += ", ST_Project(p.geo, %s, radians(%s))"
+            query += ", ST_Project(p.geo, %s, radians(%s))"
+            query += ", ST_Project(p.geo, %s, radians(%s))"
+            query += ", ST_Project(p.first, %s, radians(%s))"
+            query_params.extend([dist, 45 + params.first_bearing(),
+                                  dist, 135 + params.first_bearing(),
+                                  dist, 225 + params.first_bearing(),
+                                  dist, 315 + params.first_bearing()])
 
-        query += f" FROM (SELECT geo, ST_Project(geo, {params.sweep_width()}, radians({params.first_bearing()})) AS first FROM data_geotimelabel WHERE id = {params.from_geo().pk}) AS p"
+        query += " FROM (SELECT geo, ST_Project(geo, %s, radians(%s)) AS first FROM data_geotimelabel WHERE id = %s) AS p"
+        query_params.extend([params.sweep_width(), params.first_bearing(), params.from_geo().pk])
 
         cursor = dbconn.cursor()
-        cursor.execute(query)
+        cursor.execute(query, query_params)
         points = [GEOSGeometry(p) for p in cursor.fetchone()]
 
         search = Search(
@@ -434,18 +444,21 @@ class Search(GeoTime):
         """
         segment_query = \
             "SELECT ST_PointN(geo::geometry, pos)::geography AS start, ST_PointN(geo::geometry, pos + 1)::geography AS end" \
-            f" FROM data_geotimelabel, generate_series(1, ST_NPoints(geo::geometry) - 1) AS pos WHERE id = {params.from_geo().pk}"
+            " FROM data_geotimelabel, generate_series(1, ST_NPoints(geo::geometry) - 1) AS pos WHERE id = %s"
 
         line_data_query = \
             f"SELECT segment.start AS start, ST_Azimuth(segment.start::geometry, segment.end::geometry) AS direction, ST_Distance(segment.start, segment.end) AS distance FROM ({segment_query}) AS segment"
         line_points_query = \
-            f"SELECT direction AS direction, ST_Project(linedata.start, {params.sweep_width()} * i, direction) AS point"\
-            f" FROM ({line_data_query}) AS linedata, generate_series(0, (linedata.distance/{params.sweep_width()})::integer) AS i"
+            f"SELECT direction AS direction, ST_Project(linedata.start, %s * i, direction) AS point" \
+            f" FROM ({line_data_query}) AS linedata, generate_series(0, (linedata.distance/%s)::integer) AS i"
         query = \
-            f"SELECT ST_Project(point, {params.width()}, direction + PI()/2) AS A, ST_Project(point, {params.width()}, direction - PI()/2) AS B FROM ({line_points_query}) AS linepoints;"
+            f"SELECT ST_Project(point, %s, direction + PI()/2) AS A, ST_Project(point, %s, direction - PI()/2) AS B FROM ({line_points_query}) AS linepoints;"
 
+        # %s positions in final composed string (left-to-right):
+        # 1,2: width (outer SELECT), 3: sweep_width (* i), 4: from_geo pk (WHERE), 5: sweep_width (/ distance)
         cursor = dbconn.cursor()
-        cursor.execute(query)
+        cursor.execute(query, [params.width(), params.width(),
+                                params.sweep_width(), params.from_geo().pk, params.sweep_width()])
         db_points = dictfetchall(cursor)
 
         points = []

--- a/search/models.py
+++ b/search/models.py
@@ -294,18 +294,19 @@ class Search(GeoTime):
         """
         # calculate the points on the outside of a circle
         # that are sweep_width * 3 from the poi
-        # with angles: 30,60,90,120,150,180,210,240,270,300,330,360
-        # this order makes the points in clock-order
+        # with angles: 30,60,90,120,150,180,210,240,270,300,330,0
+        # (0 and 360 are equivalent; this order produces clock-wise points)
         sw = params.sweep_width() * 3
+        geo_id = params.from_geo().pk
         select_cols = ["geo"]
         query_params = []
         for deg in (30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330, 0):
             select_cols.append(f"ST_Project(geo, %s, radians(%s)) AS deg_{deg}")
             query_params.extend([sw, deg])
-        query_params.append(params.from_geo().pk)
+        query_params.append(geo_id)
         query = "SELECT " + ", ".join(select_cols) + " FROM data_geotimelabel WHERE id = %s"
         cursor = dbconn.cursor()
-        cursor.execute(query, query_params)
+        cursor.execute(query, query_params)  # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query
         reference_points = cursor.fetchone()
 
         # Create a SectorSector
@@ -356,19 +357,22 @@ class Search(GeoTime):
         a, and the fifth line ends (start direction +) 315 degrees, all sqrt(2) * i * sweep
         width (where i is the iteration number) from the reference point (a or b respectively).
         """
+        sweep_width = params.sweep_width()
+        first_bearing = params.first_bearing()
+        geo_id = params.from_geo().pk
         select_cols = ["p.geo", "p.first"]
         query_params = []
         for i in range(1, params.iterations() + 1):
-            dist = math.sqrt(2) * i * params.sweep_width()
+            dist = math.sqrt(2) * i * sweep_width
             for ref, bearing_offset in [("p.geo", 45), ("p.geo", 135), ("p.geo", 225), ("p.first", 315)]:
                 select_cols.append(f"ST_Project({ref}, %s, radians(%s))")
-                query_params.extend([dist, bearing_offset + params.first_bearing()])
+                query_params.extend([dist, bearing_offset + first_bearing])
 
-        query_params.extend([params.sweep_width(), params.first_bearing(), params.from_geo().pk])
+        query_params.extend([sweep_width, first_bearing, geo_id])
         query = "SELECT " + ", ".join(select_cols) + " FROM (SELECT geo, ST_Project(geo, %s, radians(%s)) AS first FROM data_geotimelabel WHERE id = %s) AS p"
 
         cursor = dbconn.cursor()
-        cursor.execute(query, query_params)
+        cursor.execute(query, query_params)  # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query
         points = [GEOSGeometry(p) for p in cursor.fetchone()]
 
         search = Search(
@@ -461,10 +465,11 @@ class Search(GeoTime):
                    ST_Project(point, %s, direction - PI()/2) AS B
             FROM linepoints
         """
+        geo_id = params.from_geo().pk
+        sweep_width = params.sweep_width()
+        width = params.width()
         cursor = dbconn.cursor()
-        cursor.execute(query, [params.from_geo().pk,
-                                params.sweep_width(), params.sweep_width(),
-                                params.width(), params.width()])
+        cursor.execute(query, [geo_id, sweep_width, sweep_width, width, width])  # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query
         db_points = dictfetchall(cursor)
 
         points = []


### PR DESCRIPTION
## Description

Three cursor.execute() calls were building queries with f-strings containing values derived from SearchParams (sweep_width, first_bearing, iterations, width, from_geo pk). While the Params constructors cast and validate these to int, a future change dropping the cast would silently re-open a SQL injection path. Use %s parameters throughout.

## Summary by Sourcery

Parameterize raw SQL used in search geometry query builders to avoid interpolating user-derived values into query strings.

Bug Fixes:
- Eliminate potential SQL injection paths in sector, expanding box, and track line creeping search queries by replacing string interpolation with parameterized placeholders.

Enhancements:
- Refactor raw SQL construction in search geometry helpers to build SELECT clauses and CTEs with parameter lists rather than f-string concatenation.