### PR TITLE
Replace ALLOWED_HOSTS wildcard with env var

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
       - DB_USER=postgres
       - DB_NAME=postgres
       - DB_PASS=password
+      - ALLOWED_HOSTS=localhost
+      - CSRF_TRUSTED_ORIGINS=http://localhost:8080
       - DJANGO_SUPERUSER_USERNAME=admin
       - DJANGO_SUPERUSER_PASSWORD=administrator
       - DJANGO_SUPERUSER_EMAIL=me@example.com

--- a/smm/local_settings.py.template
+++ b/smm/local_settings.py.template
@@ -7,7 +7,7 @@ import os
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost').split(',')
 CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS', 'http://localhost:8080').split(',')
 
 LANGUAGE_CODE = 'en-us'


### PR DESCRIPTION
## Description

ALLOWED_HOSTS=['*'] allows host header injection in production. Operators now set ALLOWED_HOSTS as a comma-separated env var; the template defaults to 'localhost' which is safe for local dev.

docker-compose.yaml explicitly sets both ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS so the dev compose setup works without changes.

## Summary by Sourcery

Configure Django host and CSRF settings via environment variables instead of relying on permissive defaults.

Enhancements:
- Switch ALLOWED_HOSTS configuration to be provided via an environment variable for safer, environment-specific host validation.

Build:
- Set ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS defaults in docker-compose.yaml for local development.