### PR TITLE
Gate Docker publish on passing tests for develop pushes

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,6 +2,7 @@ name: Docker Image CI
 
 on:
   workflow_run:
+    # COUPLING: this must match the `name:` field in run_tests.yml exactly.
     workflows: ["Run Tests"]
     branches: ["develop"]
     types:
@@ -10,12 +11,16 @@ on:
 jobs:
 
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
       uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
 
     - name: Get node ready
       uses: actions/setup-node@v6
@@ -40,5 +45,5 @@ jobs:
         context: .
         push: true
         tags: |
-          ${{ secrets.DOCKER_REPO }}:${{ github.sha }}
+          ${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha }}
           ${{ secrets.DOCKER_REPO }}:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,13 +1,16 @@
 name: Docker Image CI
 
 on:
-  push:
-    branches: [ "develop" ]
+  workflow_run:
+    workflows: ["Run Tests"]
+    branches: ["develop"]
+    types:
+      - completed
 
 jobs:
 
   build:
-
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,6 +1,9 @@
 name: Run Tests
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches: [ "develop" ]
 
 jobs:
   test:


### PR DESCRIPTION
## Description

- run_tests.yml now triggers on direct pushes to develop as well as PRs
- docker-image.yml now triggers via workflow_run on the test workflow completing successfully, so a Docker image is never published to Hub when tests are failing

## Summary by Sourcery

Gate Docker image publishing on successful completion of the test workflow for pushes to the develop branch.

CI:
- Change Docker image workflow to run on completion of the test workflow for develop pushes, only publishing images when tests succeed.
- Update test workflow to run on both pull requests and direct pushes to the develop branch.