### PR TITLE
Ignore htmlcov coverage report directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ images/thumbnail/
 node_modules/
 dist/
 .coverage
+htmlcov/
+htmlcov_assets/
+htmlcov_tmp/


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Adjust .gitignore to refine ignored coverage report artifacts.