### PR TITLE
Switch to multi-stage Docker build with slim runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,9 @@ static/
 dist/
 node_modules/
 venv/
+map/static/
+smm/local_settings.py
+smm/secretkey.txt
+images/full/
+images/thumbnail/
+.git/

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,14 +22,6 @@ jobs:
       with:
         ref: ${{ github.event.workflow_run.head_sha }}
 
-    - name: Get node ready
-      uses: actions/setup-node@v6
-      with:
-        node-version: '20.x'
-
-    - name: Build the frontend
-      run: ./build-frontend.sh
-
     - name: Setup docker buildx
       uses: docker/setup-buildx-action@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,54 @@
-FROM python:3
-ENV PYTHONUNBUFFERED=1
-RUN apt-get update && apt-get install -y --no-install-recommends libgdal-dev && rm -fr /var/lib/apt/lists/*
+# Stage 1: Build frontend bundle
+FROM node:26-slim AS frontend
+WORKDIR /app
+COPY package.json package-lock.json esbuild.config.json ./
+RUN npm ci
+COPY frontend/ ./frontend/
+RUN npm run build-only
+
+# Stage 2: App source — shared between builder and runtime; local_settings.py
+# is excluded via .dockerignore so it is never baked in here. The runtime
+# entrypoint generates it from the template at container start.
+FROM python:3.13-slim AS app-source
 WORKDIR /code
-COPY requirements.txt /code/
-RUN python3 -m venv venv && . venv/bin/activate && pip install wheel && pip install -r requirements.txt
-COPY . /code/
-RUN rm -f /code/smm/local_settings.py
-RUN . /code/venv/bin/activate && NODE_DONE=yes ./setup.sh
+COPY manage.py setup-db.sh ./
+COPY smm/ ./smm/
+COPY assets/ ./assets/
+COPY data/ ./data/
+COPY docker/ ./docker/
+COPY icons/ ./icons/
+COPY images/ ./images/
+COPY map/ ./map/
+COPY marinesar/ ./marinesar/
+COPY mission/ ./mission/
+COPY organization/ ./organization/
+COPY search/ ./search/
+COPY timeline/ ./timeline/
+
+# Stage 3: Build Python venv and collect static files
+FROM python:3.13-slim AS python-builder
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential libgdal-dev && rm -rf /var/lib/apt/lists/*
+WORKDIR /code
+COPY requirements.txt ./
+RUN python3 -m venv /code/venv && \
+    /code/venv/bin/pip install --no-cache-dir wheel && \
+    /code/venv/bin/pip install --no-cache-dir -r requirements.txt
+COPY --from=app-source /code/ ./
+COPY --from=frontend /app/dist/ ./map/static/
+RUN cp smm/local_settings.py.template smm/local_settings.py && \
+    python3 -c 'import secrets; print(secrets.token_urlsafe(50))' > smm/secretkey.txt && \
+    /code/venv/bin/python manage.py collectstatic --no-input && \
+    rm smm/secretkey.txt smm/local_settings.py && \
+    mkdir -p images/full images/thumbnail
+
+# Stage 4: Runtime image
+FROM python:3.13-slim
+ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y --no-install-recommends libgdal36 && rm -rf /var/lib/apt/lists/*
+WORKDIR /code
+COPY --from=python-builder /code/venv ./venv/
+COPY --from=python-builder /code/static ./static/
+COPY --from=app-source /code/ ./
+RUN mkdir -p images/full images/thumbnail
 
 ENTRYPOINT ["/code/docker/app/start.sh"]

--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -6,9 +6,13 @@ cp smm/local_settings.py.template smm/local_settings.py
 
 source /code/venv/bin/activate
 
+if [ ! -f "smm/secretkey.txt" ]
+then
+    python3 -c 'import secrets; print(secrets.token_urlsafe(50))' > smm/secretkey.txt
+fi
+
 ./manage.py makemigrations
 ./manage.py migrate
-
 
 if [ "$1" == "test" ]
 then


### PR DESCRIPTION
## Description

Four stages: node:26-slim builds the frontend bundle, python:3.13-slim with build-essential and libgdal-dev compiles the venv and runs collectstatic, then capture the app-source, then a clean python:3.13-slim runtime image receives only the venv, collected static files, and app source directories. The runtime stage installs libgdal36 (runtime library only, not the full -dev package) and contains no compiler toolchain, node runtime, frontend source, or build scripts. The CI workflow's separate node/frontend pre-build step is removed since Docker handles it.

## Summary by Sourcery

Adopt a multi-stage Docker build to produce a slim Python runtime image with prebuilt frontend assets and Python virtual environment, while simplifying container startup and CI.

Enhancements:
- Split Docker build into dedicated frontend, app source, Python builder, and runtime stages to reduce runtime image size and remove build toolchains from production containers.
- Prebuild the Python virtual environment and collect static files during the Docker build, copying only the venv, static assets, and app source into the runtime image.
- Adjust the application startup script to generate a secret key at runtime only if it does not already exist.

CI:
- Remove the GitHub Actions steps that set up Node and run the frontend build, delegating frontend compilation to the Docker multi-stage build.