### PR TITLE
Remove other jquery usage

### DIFF
--- a/frontend/Admin/admin.js
+++ b/frontend/Admin/admin.js
@@ -58,7 +58,7 @@ L.SMMAdmin.AssetCommand = function (map, missionId) {
       document.getElementById('assetcommanddialog').innerHTML = data
     })
   })
-  smmGet(`/mission/${missionId}/assets/command/set/`, function (data) {
+  smmGet(`/mission/${missionId}/assets/command/set/`, {}, function (data) {
     document.getElementById('assetcommanddialog').innerHTML = data
     document.getElementById('id_command').addEventListener('change', changeSelectedCommand)
   })

--- a/frontend/SearchAdder/SearchAdderDialog.tsx
+++ b/frontend/SearchAdder/SearchAdderDialog.tsx
@@ -50,12 +50,7 @@ export function SearchAdderDialog({ map, objectType, objectID, onClose }: Props)
 
   useEffect(() => {
     smmGetJSON('/assets/assettypes/', {}, function (data) {
-      const types: AssetType[] = []
-      for (const group of data as AssetType[][]) {
-        for (const assetType of group) {
-          types.push(assetType)
-        }
-      }
+      const types = (data as { asset_types: AssetType[] }).asset_types ?? []
       setAssetTypes(types)
       if (types.length > 0) setAssetTypeId(String(types[0].id))
     })

--- a/frontend/SearchAdder/SearchAdderDialog.tsx
+++ b/frontend/SearchAdder/SearchAdderDialog.tsx
@@ -49,7 +49,7 @@ export function SearchAdderDialog({ map, objectType, objectID, onClose }: Props)
   const previewRef = useRef<L.GeoJSON | null>(null)
 
   useEffect(() => {
-    smmGetJSON('/assets/assettypes/', function (data) {
+    smmGetJSON('/assets/assettypes/', {}, function (data) {
       const types: AssetType[] = []
       for (const group of data as AssetType[][]) {
         for (const assetType of group) {

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -1,5 +1,3 @@
-import $ from 'jquery'
-
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 
@@ -209,7 +207,7 @@ function mapInit() {
   wrapperEl.setAttribute('style', 'width:100%;height:100%;display:flex;flex-flow:column;')
   document.body.appendChild(wrapperEl)
 
-  const missionId = encodeURIComponent($('#missionId').val())
+  const missionId = encodeURIComponent((document.getElementById('missionId') as HTMLInputElement).value)
 
   if (missionId !== 'all' && missionId !== 'current') {
     const menuEl = document.createElement('div')

--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -16,7 +16,7 @@ export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: 
   const [selectedAssetId, setSelectedAssetId] = useState('')
 
   useEffect(() => {
-    smmGetJSON(`/mission/${missionId}/assets/`, (data) => {
+    smmGetJSON(`/mission/${missionId}/assets/`, {}, (data) => {
       const d = data as { assets: Array<MissionAssetData> }
       if ('assets' in d) {
         const filtered = d.assets.filter((a) => a.type_name === createdFor)

--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react'
+
+import { MissionAssetData } from '../asset/types'
+import { smmGetJSON, smmPost } from '../ajax'
+
+interface Props {
+  searchPk: number
+  missionId: number | string
+  createdFor: string
+  onClose: () => void
+}
+
+export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: Props) {
+  const [selectType, setSelectType] = useState<'type' | 'asset'>('type')
+  const [assets, setAssets] = useState<Array<{ id: number; name: string }>>([])
+  const [selectedAssetId, setSelectedAssetId] = useState('')
+
+  useEffect(() => {
+    smmGetJSON(`/mission/${missionId}/assets/`, (data) => {
+      const d = data as { assets: Array<MissionAssetData> }
+      if ('assets' in d) {
+        const filtered = d.assets.filter((a) => a.type_name === createdFor)
+        setAssets(filtered)
+        if (filtered.length > 0) setSelectedAssetId(String(filtered[0].id))
+      }
+    })
+  }, [])
+
+  function handleQueue() {
+    const data: { asset?: string } = {}
+    if (selectType === 'asset') data.asset = selectedAssetId
+    smmPost(`/search/${searchPk}/queue/`, data, onClose)
+  }
+
+  return (
+    <div>
+      <div>
+        Queue for{' '}
+        <select value={selectType} onChange={(e) => setSelectType(e.target.value as 'type' | 'asset')}>
+          <option value="type">Asset Type</option>
+          <option value="asset">Specific Asset</option>
+        </select>
+      </div>
+      {selectType === 'asset' && (
+        <div>
+          <select value={selectedAssetId} onChange={(e) => setSelectedAssetId(e.target.value)}>
+            {assets.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      <div>
+        <button className="btn btn-light" onClick={handleQueue}>
+          Queue
+        </button>
+        <button className="btn btn-danger" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -34,16 +34,21 @@ export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: 
 
   return (
     <div>
-      <div>
-        Queue for{' '}
-        <select value={selectType} onChange={(e) => setSelectType(e.target.value as 'type' | 'asset')}>
+      <div className="input-group input-group-sm mb-3">
+        <div className="input-group-prepend">
+          <span className="input-group-text">Queue for</span>
+        </div>
+        <select className="form-control" value={selectType} onChange={(e) => setSelectType(e.target.value as 'type' | 'asset')}>
           <option value="type">Asset Type</option>
           <option value="asset">Specific Asset</option>
         </select>
       </div>
       {selectType === 'asset' && (
-        <div>
-          <select value={selectedAssetId} onChange={(e) => setSelectedAssetId(e.target.value)}>
+        <div className="input-group input-group-sm mb-3">
+          <div className="input-group-prepend">
+            <span className="input-group-text">Asset</span>
+          </div>
+          <select className="form-control" value={selectedAssetId} onChange={(e) => setSelectedAssetId(e.target.value)}>
             {assets.map((a) => (
               <option key={a.id} value={a.id}>
                 {a.name}
@@ -52,7 +57,7 @@ export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: 
           </select>
         </div>
       )}
-      <div>
+      <div className="btn-group">
         <button className="btn btn-light" onClick={handleQueue}>
           Queue
         </button>

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -1,12 +1,13 @@
+import React from 'react'
+import * as ReactDOM from 'react-dom/client'
+
 import L from 'leaflet'
 import '@canterbury-air-patrol/leaflet-dialog'
 
-import $ from 'jquery'
-
 import { SMMRealtime } from '../smmmap'
-import { MissionAssetData } from '../asset/types'
 import { SMMSearchObjectDetailsData } from './types'
-import { smmGetJSON, smmPost, smmDelete } from '../ajax'
+import { smmDelete } from '../ajax'
+import { SearchQueueDialog } from './SearchQueueDialog'
 
 class SMMSearch {
   parent: SMMSearches
@@ -17,10 +18,7 @@ class SMMSearch {
     this.search = search
 
     this.deleteCallback = this.deleteCallback.bind(this)
-    this.searchQueueAssetListCallback = this.searchQueueAssetListCallback.bind(this)
-    this.searchQueueSubmit = this.searchQueueSubmit.bind(this)
     this.searchQueueDestroy = this.searchQueueDestroy.bind(this)
-    this.searchQueueUpdateSelectType = this.searchQueueUpdateSelectType.bind(this)
     this.searchQueueDialog = this.searchQueueDialog.bind(this)
   }
 
@@ -54,50 +52,26 @@ class SMMSearch {
     return dl
   }
 
-  searchQueueAssetListCallback(data: { assets: Array<MissionAssetData> }) {
-    if ('assets' in data) {
-      for (const asset of data.assets) {
-        if (asset.type_name === this.search.created_for) {
-          $(`#queue_${this.search.pk}_select_asset`).append(`<option value='${asset.id}'>${asset.name}</option>`)
-        }
-      }
-    }
-  }
-
   searchQueueDestroy() {
     this.QueueDialog.destroy()
     this.QueueDialog = undefined
   }
 
-  searchQueueSubmit() {
-    const data: { asset?: string } = {}
-    if ($(`#queue_${this.search.pk}_select_type`).val() === 'asset') {
-      data.asset = $(`#queue_${this.search.pk}_select_asset`).val() as string
-    }
-    smmPost(`/search/${this.search.pk}/queue/`, data, this.searchQueueDestroy)
-  }
-
-  searchQueueUpdateSelectType() {
-    if ($(`#queue_${this.search.pk}_select_type`).val() === 'type') {
-      $(`#queue_${this.search.pk}_select_asset`).hide()
-    } else {
-      $(`#queue_${this.search.pk}_select_asset`).show()
-    }
-  }
-
   searchQueueDialog() {
-    const contents = [
-      `<div>Queue for <select id='queue_${this.search.pk}_select_type'><option value='type'>Asset Type</option><option value='asset'>Specific Asset</option></select></div>`,
-      `<div><select id='queue_${this.search.pk}_select_asset'></select></div>`,
-      `<div><button class='btn btn-light' id='queue_${this.search.pk}_queue'>Queue</button></div>`,
-      `<div><button class='btn btn-danger' id='queue_${this.search.pk}_cancel'>Cancel</button>`
-    ].join('')
-    this.QueueDialog = L.control.dialog({ initOpen: true }).setContent(contents).addTo(this.parent.map).hideClose()
-    $(`#queue_${this.search.pk}_select_asset`).hide()
-    smmGetJSON(`/mission/${this.parent.missionId}/assets/`, {}, this.searchQueueAssetListCallback)
-    $(`#queue_${this.search.pk}_select_type`).on('change', this.searchQueueUpdateSelectType)
-    $(`#queue_${this.search.pk}_queue`).on('click', this.searchQueueSubmit)
-    $(`#queue_${this.search.pk}_cancel`).on('click', this.searchQueueDestroy)
+    const container = document.createElement('div')
+    this.QueueDialog = L.control.dialog({ initOpen: true }).setContent(container).addTo(this.parent.map).hideClose()
+    const root = ReactDOM.createRoot(container)
+    root.render(
+      <SearchQueueDialog
+        searchPk={this.search.pk}
+        missionId={this.parent.missionId}
+        createdFor={this.search.created_for as string}
+        onClose={() => {
+          root.unmount()
+          this.searchQueueDestroy()
+        }}
+      />
+    )
   }
 
   createPopup(layer: L.Layer) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search-management-map-map",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search-management-map-map",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@canterbury-air-patrol/deg-converter": "^0.2.0",
         "@canterbury-air-patrol/leaflet-dialog": "^1.2.1",
@@ -18,7 +18,6 @@
         "bootstrap": "^5.3.8",
         "esbuild": "^0.28.0",
         "esbuild-config": "^1.0.1",
-        "jquery": "^4.0.0",
         "leaflet": "^1.9.4",
         "leaflet-realtime": "^2.2.0",
         "leaflet.locatecontrol": "^0.90.0",
@@ -31,7 +30,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.28.0",
-        "@types/jquery": "^4.0.0",
         "@types/leaflet": "^1.9.21",
         "@types/react": "^19.2.14",
         "@types/react-color": "^3.0.13",
@@ -1143,13 +1141,6 @@
       "version": "7946.0.15",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.15.tgz",
       "integrity": "sha512-9oSxFzDCT2Rj6DfcHF8G++jxBKS7mBqXl5xrRW+Kbvjry6Uduya2iiwqHPhVXpasAVMBYKkEPGgKhd3+/HZ6xA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/jquery": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-4.0.0.tgz",
-      "integrity": "sha512-Z+to+A2VkaHq1DfI2oSwsoCdhCHMpTSgjWzNcbNlRGYzksDBpPUgEcAL+RQjOBJRaLoEAOHXxqDGBVP+BblBwg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3473,12 +3464,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/jquery": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
-      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "bootstrap": "^5.3.8",
     "esbuild": "^0.28.0",
     "esbuild-config": "^1.0.1",
-    "jquery": "^4.0.0",
     "leaflet": "^1.9.4",
     "leaflet-realtime": "^2.2.0",
     "leaflet.locatecontrol": "^0.90.0",
@@ -43,7 +42,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
-    "@types/jquery": "^4.0.0",
     "@types/leaflet": "^1.9.21",
     "@types/react": "^19.2.14",
     "@types/react-color": "^3.0.13",


### PR DESCRIPTION
## Description

Remove the remaining jquery usage from the frontend

## Summary by Sourcery

Remove remaining jQuery usage from the frontend map and related dialogs, replacing it with React components and vanilla DOM access while updating API calls accordingly.

New Features:
- Introduce a React-based SearchQueueDialog component for configuring and submitting search queue operations within the map dialog.

Bug Fixes:
- Align asset type and mission asset API response handling with the current backend response shape in search creation and admin asset command flows.

Enhancements:
- Refactor the search queue dialog on the map to render via React inside the Leaflet dialog instead of building and wiring HTML with jQuery.
- Replace jQuery-based DOM access for mission ID retrieval with standard DOM APIs in the map initialization code.
- Clean up frontend dependencies by removing jquery and its type definitions from the project.

Build:
- Remove jquery and @types/jquery from package.json dependencies and devDependencies.