### PR TITLE
Convert create dialogs to react

### DIFF
--- a/frontend/ImageUploader/ImageUploader.js
+++ b/frontend/ImageUploader/ImageUploader.js
@@ -1,10 +1,8 @@
-import $ from 'jquery'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import L from 'leaflet'
 
-import { LatLngMarkerInput } from '../LatLngMarkerInput'
-import { smmPostBody } from '../ajax'
+import { ImageUploaderDialog } from './ImageUploaderDialog'
 
 L.Control.ImageUploader = L.Control.extend({
   options: {
@@ -15,64 +13,20 @@ L.Control.ImageUploader = L.Control.extend({
     L.Control.prototype.initialize.call(this, options)
   },
 
-  onCancel: function () {
-    this.latlngRoot.unmount()
-    this.imageUploadDialog.destroy()
-  },
-
-  onSubmit: function () {
-    const latLng = this.currentPos
-
-    const formData = new FormData()
-    formData.append('description', document.getElementById('image_upload_description').value)
-    formData.append('latitude', latLng.lat)
-    formData.append('longitude', latLng.lng)
-    formData.append('file', document.getElementById('image_upload_file').files[0])
-
-    smmPostBody(`/mission/${this.options.missionId}/image/upload/`, formData)
-
-    this.latlngRoot.unmount()
-    this.imageUploadDialog.destroy()
-  },
-
   onClick: function () {
-    const contents = [
-      `<form method="post" enctype="multipart/form-data" id="image_upload_form" action="/mission/${this.options.missionId}/image/upload/">`,
-      '<table>',
-      '<tr>',
-      '<td>File:</td>',
-      '<td><input name="file" type="file" id="image_upload_file" accept="image/*" /></td>',
-      '<tr>',
-      '<tr>',
-      '<td>Description:</td>',
-      '<td><input name="description" id="image_upload_description" type="text" /></td>',
-      '<tr>',
-      '<tr>',
-      '<td colspan="2"><div id="image_upload_latlng"></div></td>',
-      '</tr>',
-      '</table>',
-      '</form>',
-      '<div class="btn-class" role="group">',
-      '<button class="btn btn-primary" id="image_upload">Upload</button>',
-      '<button class="btn btn-danger" id="image_cancel">Cancel</button>',
-      '</div>'
-    ].join('')
-    this.imageUploadDialog = L.control.dialog({ initOpen: true }).setContent(contents).addTo(this.map).hideClose()
-
-    this.currentPos = this.map.getCenter()
-    this.latlngRoot = ReactDOM.createRoot(document.getElementById('image_upload_latlng'))
-    this.latlngRoot.render(
-      <LatLngMarkerInput
+    const container = document.createElement('div')
+    this.imageUploadDialog = L.control.dialog({ initOpen: true }).setContent(container).addTo(this.map).hideClose()
+    const root = ReactDOM.createRoot(container)
+    root.render(
+      <ImageUploaderDialog
         map={this.map}
-        initialPos={this.map.getCenter()}
-        onChange={(p) => {
-          this.currentPos = p
+        missionId={this.options.missionId}
+        onClose={() => {
+          root.unmount()
+          this.imageUploadDialog.destroy()
         }}
       />
     )
-
-    $('#image_cancel').on('click', this.onCancel.bind(this))
-    $('#image_upload').on('click', this.onSubmit.bind(this))
   },
 
   onAdd: function (map) {

--- a/frontend/ImageUploader/ImageUploaderDialog.tsx
+++ b/frontend/ImageUploader/ImageUploaderDialog.tsx
@@ -1,0 +1,69 @@
+import React, { useRef } from 'react'
+import L from 'leaflet'
+
+import { LatLngMarkerInput } from '../LatLngMarkerInput'
+import { smmPostBody } from '../ajax'
+
+interface Props {
+  map: L.Map
+  missionId: number
+  onClose: () => void
+}
+
+export function ImageUploaderDialog({ map, missionId, onClose }: Props) {
+  const posRef = useRef<L.LatLng>(map.getCenter())
+  const fileRef = useRef<HTMLInputElement>(null)
+  const descRef = useRef<HTMLInputElement>(null)
+
+  function handleUpload() {
+    const formData = new FormData()
+    formData.append('description', descRef.current?.value ?? '')
+    formData.append('latitude', String(posRef.current.lat))
+    formData.append('longitude', String(posRef.current.lng))
+    if (fileRef.current?.files?.[0]) {
+      formData.append('file', fileRef.current.files[0])
+    }
+    smmPostBody(`/mission/${missionId}/image/upload/`, formData)
+    onClose()
+  }
+
+  return (
+    <div>
+      <table>
+        <tbody>
+          <tr>
+            <td>File:</td>
+            <td>
+              <input ref={fileRef} name="file" type="file" accept="image/*" />
+            </td>
+          </tr>
+          <tr>
+            <td>Description:</td>
+            <td>
+              <input ref={descRef} name="description" type="text" />
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={2}>
+              <LatLngMarkerInput
+                map={map}
+                initialPos={map.getCenter()}
+                onChange={(p) => {
+                  posRef.current = p
+                }}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="btn-group" role="group">
+        <button className="btn btn-primary" onClick={handleUpload}>
+          Upload
+        </button>
+        <button className="btn btn-danger" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/LineAdder/LineAdder.js
+++ b/frontend/LineAdder/LineAdder.js
@@ -1,127 +1,26 @@
-import $ from 'jquery'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import L from 'leaflet'
 
-import { LatLngMarkerInput } from '../LatLngMarkerInput'
-import { smmPost } from '../ajax'
+import { LineAdderDialog } from './LineAdderDialog'
 
 L.LineAdder = function (map, missionId, currentPoints, replaces, label) {
-  const RAND_NUM = Math.floor(Math.random() * 16536)
-  const markers = []
-  const line = L.polyline(currentPoints, { color: 'yellow' }).addTo(map)
-  const dialog = L.control.dialog()
-
-  const contents = [
-    '<div class="input-group input-group-sm mb-3"><div class="input-group-prepend"><span class="input-group-text">Name</span></div>',
-    `<input type="text" id="lineadder-dialog-name-${RAND_NUM}" value="${label}"></input></div>`,
-    '<div class="btn-group">',
-    `<button class="btn btn-primary" id="lineadder-dialog-done-${RAND_NUM}">Done</button>`,
-    `<button class="btn btn-danger" id="lineadder-dialog-cancel-${RAND_NUM}">Cancel</button>`,
-    '</div>',
-    `<div id="lineadder-points-${RAND_NUM}"></div>`,
-    '<div class="btn-group">',
-    `<button class="btn btn-primary" id="lineadder-dialog-next-${RAND_NUM}">Next</button>`,
-    `<button class="btn btn-danger" id="lineadder-dialog-remove-${RAND_NUM}">Remove</button>`,
-    '</div>'
-  ].join('')
-  dialog.setContent(contents).addTo(map).hideClose()
-
-  let pointCount = 0
-  const addPointRow = function () {
-    const pointsEl = document.getElementById(`lineadder-points-${RAND_NUM}`)
-    const row = document.createElement('div')
-    row.id = `lineadder-points-${RAND_NUM}-${pointCount}`
-    const mountEl = document.createElement('div')
-    row.appendChild(mountEl)
-    pointsEl.appendChild(row)
-    return { mountEl, pointIndex: pointCount++ }
-  }
-
-  const updateLine = function () {
-    const newPoints = []
-    markers.forEach(function (m) {
-      newPoints.push(m.getLatLng())
-    })
-    line.setLatLngs(newPoints)
-  }
-
-  const addMarker = function (pos) {
-    const { mountEl, pointIndex } = addPointRow()
-    let currentPos = pos
-    const root = ReactDOM.createRoot(mountEl)
-    root.render(
-      <LatLngMarkerInput
-        map={map}
-        initialPos={pos}
-        showLabels={pointIndex === 0}
-        onChange={function (p) {
-          currentPos = p
-          updateLine()
-        }}
-      />
-    )
-    markers.push({
-      root: root,
-      getLatLng: function () {
-        return currentPos
-      }
-    })
-    updateLine()
-  }
-
-  currentPoints.forEach(addMarker)
-
-  const removeAllMarkers = function () {
-    markers.forEach(function (m) {
-      m.root.unmount()
-    })
-  }
-
-  const removeMarker = function () {
-    pointCount--
-    document.getElementById(`lineadder-points-${RAND_NUM}-${pointCount}`).remove()
-    const handle = markers.pop()
-    handle.root.unmount()
-    updateLine()
-  }
-
-  $(`#lineadder-dialog-next-${RAND_NUM}`).on('click', function () {
-    addMarker(map.getCenter())
-  })
-
-  $(`#lineadder-dialog-done-${RAND_NUM}`).on('click', function () {
-    const data = {
-      label: $(`#lineadder-dialog-name-${RAND_NUM}`).val(),
-      points: markers.length
-    }
-    for (const i in markers) {
-      const markerLatLng = markers[i].getLatLng()
-      data[`point${i}_lat`] = markerLatLng.lat
-      data[`point${i}_lng`] = markerLatLng.lng
-    }
-
-    if (replaces !== -1) {
-      smmPost(`/data/userlines/${replaces}/replace/`, data)
-    } else {
-      smmPost(`/mission/${missionId}/data/userlines/create/`, data)
-    }
-    removeAllMarkers()
-    map.removeLayer(line)
-    dialog.destroy()
-  })
-
-  $(`#lineadder-dialog-cancel-${RAND_NUM}`).on('click', function () {
-    removeAllMarkers()
-    map.removeLayer(line)
-    dialog.destroy()
-  })
-
-  $(`#lineadder-dialog-remove-${RAND_NUM}`).on('click', function () {
-    if (markers.length > 1) {
-      removeMarker()
-    }
-  })
+  const container = document.createElement('div')
+  const dialog = L.control.dialog().setContent(container).addTo(map).hideClose()
+  const root = ReactDOM.createRoot(container)
+  root.render(
+    <LineAdderDialog
+      map={map}
+      missionId={missionId}
+      initialPoints={currentPoints}
+      replaces={replaces}
+      initialLabel={label}
+      onClose={() => {
+        root.unmount()
+        dialog.destroy()
+      }}
+    />
+  )
 }
 
 L.Control.LineAdder = L.Control.extend({

--- a/frontend/LineAdder/LineAdderDialog.tsx
+++ b/frontend/LineAdder/LineAdderDialog.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef, useState } from 'react'
+import L from 'leaflet'
+
+import { LatLngMarkerInput } from '../LatLngMarkerInput'
+import { smmPost } from '../ajax'
+
+interface Props {
+  map: L.Map
+  missionId: number
+  initialPoints: L.LatLng[]
+  replaces: number
+  initialLabel: string
+  onClose: () => void
+}
+
+export function LineAdderDialog({ map, missionId, initialPoints, replaces, initialLabel, onClose }: Props) {
+  const [label, setLabel] = useState(initialLabel)
+  const [positions, setPositions] = useState<L.LatLng[]>(initialPoints)
+  const positionsRef = useRef<L.LatLng[]>([...initialPoints])
+  const lineRef = useRef<L.Polyline | null>(null)
+
+  useEffect(() => {
+    const line = L.polyline(positionsRef.current, { color: 'yellow' }).addTo(map)
+    lineRef.current = line
+    return () => {
+      line.remove()
+    }
+  }, [])
+
+  function handlePositionChange(index: number, pos: L.LatLng) {
+    positionsRef.current[index] = pos
+    lineRef.current?.setLatLngs(positionsRef.current)
+  }
+
+  function addPoint() {
+    const next = [...positionsRef.current, map.getCenter()]
+    positionsRef.current = next
+    setPositions(next)
+    lineRef.current?.setLatLngs(next)
+  }
+
+  function removePoint() {
+    if (positionsRef.current.length <= 1) return
+    const next = positionsRef.current.slice(0, -1)
+    positionsRef.current = next
+    setPositions(next)
+    lineRef.current?.setLatLngs(next)
+  }
+
+  function handleDone() {
+    const data: Record<string, string | number> = { label, points: positionsRef.current.length }
+    positionsRef.current.forEach((p, i) => {
+      data[`point${i}_lat`] = p.lat
+      data[`point${i}_lng`] = p.lng
+    })
+    if (replaces !== -1) {
+      smmPost(`/data/userlines/${replaces}/replace/`, data)
+    } else {
+      smmPost(`/mission/${missionId}/data/userlines/create/`, data)
+    }
+    onClose()
+  }
+
+  return (
+    <div>
+      <div className="input-group input-group-sm mb-3">
+        <div className="input-group-prepend">
+          <span className="input-group-text">Name</span>
+        </div>
+        <input type="text" className="form-control" value={label} onChange={(e) => setLabel(e.target.value)} />
+      </div>
+      <div className="btn-group mb-2">
+        <button className="btn btn-primary" onClick={handleDone}>
+          Done
+        </button>
+        <button className="btn btn-danger" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+      {positions.map((pos, i) => (
+        <LatLngMarkerInput key={i} map={map} initialPos={pos} showLabels={i === 0} onChange={(p) => handlePositionChange(i, p)} />
+      ))}
+      <div className="btn-group">
+        <button className="btn btn-primary" onClick={addPoint}>
+          Next
+        </button>
+        <button className="btn btn-danger" onClick={removePoint} disabled={positions.length <= 1}>
+          Remove
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/POIAdder/POIAdder.js
+++ b/frontend/POIAdder/POIAdder.js
@@ -1,56 +1,27 @@
-import $ from 'jquery'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
-
 import L from 'leaflet'
 import markerIcon from 'leaflet/dist/images/marker-icon.png'
 
-import { LatLngMarkerInput } from '../LatLngMarkerInput'
-import { smmPost } from '../ajax'
+import { POIAdderDialog } from './POIAdderDialog'
 
 L.POIAdder = function (map, missionId, pos, replaces, label) {
-  const RAND_NUM = Math.floor(Math.random() * 16536)
-  const contents = [
-    '<div class="input-group input-group-sm mb-3"><div class="input-group-prepend"><span class="input-group-text">Name</span></div>',
-    `<textarea autofocus id="poi-dialog-label-${RAND_NUM}" rows=2>${label}</textarea></div>`,
-    `<div id="poi-latlng-${RAND_NUM}"></div>`,
-    `<div class="btn-group"><button class="btn btn-primary" id="poi-dialog-create-${RAND_NUM}">Create</button>`,
-    `<button class="btn btn-danger" id="poi-dialog-cancel-${RAND_NUM}">Cancel</button></div>`
-  ].join('')
-  const markerDialog = L.control.dialog({ initOpen: true }).setContent(contents).addTo(map).hideClose()
-
-  let currentPos = pos
-  const latlngRoot = ReactDOM.createRoot(document.getElementById(`poi-latlng-${RAND_NUM}`))
-  latlngRoot.render(
-    <LatLngMarkerInput
+  const container = document.createElement('div')
+  const dialog = L.control.dialog({ initOpen: true }).setContent(container).addTo(map).hideClose()
+  const root = ReactDOM.createRoot(container)
+  root.render(
+    <POIAdderDialog
       map={map}
+      missionId={missionId}
       initialPos={pos}
-      onChange={function (p) {
-        currentPos = p
+      replaces={replaces}
+      initialLabel={label}
+      onClose={() => {
+        root.unmount()
+        dialog.destroy()
       }}
     />
   )
-
-  function createOrReplace() {
-    const data = {
-      lat: currentPos.lat,
-      lon: currentPos.lng,
-      label: $(`#poi-dialog-label-${RAND_NUM}`).val()
-    }
-    if (replaces === -1) {
-      smmPost(`/mission/${missionId}/data/pois/create/`, data)
-    } else {
-      smmPost(`/data/pois/${replaces}/replace/`, data)
-    }
-    latlngRoot.unmount()
-    markerDialog.destroy()
-  }
-
-  $(`#poi-dialog-create-${RAND_NUM}`).on('click', createOrReplace)
-  $(`#poi-dialog-cancel-${RAND_NUM}`).on('click', function () {
-    latlngRoot.unmount()
-    markerDialog.destroy()
-  })
 }
 
 L.Control.POIAdder = L.Control.extend({

--- a/frontend/POIAdder/POIAdderDialog.tsx
+++ b/frontend/POIAdder/POIAdderDialog.tsx
@@ -1,0 +1,55 @@
+import React, { useRef, useState } from 'react'
+import L from 'leaflet'
+
+import { LatLngMarkerInput } from '../LatLngMarkerInput'
+import { smmPost } from '../ajax'
+
+interface Props {
+  map: L.Map
+  missionId: number
+  initialPos: L.LatLng
+  replaces: number
+  initialLabel: string
+  onClose: () => void
+}
+
+export function POIAdderDialog({ map, missionId, initialPos, replaces, initialLabel, onClose }: Props) {
+  const [label, setLabel] = useState(initialLabel)
+  const posRef = useRef<L.LatLng>(initialPos)
+
+  function createOrReplace() {
+    const data = { lat: posRef.current.lat, lon: posRef.current.lng, label }
+    if (replaces === -1) {
+      smmPost(`/mission/${missionId}/data/pois/create/`, data)
+    } else {
+      smmPost(`/data/pois/${replaces}/replace/`, data)
+    }
+    onClose()
+  }
+
+  return (
+    <div>
+      <div className="input-group input-group-sm mb-3">
+        <div className="input-group-prepend">
+          <span className="input-group-text">Name</span>
+        </div>
+        <textarea autoFocus className="form-control" rows={2} value={label} onChange={(e) => setLabel(e.target.value)} />
+      </div>
+      <LatLngMarkerInput
+        map={map}
+        initialPos={initialPos}
+        onChange={(p) => {
+          posRef.current = p
+        }}
+      />
+      <div className="btn-group">
+        <button className="btn btn-primary" onClick={createOrReplace}>
+          Create
+        </button>
+        <button className="btn btn-danger" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/PolygonAdder/PolygonAdder.js
+++ b/frontend/PolygonAdder/PolygonAdder.js
@@ -1,127 +1,26 @@
-import $ from 'jquery'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import L from 'leaflet'
 
-import { LatLngMarkerInput } from '../LatLngMarkerInput'
-import { smmPost } from '../ajax'
+import { PolygonAdderDialog } from './PolygonAdderDialog'
 
 L.PolygonAdder = function (map, missionId, currentPoints, replaces, label) {
-  const RAND_NUM = Math.floor(Math.random() * 16536)
-  const markers = []
-  const polygon = L.polygon(currentPoints, { color: 'yellow' }).addTo(map)
-  const dialog = L.control.dialog()
-
-  const contents = [
-    '<div class="input-group input-group-sm mb-3"><div class="input-group-prepend"><span class="input-group-text">Name</span></div>',
-    `<input type="text" id="polygonadder-dialog-name-${RAND_NUM}" value="${label}"></input></div>`,
-    '<div class="btn-group">',
-    `<button class="btn btn-primary" id="polygonadder-dialog-done-${RAND_NUM}">Done</button>`,
-    `<button class="btn btn-danger" id="polygonadder-dialog-cancel-${RAND_NUM}">Cancel</button>`,
-    '</div>',
-    `<div id="polygonadder-points-${RAND_NUM}"></div>`,
-    '<div class="btn-group">',
-    `<button class="btn btn-primary" id="polygonadder-dialog-next-${RAND_NUM}">Next</button>`,
-    `<button class="btn btn-danger" id="polygonadder-dialog-remove-${RAND_NUM}">Remove</button>`,
-    '</div>'
-  ].join('')
-  dialog.setContent(contents).addTo(map).hideClose()
-
-  let pointCount = 0
-  const addPointRow = function () {
-    const pointsEl = document.getElementById(`polygonadder-points-${RAND_NUM}`)
-    const row = document.createElement('div')
-    row.id = `polygonadder-points-${RAND_NUM}-${pointCount}`
-    const mountEl = document.createElement('div')
-    row.appendChild(mountEl)
-    pointsEl.appendChild(row)
-    return { mountEl, pointIndex: pointCount++ }
-  }
-
-  const updatePolygon = function () {
-    const newPoints = []
-    markers.forEach(function (m) {
-      newPoints.push(m.getLatLng())
-    })
-    polygon.setLatLngs(newPoints)
-  }
-
-  const addMarker = function (pos) {
-    const { mountEl, pointIndex } = addPointRow()
-    let currentPos = pos
-    const root = ReactDOM.createRoot(mountEl)
-    root.render(
-      <LatLngMarkerInput
-        map={map}
-        initialPos={pos}
-        showLabels={pointIndex === 0}
-        onChange={function (p) {
-          currentPos = p
-          updatePolygon()
-        }}
-      />
-    )
-    markers.push({
-      root: root,
-      getLatLng: function () {
-        return currentPos
-      }
-    })
-    updatePolygon()
-  }
-
-  currentPoints.forEach(addMarker)
-
-  const removeAllMarkers = function () {
-    markers.forEach(function (m) {
-      m.root.unmount()
-    })
-  }
-
-  const removeMarker = function () {
-    pointCount--
-    document.getElementById(`polygonadder-points-${RAND_NUM}-${pointCount}`).remove()
-    const handle = markers.pop()
-    handle.root.unmount()
-    updatePolygon()
-  }
-
-  $(`#polygonadder-dialog-next-${RAND_NUM}`).on('click', function () {
-    addMarker(map.getCenter())
-  })
-
-  $(`#polygonadder-dialog-done-${RAND_NUM}`).on('click', function () {
-    const data = {
-      label: $(`#polygonadder-dialog-name-${RAND_NUM}`).val(),
-      points: markers.length
-    }
-    for (const i in markers) {
-      const markerLatLng = markers[i].getLatLng()
-      data[`point${i}_lat`] = markerLatLng.lat
-      data[`point${i}_lng`] = markerLatLng.lng
-    }
-
-    if (replaces !== -1) {
-      smmPost(`/data/userpolygons/${replaces}/replace/`, data)
-    } else {
-      smmPost(`/mission/${missionId}/data/userpolygons/create/`, data)
-    }
-    removeAllMarkers()
-    map.removeLayer(polygon)
-    dialog.destroy()
-  })
-
-  $(`#polygonadder-dialog-cancel-${RAND_NUM}`).on('click', function () {
-    removeAllMarkers()
-    map.removeLayer(polygon)
-    dialog.destroy()
-  })
-
-  $(`#polygonadder-dialog-remove-${RAND_NUM}`).on('click', function () {
-    if (markers.length > 1) {
-      removeMarker()
-    }
-  })
+  const container = document.createElement('div')
+  const dialog = L.control.dialog().setContent(container).addTo(map).hideClose()
+  const root = ReactDOM.createRoot(container)
+  root.render(
+    <PolygonAdderDialog
+      map={map}
+      missionId={missionId}
+      initialPoints={currentPoints}
+      replaces={replaces}
+      initialLabel={label}
+      onClose={() => {
+        root.unmount()
+        dialog.destroy()
+      }}
+    />
+  )
 }
 
 L.Control.PolygonAdder = L.Control.extend({

--- a/frontend/PolygonAdder/PolygonAdderDialog.tsx
+++ b/frontend/PolygonAdder/PolygonAdderDialog.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef, useState } from 'react'
+import L from 'leaflet'
+
+import { LatLngMarkerInput } from '../LatLngMarkerInput'
+import { smmPost } from '../ajax'
+
+interface Props {
+  map: L.Map
+  missionId: number
+  initialPoints: L.LatLng[]
+  replaces: number
+  initialLabel: string
+  onClose: () => void
+}
+
+export function PolygonAdderDialog({ map, missionId, initialPoints, replaces, initialLabel, onClose }: Props) {
+  const [label, setLabel] = useState(initialLabel)
+  const [positions, setPositions] = useState<L.LatLng[]>(initialPoints)
+  const positionsRef = useRef<L.LatLng[]>([...initialPoints])
+  const polygonRef = useRef<L.Polygon | null>(null)
+
+  useEffect(() => {
+    const polygon = L.polygon(positionsRef.current, { color: 'yellow' }).addTo(map)
+    polygonRef.current = polygon
+    return () => {
+      polygon.remove()
+    }
+  }, [])
+
+  function handlePositionChange(index: number, pos: L.LatLng) {
+    positionsRef.current[index] = pos
+    polygonRef.current?.setLatLngs(positionsRef.current)
+  }
+
+  function addPoint() {
+    const next = [...positionsRef.current, map.getCenter()]
+    positionsRef.current = next
+    setPositions(next)
+    polygonRef.current?.setLatLngs(next)
+  }
+
+  function removePoint() {
+    if (positionsRef.current.length <= 1) return
+    const next = positionsRef.current.slice(0, -1)
+    positionsRef.current = next
+    setPositions(next)
+    polygonRef.current?.setLatLngs(next)
+  }
+
+  function handleDone() {
+    const data: Record<string, string | number> = { label, points: positionsRef.current.length }
+    positionsRef.current.forEach((p, i) => {
+      data[`point${i}_lat`] = p.lat
+      data[`point${i}_lng`] = p.lng
+    })
+    if (replaces !== -1) {
+      smmPost(`/data/userpolygons/${replaces}/replace/`, data)
+    } else {
+      smmPost(`/mission/${missionId}/data/userpolygons/create/`, data)
+    }
+    onClose()
+  }
+
+  return (
+    <div>
+      <div className="input-group input-group-sm mb-3">
+        <div className="input-group-prepend">
+          <span className="input-group-text">Name</span>
+        </div>
+        <input type="text" className="form-control" value={label} onChange={(e) => setLabel(e.target.value)} />
+      </div>
+      <div className="btn-group mb-2">
+        <button className="btn btn-primary" onClick={handleDone}>
+          Done
+        </button>
+        <button className="btn btn-danger" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+      {positions.map((pos, i) => (
+        <LatLngMarkerInput key={i} map={map} initialPos={pos} showLabels={i === 0} onChange={(p) => handlePositionChange(i, p)} />
+      ))}
+      <div className="btn-group">
+        <button className="btn btn-primary" onClick={addPoint}>
+          Next
+        </button>
+        <button className="btn btn-danger" onClick={removePoint} disabled={positions.length <= 1}>
+          Remove
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/SearchAdder/SearchAdder.js
+++ b/frontend/SearchAdder/SearchAdder.js
@@ -1,158 +1,22 @@
-import $ from 'jquery'
-
+import React from 'react'
+import * as ReactDOM from 'react-dom/client'
 import L from 'leaflet'
 
-import { smmGetJSON, smmPost } from '../ajax'
+import { SearchAdderDialog } from './SearchAdderDialog'
 
 L.SearchAdder = function (map, objectType, objectID) {
-  const RAND_NUM = Math.floor(Math.random() * 16536)
-  let searchSelection = `<select class='form-control' id='SearchAdder-search-type-${RAND_NUM}'>`
-  switch (objectType) {
-    case 'point':
-      searchSelection += '<option value="sector">Sector</option>'
-      searchSelection += '<option value="expanding-box">Expanding Box</option>'
-      break
-    case 'line':
-      searchSelection += '<option value="track-line">Track Line</option>'
-      searchSelection += '<option value="shore-line">Shore Line</option>'
-      searchSelection += '<option value="creeping-line">Creeping Line Ahead</option>'
-      break
-    case 'polygon':
-      searchSelection += '<option value="creeping-line">Creeping Line Ahead</option>'
-      break
-  }
-  searchSelection += '</select>'
-  const assetSelection = `<select class="form-control" id="SearchAdder-asset-type-${RAND_NUM}"></select>`
-  smmGetJSON('/assets/assettypes/', {}, function (data) {
-    $.each(data, function (index, json) {
-      for (const assetType of json) {
-        $(`#SearchAdder-asset-type-${RAND_NUM}`).append(`<option value='${assetType.id}'>${assetType.name}</option>`)
-      }
-    })
-  })
-  const generateInputs = function (inputs) {
-    let res = ''
-    for (const input of inputs) {
-      res += `<div class="input-group input-group-sm mb-3" id="SearchAdder-${input.id}-${RAND_NUM}">`
-      res += '<div class="input-group-prepend">'
-      res += '<span class="input-group-text">'
-      res += input.label
-      res += '</span>'
-      res += '</div>'
-      res += input.input_html
-      res += '</div>'
-    }
-    return res
-  }
-  let contents = generateInputs([
-    { id: 'st', label: 'Search Type', input_html: searchSelection },
-    { id: 'at', label: 'Asset Type', input_html: assetSelection },
-    { id: 'sw', label: 'Sweep Width', input_html: `<input class="form-control form-control-sm" type="number" id="SearchAdder-sweep-width-${RAND_NUM}" size="4" />` },
-    { id: 'i', label: 'Iterations', input_html: `<input class="form-control form-control-sm" type="number" id="SearchAdder-iterations-${RAND_NUM}" size="3" />` },
-    {
-      id: 'fb',
-      label: 'First Bearing',
-      input_html: `<input class="form-control form-control-sm" type="number" id="SearchAdder-first-bearing-${RAND_NUM}" min="0" max="359" value="0" size="3"/>`
-    },
-    { id: 'w', label: 'Width (across line)', input_html: `<input class="form-control form-control-sm" type="number" id="SearchAdder-width-${RAND_NUM}" min="0" size="4" />` }
-  ])
-
-  contents += [
-    `<div class="btn-group"><button class="btn btn-warning" id="SearchAdder-preview-${RAND_NUM}">Preview</button>`,
-    `<button class="btn btn-primary" id="SearchAdder-create-${RAND_NUM}">Create</button>`,
-    `<button class="btn btn-danger" id="SearchAdder-cancel-${RAND_NUM}">Cancel</button></div>`
-  ].join('')
-
-  const dialog = L.control.dialog({}).setContent(contents).addTo(map)
-  dialog.hideClose()
-
-  const changeSearchType = function () {
-    const selectedType = $(`#SearchAdder-search-type-${RAND_NUM}`).val()
-    const itElem = $(`#SearchAdder-i-${RAND_NUM}`)
-    const fbElem = $(`#SearchAdder-fb-${RAND_NUM}`)
-    const wdElem = $(`#SearchAdder-w-${RAND_NUM}`)
-    if (selectedType === 'expanding-box') {
-      itElem.show()
-      fbElem.show()
-    } else {
-      itElem.hide()
-      fbElem.hide()
-    }
-    if (selectedType === 'creeping-line' && objectType === 'line') {
-      wdElem.show()
-    } else {
-      wdElem.hide()
-    }
-  }
-
-  changeSearchType()
-
-  $(`#SearchAdder-search-type-${RAND_NUM}`).on('change', changeSearchType)
-
-  const getUrl = function () {
-    const selectedType = $(`#SearchAdder-search-type-${RAND_NUM}`).val()
-    switch (selectedType) {
-      case 'sector':
-        return '/search/sector/create/'
-      case 'expanding-box':
-        return '/search/expandingbox/create/'
-      case 'track-line':
-        return '/search/trackline/create/'
-      case 'shore-line':
-        return '/search/shoreline/create/'
-      case 'creeping-line':
-        return objectType === 'line' ? '/search/creepingline/create/track/' : '/search/creepingline/create/polygon/'
-      default:
-        console.log('search type not supported')
-    }
-  }
-
-  const getData = function () {
-    const data = {
-      sweep_width: $(`#SearchAdder-sweep-width-${RAND_NUM}`).val(),
-      asset_type_id: $(`#SearchAdder-asset-type-${RAND_NUM}`).val(),
-      iterations: $(`#SearchAdder-iterations-${RAND_NUM}`).val(),
-      first_bearing: $(`#SearchAdder-first-bearing-${RAND_NUM}`).val(),
-      width: $(`#SearchAdder-width-${RAND_NUM}`).val()
-    }
-    switch (objectType) {
-      case 'point':
-        data.poi_id = objectID
-        break
-      case 'line':
-        data.line_id = objectID
-        break
-      case 'polygon':
-        data.poly_id = objectID
-        break
-    }
-    return data
-  }
-
-  let onMap = null
-
-  $(`#SearchAdder-preview-${RAND_NUM}`).on('click', function () {
-    smmGetJSON(getUrl(), getData(), function (data) {
-      if (onMap !== null) {
-        onMap.remove()
-      }
-      onMap = L.geoJSON(data, { color: 'yellow' })
-      onMap.addTo(map)
-    })
-  })
-
-  $(`#SearchAdder-create-${RAND_NUM}`).on('click', function () {
-    if (onMap !== null) {
-      onMap.remove()
-    }
-    smmPost(getUrl(), getData())
-    dialog.destroy()
-  })
-
-  $(`#SearchAdder-cancel-${RAND_NUM}`).on('click', function () {
-    if (onMap !== null) {
-      onMap.remove()
-    }
-    dialog.destroy()
-  })
+  const container = document.createElement('div')
+  const dialog = L.control.dialog({}).setContent(container).addTo(map).hideClose()
+  const root = ReactDOM.createRoot(container)
+  root.render(
+    <SearchAdderDialog
+      map={map}
+      objectType={objectType}
+      objectID={objectID}
+      onClose={() => {
+        root.unmount()
+        dialog.destroy()
+      }}
+    />
+  )
 }

--- a/frontend/SearchAdder/SearchAdderDialog.tsx
+++ b/frontend/SearchAdder/SearchAdderDialog.tsx
@@ -1,0 +1,180 @@
+import React, { useEffect, useRef, useState } from 'react'
+import L from 'leaflet'
+
+import { smmGetJSON, smmPost } from '../ajax'
+
+type SearchType = 'sector' | 'expanding-box' | 'track-line' | 'shore-line' | 'creeping-line'
+
+interface AssetType {
+  id: number
+  name: string
+}
+
+interface Props {
+  map: L.Map
+  objectType: 'point' | 'line' | 'polygon'
+  objectID: number
+  onClose: () => void
+}
+
+function initialSearchType(objectType: Props['objectType']): SearchType {
+  if (objectType === 'point') return 'sector'
+  if (objectType === 'line') return 'track-line'
+  return 'creeping-line'
+}
+
+function getUrl(searchType: SearchType, objectType: Props['objectType']): string {
+  switch (searchType) {
+    case 'sector':
+      return '/search/sector/create/'
+    case 'expanding-box':
+      return '/search/expandingbox/create/'
+    case 'track-line':
+      return '/search/trackline/create/'
+    case 'shore-line':
+      return '/search/shoreline/create/'
+    case 'creeping-line':
+      return objectType === 'line' ? '/search/creepingline/create/track/' : '/search/creepingline/create/polygon/'
+  }
+}
+
+export function SearchAdderDialog({ map, objectType, objectID, onClose }: Props) {
+  const [searchType, setSearchType] = useState<SearchType>(initialSearchType(objectType))
+  const [assetTypes, setAssetTypes] = useState<AssetType[]>([])
+  const [sweepWidth, setSweepWidth] = useState('')
+  const [assetTypeId, setAssetTypeId] = useState('')
+  const [iterations, setIterations] = useState('')
+  const [firstBearing, setFirstBearing] = useState('0')
+  const [width, setWidth] = useState('')
+  const previewRef = useRef<L.GeoJSON | null>(null)
+
+  useEffect(() => {
+    smmGetJSON('/assets/assettypes/', function (data) {
+      const types: AssetType[] = []
+      for (const group of data as AssetType[][]) {
+        for (const assetType of group) {
+          types.push(assetType)
+        }
+      }
+      setAssetTypes(types)
+      if (types.length > 0) setAssetTypeId(String(types[0].id))
+    })
+    return () => {
+      previewRef.current?.remove()
+    }
+  }, [])
+
+  function getData() {
+    const data: Record<string, string | number> = {
+      sweep_width: sweepWidth,
+      asset_type_id: assetTypeId,
+      iterations,
+      first_bearing: firstBearing,
+      width
+    }
+    if (objectType === 'point') data.poi_id = objectID
+    else if (objectType === 'line') data.line_id = objectID
+    else data.poly_id = objectID
+    return data
+  }
+
+  function handlePreview() {
+    smmGetJSON(getUrl(searchType, objectType), getData(), function (data) {
+      previewRef.current?.remove()
+      previewRef.current = L.geoJSON(data as GeoJSON.GeoJsonObject, { color: 'yellow' }).addTo(map)
+    })
+  }
+
+  function handleCreate() {
+    previewRef.current?.remove()
+    smmPost(getUrl(searchType, objectType), getData())
+    onClose()
+  }
+
+  function handleCancel() {
+    previewRef.current?.remove()
+    onClose()
+  }
+
+  const showIterations = searchType === 'expanding-box'
+  const showWidth = searchType === 'creeping-line' && objectType === 'line'
+
+  return (
+    <div>
+      <div className="input-group input-group-sm mb-3">
+        <div className="input-group-prepend">
+          <span className="input-group-text">Search Type</span>
+        </div>
+        <select className="form-control" value={searchType} onChange={(e) => setSearchType(e.target.value as SearchType)}>
+          {objectType === 'point' && (
+            <>
+              <option value="sector">Sector</option>
+              <option value="expanding-box">Expanding Box</option>
+            </>
+          )}
+          {objectType === 'line' && (
+            <>
+              <option value="track-line">Track Line</option>
+              <option value="shore-line">Shore Line</option>
+              <option value="creeping-line">Creeping Line Ahead</option>
+            </>
+          )}
+          {objectType === 'polygon' && <option value="creeping-line">Creeping Line Ahead</option>}
+        </select>
+      </div>
+      <div className="input-group input-group-sm mb-3">
+        <div className="input-group-prepend">
+          <span className="input-group-text">Asset Type</span>
+        </div>
+        <select className="form-control" value={assetTypeId} onChange={(e) => setAssetTypeId(e.target.value)}>
+          {assetTypes.map((at) => (
+            <option key={at.id} value={at.id}>
+              {at.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="input-group input-group-sm mb-3">
+        <div className="input-group-prepend">
+          <span className="input-group-text">Sweep Width</span>
+        </div>
+        <input className="form-control form-control-sm" type="number" value={sweepWidth} onChange={(e) => setSweepWidth(e.target.value)} />
+      </div>
+      {showIterations && (
+        <div className="input-group input-group-sm mb-3">
+          <div className="input-group-prepend">
+            <span className="input-group-text">Iterations</span>
+          </div>
+          <input className="form-control form-control-sm" type="number" value={iterations} onChange={(e) => setIterations(e.target.value)} />
+        </div>
+      )}
+      {showIterations && (
+        <div className="input-group input-group-sm mb-3">
+          <div className="input-group-prepend">
+            <span className="input-group-text">First Bearing</span>
+          </div>
+          <input className="form-control form-control-sm" type="number" min={0} max={359} value={firstBearing} onChange={(e) => setFirstBearing(e.target.value)} />
+        </div>
+      )}
+      {showWidth && (
+        <div className="input-group input-group-sm mb-3">
+          <div className="input-group-prepend">
+            <span className="input-group-text">Width (across line)</span>
+          </div>
+          <input className="form-control form-control-sm" type="number" min={0} value={width} onChange={(e) => setWidth(e.target.value)} />
+        </div>
+      )}
+      <div className="btn-group">
+        <button className="btn btn-warning" onClick={handlePreview}>
+          Preview
+        </button>
+        <button className="btn btn-primary" onClick={handleCreate}>
+          Create
+        </button>
+        <button className="btn btn-danger" onClick={handleCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

Converts the dialogs that create geo objects to use react rather than jquery

## Summary by Sourcery

Convert map-based create dialogs for images, POIs, lines, polygons, and searches to React components mounted inside Leaflet dialogs.

New Features:
- Introduce React-based dialogs for creating search patterns tied to existing point, line, or polygon objects on the map.

Enhancements:
- Replace jQuery/imperative HTML image upload dialog with a React ImageUploaderDialog component integrated with the existing LatLngMarkerInput.
- Add React LineAdderDialog and PolygonAdderDialog components to create or replace user-defined lines and polygons with live map previews.
- Add a React POIAdderDialog component for creating or replacing POIs with label editing and position selection via LatLngMarkerInput.