### PR TITLE
Replace trivial jquery usages

### DIFF
--- a/frontend/Admin/admin.js
+++ b/frontend/Admin/admin.js
@@ -1,4 +1,3 @@
-import $ from 'jquery'
 import L from 'leaflet'
 
 import { smmGet, smmPost } from '../ajax'
@@ -14,34 +13,34 @@ L.SMMAdmin.AssetCommand = function (map, missionId) {
   const assetCommandDialog = L.control.dialog({ initOpen: true }).setContent(contents).addTo(map).hideClose()
   let gotoPoint = null
   const changeSelectedCommand = function () {
-    const selectedCommand = $('#id_command').val()
+    const selectedCommand = document.getElementById('id_command').value
     if (selectedCommand === 'GOTO') {
-      $('#latitude').show()
-      $('#longitude').show()
+      document.getElementById('latitude').style.display = ''
+      document.getElementById('longitude').style.display = ''
       if (gotoPoint == null) {
         gotoPoint = L.marker(map.getCenter(), { draggable: true, autoPan: true }).addTo(map)
         gotoPoint.on('dragend', function () {})
       }
     } else {
-      $('#latitude').hide()
-      $('#longitude').hide()
+      document.getElementById('latitude').style.display = 'none'
+      document.getElementById('longitude').style.display = 'none'
       if (gotoPoint != null) {
         map.removeLayer(gotoPoint)
         gotoPoint = null
       }
     }
   }
-  $('#command_cancel').on('click', function () {
+  document.getElementById('command_cancel').addEventListener('click', function () {
     if (gotoPoint != null) {
       map.removeLayer(gotoPoint)
     }
     assetCommandDialog.destroy()
   })
-  $('#command_create').on('click', function () {
+  document.getElementById('command_create').addEventListener('click', function () {
     const data = {
-      asset: $('#id_asset').val(),
-      reason: $('#id_reason').val(),
-      command: $('#id_command').val()
+      asset: document.getElementById('id_asset').value,
+      reason: document.getElementById('id_reason').value,
+      command: document.getElementById('id_command').value
     }
     if (gotoPoint != null) {
       const coords = gotoPoint.getLatLng()
@@ -56,12 +55,12 @@ L.SMMAdmin.AssetCommand = function (map, missionId) {
         assetCommandDialog.destroy()
         return
       }
-      $('#assetcommanddialog').html(data)
+      document.getElementById('assetcommanddialog').innerHTML = data
     })
   })
-  smmGet(`/mission/${missionId}/assets/command/set/`, {}, function (data) {
-    $('#assetcommanddialog').html(data)
-    $('#id_command').on('change', changeSelectedCommand)
+  smmGet(`/mission/${missionId}/assets/command/set/`, function (data) {
+    document.getElementById('assetcommanddialog').innerHTML = data
+    document.getElementById('id_command').addEventListener('change', changeSelectedCommand)
   })
 }
 
@@ -88,8 +87,8 @@ L.Control.SMMAdmin = L.Control.extend({
       '<div><button class="btn btn-danger" id="admin_close">Close</button>'
     ].join('')
     this.AdminDialog = L.control.dialog({ initOpen: true }).setContent(contents).addTo(this.map).hideClose()
-    $('#asset_command').on('click', this.onCommand.bind(this))
-    $('#admin_close').on('click', this.onCancel.bind(this))
+    document.getElementById('asset_command').addEventListener('click', this.onCommand.bind(this))
+    document.getElementById('admin_close').addEventListener('click', this.onCancel.bind(this))
   },
 
   onAdd: function (map) {

--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -1,7 +1,5 @@
 import L from 'leaflet'
 
-import $ from 'jquery'
-
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { SMMRealtime } from '../smmmap'
 import '@canterbury-air-patrol/leaflet-dialog'
@@ -135,12 +133,10 @@ class SMMAsset {
       assetUrl = `${assetUrl}&from=${this.lastUpdate}`
     }
 
-    $.ajax({
-      type: 'GET',
-      url: assetUrl,
-      success: this.updateNewRoute,
-      error: this.updateFailed
-    })
+    fetch(assetUrl)
+      .then((r) => r.json())
+      .then(this.updateNewRoute)
+      .catch(this.updateFailed)
   }
 }
 
@@ -215,11 +211,11 @@ class SMMAssets extends SMMRealtime {
       this.overlayAdd(`${this.assetNameMap[assetId]} <div id='assetNamePicker${assetId}' />`, assetObject.overlay())
     }
     const assetObject = this.assetObjects[assetId]
-    $(`#assetNamePicker${assetId}`).on('click', assetObject.colorPicker)
-    $(`#assetNamePicker${assetId}`).css('width', '15px')
-    $(`#assetNamePicker${assetId}`).css('height', '15px')
-    $(`#assetNamePicker${assetId}`).css('display', 'inline-block')
-    $(`#assetNamePicker${assetId}`).css('background-color', assetObject.color)
+    const pickerDiv = document.getElementById(`assetNamePicker${assetId}`)
+    if (pickerDiv) {
+      pickerDiv.addEventListener('click', assetObject.colorPicker)
+      Object.assign(pickerDiv.style, { width: '15px', height: '15px', display: 'inline-block', backgroundColor: assetObject.color })
+    }
     return assetObject
   }
 

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -1,7 +1,5 @@
 import L from 'leaflet'
 
-import $ from 'jquery'
-
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { SMMRealtime } from '../smmmap'
 import { AssetColorPicker } from '../asset/map'
@@ -101,12 +99,10 @@ class SMMUserPosition {
       userUrl = `${userUrl}&from=${this.lastUpdate}`
     }
 
-    $.ajax({
-      type: 'GET',
-      url: userUrl,
-      success: this.updateNewPosition,
-      error: this.updateError
-    })
+    fetch(userUrl)
+      .then((r) => r.json())
+      .then(this.updateNewPosition)
+      .catch(this.updateError)
   }
 }
 
@@ -153,11 +149,11 @@ class SMMUserPositions extends SMMRealtime {
       this.overlayAdd(`${userName} <div id='userNamePicker${userName}' />`, userObject.overlay())
     }
     const userObject = this.userObjects[userName]
-    $(`#userNamePicker${userName}`).on('click', userObject.colorPicker)
-    $(`#userNamePicker${userName}`).css('width', '15px')
-    $(`#userNamePicker${userName}`).css('height', '15px')
-    $(`#userNamePicker${userName}`).css('display', 'inline-block')
-    $(`#userNamePicker${userName}`).css('background-color', userObject.color)
+    const pickerDiv = document.getElementById(`userNamePicker${userName}`)
+    if (pickerDiv) {
+      pickerDiv.addEventListener('click', userObject.colorPicker)
+      Object.assign(pickerDiv.style, { width: '15px', height: '15px', display: 'inline-block', backgroundColor: userObject.color })
+    }
     return userObject
   }
 


### PR DESCRIPTION
## Description

Replace usages of jquery $.ajax and html generation

## Summary by Sourcery

Replace remaining trivial jQuery usages with native DOM APIs and the Fetch API for admin, asset, and user map interactions.

Enhancements:
- Switch asset and user map polling from jQuery $.ajax to the Fetch API while preserving existing callbacks.
- Replace jQuery-based DOM selection, event binding, and styling in admin, asset, and user views with vanilla DOM methods and inline style updates.