### PR TITLE
Exclude dev dependencies from the production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM python:3
 ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends libgdal-dev && rm -fr /var/lib/apt/lists/*
-RUN mkdir /code
 WORKDIR /code
+COPY requirements.txt /code/
+RUN python3 -m venv venv && . venv/bin/activate && pip install wheel && pip install -r requirements.txt
 COPY . /code/
-RUN rm -fr /code/smm/local_settings.py /code/venv
-RUN NODE_DONE=yes ./setup-venv.sh
+RUN rm -f /code/smm/local_settings.py
+RUN . /code/venv/bin/activate && NODE_DONE=yes ./setup.sh
 
 ENTRYPOINT ["/code/docker/app/start.sh"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+-r requirements.txt
+
+# Code checking
+pycodestyle
+pylint==4.0.*
+pylint-django==2.7.0
+
+# coverage reporting
+coverage==7.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,6 @@ pytz
 # Database
 psycopg[binary,pool]==3.3.4
 
-# Code checking
-pycodestyle
-pylint==4.0.*
-pylint-django==2.7.0
-
 # Numerical
 numpy
 haversine
@@ -23,6 +18,3 @@ whitenoise
 
 # image support
 image
-
-# coverage reporting
-coverage==7.14.0

--- a/setup-venv.sh
+++ b/setup-venv.sh
@@ -6,7 +6,7 @@ python3 -m venv venv
 source venv/bin/activate
 pip install wheel
 # Install the required packages
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 
 ./setup.sh
 


### PR DESCRIPTION
## Description

Split requirements.txt into runtime-only deps and a new requirements-dev.txt (pycodestyle, pylint, pylint-django, coverage) for local dev and CI. The Dockerfile now builds the venv from requirements.txt directly, improving both image size and layer caching. setup-venv.sh installs requirements-dev.txt so local dev and CI lint/test workflows retain the full toolset.

## Summary by Sourcery

Split runtime and development Python dependencies and adjust Docker and setup scripts to only include runtime dependencies in the production image while keeping dev tooling for local and CI use.

Enhancements:
- Introduce a dedicated requirements-dev.txt for linting, testing, and other development-only dependencies.
- Update the Docker image build process to create the virtual environment from runtime requirements only and run setup via the existing venv.
- Change local virtualenv setup to install development dependencies from requirements-dev.txt instead of the main requirements file.

Build:
- Refine Dockerfile to copy and install only runtime requirements into the image and avoid bundling development tools.