### PR TITLE
Update to postgis:18-3.6

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,7 @@ jobs:
     
     services:
       postgres:
-        image: postgis/postgis:15-3.3
+        image: postgis/postgis:18-3.6-alpine
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: postgis/postgis:15-3.3
+    image: postgis/postgis:18-3.6-alpine
     environment:
       - POSTGRES_PASSWORD=password
     healthcheck:


### PR DESCRIPTION
## Summary by Sourcery

Update PostGIS Docker images to a newer PostgreSQL/PostGIS version across development and CI configurations.

Build:
- Bump PostGIS Docker image from 15-3.3 to 18-3.6-alpine in docker-compose configuration.

CI:
- Update test workflow PostgreSQL service image to postgis/postgis:18-3.6-alpine to align with the new database version.