### PR TITLE
Fix JS data loading and asset map rendering bugs

### DIFF
--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -49,7 +49,7 @@ function smmGet(url: string, data?: RequestData, success?: (data: unknown) => vo
 }
 
 function smmGetJSON(url: string, data?: RequestData, success?: (data: unknown) => void, error?: () => void) {
-  return request(appendQueryString(url, data), {}, (r) => r.json(), success, error)
+  return request(appendQueryString(url, data), { headers: { Accept: 'application/json' } }, (r) => r.json(), success, error)
 }
 
 function smmPost(url: string, data: RequestData, success?: (data: unknown) => void, error?: () => void) {

--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -261,8 +261,8 @@ class SMMAssets extends SMMRealtime {
     return dl
   }
 
-  assetLayer(asset: { properties: { id: number } }, latlng: L.LatLng) {
-    const iconUrl = this.getAssetIcon(asset.properties.id)
+  assetLayer(asset: { properties: { asset: number } }, latlng: L.LatLng) {
+    const iconUrl = this.getAssetIcon(asset.properties.asset)
     if (iconUrl) {
       return L.marker(latlng, {
         icon: L.icon(
@@ -272,13 +272,13 @@ class SMMAssets extends SMMRealtime {
             iconAnchor: [25, 50]
           },
           {
-            title: this.assetNameMap[asset.properties.id]
+            title: this.assetNameMap[asset.properties.asset]
           }
         )
       })
     }
     return L.marker(latlng, {
-      title: this.assetNameMap[asset.properties.id]
+      title: this.assetNameMap[asset.properties.asset]
     })
   }
 
@@ -323,7 +323,7 @@ class SMMAssets extends SMMRealtime {
     if (asset.geometry.type === 'Point') {
       const c = asset.geometry.coordinates
       oldLayer.setLatLng([c[1], c[0]])
-      if (oldLayer._icon.title !== this.assetNameMap[assetId]) {
+      if (oldLayer._icon && oldLayer._icon.title !== this.assetNameMap[assetId]) {
         oldLayer._icon.title = this.assetNameMap[assetId]
       }
 


### PR DESCRIPTION
## Description

smmGetJSON was missing the Accept: application/json header, so any Django view that checks HTTP_ACCEPT (mission details, mission assets, organizations, etc.) returned HTML instead of JSON. This caused r.json() to throw on every call, leaving pages stuck at "Loading..." and populating no asset names or icons on the map.

assetLayer() was looking up icons and names via asset.properties.id, but the GeoJSON from AssetPointTime uses asset.properties.asset (the natural-key field). Icon and name lookups always missed, so assets rendered with no title and default Leaflet markers.

Also guards the private _icon access in assetUpdate() against null to avoid a TypeError if the marker hasn't been rendered yet.

## Summary by Sourcery

Fix JSON data loading and asset map rendering issues in the frontend.

Bug Fixes:
- Ensure smmGetJSON requests include an application/json Accept header so Django JSON views return parseable JSON instead of HTML.
- Use the correct asset identifier property from GeoJSON features when resolving asset icons and titles on the map.
- Guard asset marker title updates against missing DOM icons to avoid runtime errors when markers are not yet rendered.