### PR TITLE
Switch to multi-stage Docker build with slim runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,13 @@
-static/
-dist/
+# Large build artifacts (keep context lean)
 node_modules/
 venv/
+static/
+dist/
 map/static/
-smm/local_settings.py
-smm/secretkey.txt
 images/full/
 images/thumbnail/
+
+# Local settings (Docker reads all config from environment variables)
+smm/local_settings.py
+smm/local_settings.py.template
+smm/secretkey.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,8 @@ static/
 dist/
 node_modules/
 venv/
+map/static/
+smm/local_settings.py
+smm/secretkey.txt
+images/full/
+images/thumbnail/

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,14 +22,6 @@ jobs:
       with:
         ref: ${{ github.event.workflow_run.head_sha }}
 
-    - name: Get node ready
-      uses: actions/setup-node@v6
-      with:
-        node-version: '20.x'
-
-    - name: Build the frontend
-      run: ./build-frontend.sh
-
     - name: Setup docker buildx
       uses: docker/setup-buildx-action@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,15 @@ RUN npm ci
 COPY frontend/ ./frontend/
 RUN npm run build-only
 
-# Stage 2: Build Python venv and collect static files
-FROM python:3.13-slim AS python-builder
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential libgdal-dev && rm -rf /var/lib/apt/lists/*
+# Stage 2: App source — single definition of what files land in the container.
+# Both python-builder and runtime COPY --from this stage, so the list only
+# lives here and the two stages can never drift out of sync.
+FROM scratch AS app-source
 WORKDIR /code
-COPY requirements.txt ./
-RUN python3 -m venv /code/venv && \
-    /code/venv/bin/pip install --no-cache-dir wheel && \
-    /code/venv/bin/pip install --no-cache-dir -r requirements.txt
-COPY manage.py ./
-COPY smm/ ./smm/
+COPY manage.py requirements.txt ./
 COPY assets/ ./assets/
 COPY data/ ./data/
+COPY docker/ ./docker/
 COPY icons/ ./icons/
 COPY images/ ./images/
 COPY map/ ./map/
@@ -25,33 +22,31 @@ COPY marinesar/ ./marinesar/
 COPY mission/ ./mission/
 COPY organization/ ./organization/
 COPY search/ ./search/
+COPY smm/ ./smm/
 COPY timeline/ ./timeline/
+
+# Stage 3: Build Python venv and collect static files
+FROM python:3.13-slim AS python-builder
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential libgdal-dev && rm -rf /var/lib/apt/lists/*
+WORKDIR /code
+COPY --from=app-source /code/requirements.txt ./
+RUN python3 -m venv /code/venv && \
+    /code/venv/bin/pip install --no-cache-dir wheel && \
+    /code/venv/bin/pip install --no-cache-dir -r requirements.txt
+COPY --from=app-source /code/ .
 COPY --from=frontend /app/dist/ ./map/static/
-RUN cp smm/local_settings.py.template smm/local_settings.py && \
-    DJANGO_SECRET_KEY=build-placeholder /code/venv/bin/python manage.py collectstatic --no-input && \
+RUN DJANGO_SECRET_KEY=build-placeholder \
+    /code/venv/bin/python manage.py collectstatic --no-input && \
     mkdir -p images/full images/thumbnail
 
-# Stage 3: Runtime image
+# Stage 4: Runtime image
 FROM python:3.13-slim
 ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends libgdal36 && rm -rf /var/lib/apt/lists/*
 WORKDIR /code
 COPY --from=python-builder /code/venv ./venv/
 COPY --from=python-builder /code/static ./static/
-COPY manage.py ./
-COPY smm/ ./smm/
-COPY assets/ ./assets/
-COPY data/ ./data/
-COPY icons/ ./icons/
-COPY images/ ./images/
-COPY map/ ./map/
-COPY marinesar/ ./marinesar/
-COPY mission/ ./mission/
-COPY organization/ ./organization/
-COPY search/ ./search/
-COPY timeline/ ./timeline/
-COPY setup-db.sh ./
-COPY docker/ ./docker/
+COPY --from=app-source /code/ .
 RUN mkdir -p images/full images/thumbnail
 
 ENTRYPOINT ["/code/docker/app/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,59 @@
-FROM python:3
-ENV PYTHONUNBUFFERED=1
-RUN apt-get update && apt-get install -y --no-install-recommends libgdal-dev && rm -fr /var/lib/apt/lists/*
+# Stage 1: Build frontend bundle
+FROM node:26-slim AS frontend
+WORKDIR /app
+COPY package.json package-lock.json esbuild.config.json ./
+RUN npm ci
+COPY frontend/ ./frontend/
+RUN npm run build-only
+
+# Stage 2: Build Python venv and collect static files
+FROM python:3.13-slim AS python-builder
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential libgdal-dev && rm -rf /var/lib/apt/lists/*
 WORKDIR /code
-COPY requirements.txt /code/
-RUN python3 -m venv venv && . venv/bin/activate && pip install wheel && pip install -r requirements.txt
-COPY . /code/
-RUN rm -f /code/smm/local_settings.py
-RUN . /code/venv/bin/activate && NODE_DONE=yes ./setup.sh
+COPY requirements.txt ./
+RUN python3 -m venv /code/venv && \
+    /code/venv/bin/pip install --no-cache-dir wheel && \
+    /code/venv/bin/pip install --no-cache-dir -r requirements.txt
+COPY manage.py ./
+COPY smm/ ./smm/
+COPY assets/ ./assets/
+COPY data/ ./data/
+COPY icons/ ./icons/
+COPY images/ ./images/
+COPY map/ ./map/
+COPY marinesar/ ./marinesar/
+COPY mission/ ./mission/
+COPY organization/ ./organization/
+COPY search/ ./search/
+COPY timeline/ ./timeline/
+COPY --from=frontend /app/dist/ ./map/static/
+RUN cp smm/local_settings.py.template smm/local_settings.py && \
+    python3 -c 'import secrets; print(secrets.token_urlsafe(50))' > smm/secretkey.txt && \
+    /code/venv/bin/python manage.py collectstatic --no-input && \
+    mkdir -p images/full images/thumbnail
+
+# Stage 3: Runtime image
+FROM python:3.13-slim
+ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y --no-install-recommends libgdal36 && rm -rf /var/lib/apt/lists/*
+WORKDIR /code
+COPY --from=python-builder /code/venv ./venv/
+COPY --from=python-builder /code/static ./static/
+COPY manage.py ./
+COPY smm/ ./smm/
+COPY assets/ ./assets/
+COPY data/ ./data/
+COPY icons/ ./icons/
+COPY images/ ./images/
+COPY map/ ./map/
+COPY marinesar/ ./marinesar/
+COPY mission/ ./mission/
+COPY organization/ ./organization/
+COPY search/ ./search/
+COPY timeline/ ./timeline/
+COPY setup-db.sh ./
+COPY docker/ ./docker/
+COPY --from=python-builder /code/smm/secretkey.txt ./smm/
+RUN mkdir -p images/full images/thumbnail
 
 ENTRYPOINT ["/code/docker/app/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ COPY search/ ./search/
 COPY timeline/ ./timeline/
 COPY --from=frontend /app/dist/ ./map/static/
 RUN cp smm/local_settings.py.template smm/local_settings.py && \
-    python3 -c 'import secrets; print(secrets.token_urlsafe(50))' > smm/secretkey.txt && \
-    /code/venv/bin/python manage.py collectstatic --no-input && \
+    DJANGO_SECRET_KEY=build-placeholder /code/venv/bin/python manage.py collectstatic --no-input && \
     mkdir -p images/full images/thumbnail
 
 # Stage 3: Runtime image
@@ -53,7 +52,6 @@ COPY search/ ./search/
 COPY timeline/ ./timeline/
 COPY setup-db.sh ./
 COPY docker/ ./docker/
-COPY --from=python-builder /code/smm/secretkey.txt ./smm/
 RUN mkdir -p images/full images/thumbnail
 
 ENTRYPOINT ["/code/docker/app/start.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       - DB_USER=postgres
       - DB_NAME=postgres
       - DB_PASS=password
+      - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
       - ALLOWED_HOSTS=localhost
       - CSRF_TRUSTED_ORIGINS=http://localhost:8080
       - DJANGO_SUPERUSER_USERNAME=admin

--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -ex
 
-cp smm/local_settings.py.template smm/local_settings.py
-
-./setup-db.sh
-
 source /code/venv/bin/activate
 
 ./manage.py migrate

--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -6,7 +6,6 @@ cp smm/local_settings.py.template smm/local_settings.py
 
 source /code/venv/bin/activate
 
-./manage.py makemigrations
 ./manage.py migrate
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -34,6 +34,7 @@ then
 	echo "Created new secretkey.txt in smm/secretkey.txt"
 fi
 
+export DJANGO_SECRET_KEY=$(cat smm/secretkey.txt)
 ./manage.py collectstatic --no-input
 
 echo ""

--- a/smm/settings.py
+++ b/smm/settings.py
@@ -10,8 +10,7 @@ from smm.local_settings import *
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-with open(os.path.join(BASE_DIR, 'smm', 'secretkey.txt')) as f:
-    SECRET_KEY = f.read().strip()
+SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 # Application definition
 

--- a/smm/settings.py
+++ b/smm/settings.py
@@ -4,12 +4,38 @@ Django settings for smm project.
 
 import os
 
-# Import other settings
-from smm.local_settings import *
-
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+DEBUG = False
+
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost').split(',')
+
+CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS', 'http://localhost:8080').split(',')
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'HOST': os.environ.get('DB_HOST', 'localhost'),
+        'NAME': os.environ.get('DB_NAME', 'smm'),
+        'USER': os.environ.get('DB_USER', 'smm'),
+        'PASSWORD': os.environ.get('DB_PASS', ''),
+        'OPTIONS': {
+            'pool': True,
+        },
+    }
+}
+
+# Allow a local_settings.py to override any of the above for local development.
+try:
+    from smm.local_settings import *
+except ImportError:
+    pass
+
+# Always read from environment so this cannot be overridden by local_settings.
 SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 # Application definition

--- a/start-venv.sh
+++ b/start-venv.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 source venv/bin/activate
-
+export DJANGO_SECRET_KEY=$(cat smm/secretkey.txt)
 ./start.sh


### PR DESCRIPTION
## Description

Three stages: node:26-slim builds the frontend bundle, python:3.13-slim with build-essential and libgdal-dev compiles the venv and runs collectstatic, then a clean python:3.13-slim runtime image receives only the venv, collected static files, and app source directories. The runtime stage installs libgdal36 (runtime library only, not the full -dev package) and contains no compiler toolchain, node runtime, frontend source, or build scripts. The CI workflow's separate node/frontend pre-build step is removed since Docker handles it.

## Summary by Sourcery

Switch to a multi-stage Docker build that produces a minimal Python runtime image and moves Django configuration to environment-based settings suitable for containerized deployment.

New Features:
- Add a dedicated frontend build stage using node:26-slim to produce the static bundle within the Docker build.
- Introduce a Python builder stage that creates a virtualenv, installs dependencies, and runs collectstatic before copying artifacts into the runtime image.
- Configure Django settings to be driven primarily by environment variables, including database configuration and secret key.

Enhancements:
- Refactor Dockerfile into separate frontend, app-source, Python builder, and slim runtime stages to reduce image size and remove build toolchains from the final image.
- Ensure both builder and runtime stages share a single source-of-truth file list via an intermediate app-source stage to keep container contents consistent.
- Update runtime image to use libgdal36 runtime library instead of the full libgdal-dev toolchain.
- Simplify container startup by removing in-container schema creation and migration generation from the start script and relying on pre-built artifacts.
- Pass DJANGO_SECRET_KEY via environment instead of reading from a file at runtime for better alignment with container practices.

CI:
- Remove GitHub Actions steps that separately set up Node and build the frontend, delegating the frontend build to the Docker build process.

Deployment:
- Wire docker-compose to supply DJANGO_SECRET_KEY and other Django settings via environment variables for containerized deployments.