### PR TITLE
Remove makemigrations from container startup

### DIFF
--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -11,7 +11,6 @@ then
     python3 -c 'import secrets; print(secrets.token_urlsafe(50))' > smm/secretkey.txt
 fi
 
-./manage.py makemigrations
 ./manage.py migrate
 
 if [ "$1" == "test" ]


### PR DESCRIPTION
## Description

makemigrations generates migration files from model state and should be run by a developer and committed to the repo, not executed on every container start. Running it in production risks creating spurious migrations and is a sign that migrations are out of sync. migrate alone is the correct startup-time operation.

## Summary by Sourcery

Enhancements:
- Stop running `makemigrations` on container startup and rely solely on `migrate` to apply committed migrations.