### PR TITLE
Expand asset test coverage

### DIFF
--- a/assets/test_asset.py
+++ b/assets/test_asset.py
@@ -81,6 +81,16 @@ class AssetTestCase(TestCase):
         data = asset.as_object()
         self.assertEqual(data['icon_url'], f'/icons/{icon.pk}.png')
 
+    def test_asset_icon_url_asset_type_icon(self):
+        """
+        Asset.icon_url() falls back to asset_type icon when asset has no icon of its own
+        """
+        icon = Icon.objects.create(name='type_icon', filename='type.png')
+        asset_type = AssetType.objects.create(name='icontype2', description='', icon=icon)
+        asset = Asset.objects.create(name='TypeIconAsset', asset_type=asset_type,
+                                     owner=self.smm.user1, icon=None)
+        self.assertEqual(asset.icon_url(), f'/icons/{icon.pk}.png')
+
     def test_asset_mine_list(self):
         """
         Check the my assets list correctly reflects only assets the current user owns

--- a/assets/test_asset.py
+++ b/assets/test_asset.py
@@ -7,9 +7,10 @@ import json
 from django.test import TestCase
 from django.core import serializers
 
+from icons.models import Icon
 from smm.tests import SMMTestUsers
 
-from .models import Asset
+from .models import Asset, AssetType
 from .tests import AssetsHelpers
 
 
@@ -67,6 +68,18 @@ class AssetTestCase(TestCase):
         data = json.loads(serialised)
         self.assertFalse('pk' in data[0])
         self.assertEqual(data[0]['fields']['name'], 'PCCR')
+
+    def test_asset_icon_url_asset_icon(self):
+        """
+        Asset.icon_url() returns the asset's own icon URL when the asset has an icon set
+        """
+        icon = Icon.objects.create(name='boat_icon', filename='boat.png')
+        asset_type = self.assets.create_asset_type(at_name='icontype')
+        asset = Asset.objects.create(name='IconAsset', asset_type=asset_type,
+                                     owner=self.smm.user1, icon=icon)
+        self.assertEqual(asset.icon_url(), f'/icons/{icon.pk}.png')
+        data = asset.as_object()
+        self.assertEqual(data['icon_url'], f'/icons/{icon.pk}.png')
 
     def test_asset_mine_list(self):
         """

--- a/assets/test_asset_status.py
+++ b/assets/test_asset_status.py
@@ -86,6 +86,13 @@ class AssetStatusTestCase(AssetStatusBase):
         status_asset1 = AssetStatus.current_for_asset(asset=self.asset1)
         self.assertEqual(status2.pk, status_asset1.pk)
 
+    def test_0050_asset_status_str(self):
+        """
+        Check the string representation of AssetStatus
+        """
+        status = self.create_asset_status(asset=self.asset1, status=self.status_value1)
+        self.assertEqual(str(status), f'{self.asset1.name} is {self.status_value1.name}')
+
     def test_0100_check_asset_has_status(self):
         """
         Check that an asset reports its status when there is one set

--- a/assets/test_decorators.py
+++ b/assets/test_decorators.py
@@ -58,7 +58,7 @@ class AssetDecoratorsTestCase(TestCase):
         self.assertEqual(resp.status_code, 200)
 
     def test_asset_is_recorder_forbidden(self):
-        """Users without recorder permission receive 403."""
+        """Users without recorder permission receive 403; with permission, view is called."""
         asset = self._make_asset(owner=None)
 
         @asset_is_recorder
@@ -67,6 +67,9 @@ class AssetDecoratorsTestCase(TestCase):
 
         req = self.factory.get('/')
         req.user = self.smm.user1
+        with patch('assets.decorators.organization_user_is_asset_recorder', return_value=True):
+            resp = view(req, asset_id=asset.pk)
+        self.assertEqual(resp.status_code, 200)
         with patch('assets.decorators.organization_user_is_asset_recorder', return_value=False):
             resp = view(req, asset_id=asset.pk)
         self.assertEqual(resp.status_code, 403)

--- a/assets/test_decorators.py
+++ b/assets/test_decorators.py
@@ -1,0 +1,152 @@
+"""
+Tests for asset decorator functions.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase, RequestFactory
+from django.http import HttpResponse
+
+from smm.tests import SMMTestUsers
+
+from .models import Asset, AssetType
+from .decorators import (
+    asset_is_recorder,
+    asset_is_operator,
+    asset_is_owner,
+    asset_id_in_get_post,
+)
+
+
+class AssetDecoratorsTestCase(TestCase):
+    """Tests for the asset access-control decorators."""
+
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        self.factory = RequestFactory()
+        self.at = AssetType.objects.create(name='boat', description='b')
+
+    def _make_asset(self, owner=None):
+        return Asset.objects.create(name='A1', owner=owner, asset_type=self.at)
+
+    def test_asset_is_recorder_owner_allowed(self):
+        """Asset owner is allowed to record positions."""
+        asset = self._make_asset(owner=self.smm.user1)
+
+        @asset_is_recorder
+        def view(request, asset=None):
+            return HttpResponse(f'ok:{asset.name}')
+
+        req = self.factory.get('/')
+        req.user = self.smm.user1
+        resp = view(req, asset_id=asset.pk)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('A1', resp.content.decode())
+
+    def test_asset_is_recorder_org_allowed(self):
+        """Org-level recorder permission allows access."""
+        asset = self._make_asset(owner=None)
+
+        @asset_is_recorder
+        def view(request, asset=None):  # pylint: disable=unused-argument
+            return HttpResponse('ok')
+
+        req = self.factory.get('/')
+        req.user = self.smm.user1
+        with patch('assets.decorators.organization_user_is_asset_recorder', return_value=True):
+            resp = view(req, asset_id=asset.pk)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_asset_is_recorder_forbidden(self):
+        """Users without recorder permission receive 403."""
+        asset = self._make_asset(owner=None)
+
+        @asset_is_recorder
+        def view(request, asset=None):  # pylint: disable=unused-argument
+            return HttpResponse('ok')
+
+        req = self.factory.get('/')
+        req.user = self.smm.user1
+        with patch('assets.decorators.organization_user_is_asset_recorder', return_value=False):
+            resp = view(req, asset_id=asset.pk)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_asset_is_operator_org_allowed_and_forbidden(self):
+        """Org radio-operator permission allows access; absence returns 403."""
+        asset = self._make_asset(owner=None)
+
+        @asset_is_operator
+        def view(request, asset=None):  # pylint: disable=unused-argument
+            return HttpResponse('op')
+
+        req = self.factory.get('/')
+        req.user = self.smm.user1
+        # org operator allowed
+        with patch('assets.decorators.organization_user_is_asset_radio_operator', return_value=True):
+            resp = view(req, asset_id=asset.pk)
+        self.assertEqual(resp.status_code, 200)
+
+        # forbidden when not owner and not org operator
+        with patch('assets.decorators.organization_user_is_asset_radio_operator', return_value=False):
+            resp2 = view(req, asset_id=asset.pk)
+        self.assertEqual(resp2.status_code, 403)
+
+    def test_asset_is_owner(self):
+        """Asset owner is allowed; other users receive 403."""
+        asset = self._make_asset(owner=self.smm.user1)
+
+        @asset_is_owner
+        def view(request, asset=None):  # pylint: disable=unused-argument
+            return HttpResponse('owner')
+
+        req = self.factory.get('/')
+        req.user = self.smm.user1
+        resp = view(req, asset_id=asset.pk)
+        self.assertEqual(resp.status_code, 200)
+
+        # other user should be forbidden
+        req2 = self.factory.get('/')
+        req2.user = self.smm.user2
+        resp2 = view(req2, asset_id=asset.pk)
+        self.assertEqual(resp2.status_code, 403)
+
+    def test_asset_id_in_get_post_and_not_allowed(self):
+        """asset_id_in_get_post resolves asset from GET/POST and rejects other methods."""
+        asset = self._make_asset(owner=self.smm.user1)
+
+        @asset_id_in_get_post
+        def view(request, asset=None):
+            return HttpResponse(f'ok:{asset.name}')
+
+        # GET path
+        req = self.factory.get('/', data={'asset_id': asset.pk})
+        req.user = self.smm.user1
+        resp = view(req)
+        self.assertEqual(resp.status_code, 200)
+
+        # POST path
+        req2 = self.factory.post('/', data={'asset_id': asset.pk})
+        req2.user = self.smm.user1
+        resp2 = view(req2)
+        self.assertEqual(resp2.status_code, 200)
+
+        # not allowed method
+        req3 = self.factory.put('/')
+        req3.user = self.smm.user1
+        resp3 = view(req3)
+        # HttpResponseNotAllowed yields 405
+        self.assertEqual(resp3.status_code, 405)
+
+    def test_asset_id_in_get_post_forbidden(self):
+        """Users without operator permission receive 403."""
+        asset = self._make_asset(owner=None)
+
+        @asset_id_in_get_post
+        def view(request, asset=None):  # pylint: disable=unused-argument
+            return HttpResponse('ok')
+
+        req = self.factory.get('/', data={'asset_id': asset.pk})
+        req.user = self.smm.user1
+        with patch('assets.decorators.organization_user_is_asset_radio_operator', return_value=False):
+            resp = view(req)
+        self.assertEqual(resp.status_code, 403)

--- a/assets/test_decorators.py
+++ b/assets/test_decorators.py
@@ -141,7 +141,7 @@ class AssetDecoratorsTestCase(TestCase):
         self.assertEqual(resp3.status_code, 405)
 
     def test_asset_id_in_get_post_forbidden(self):
-        """Users without operator permission receive 403."""
+        """Users without operator permission receive 403; with permission, view is called."""
         asset = self._make_asset(owner=None)
 
         @asset_id_in_get_post
@@ -150,6 +150,9 @@ class AssetDecoratorsTestCase(TestCase):
 
         req = self.factory.get('/', data={'asset_id': asset.pk})
         req.user = self.smm.user1
+        with patch('assets.decorators.organization_user_is_asset_radio_operator', return_value=True):
+            resp = view(req)
+        self.assertEqual(resp.status_code, 200)
         with patch('assets.decorators.organization_user_is_asset_radio_operator', return_value=False):
             resp = view(req)
         self.assertEqual(resp.status_code, 403)

--- a/assets/tests.py
+++ b/assets/tests.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from smm.tests import SMMTestUsers
 
 from mission.models import Mission, MissionUser, MissionAsset
+from organization.models import Organization, OrganizationMember, OrganizationAsset
 
 from .models import AssetType, Asset
 
@@ -323,6 +324,24 @@ class AssetTestCase(TestCase):
         })
         self.assertEqual(response.status_code, 400)
         self.assertIn('errors', response.json())
+
+    def test_assets_all_includes_org_assets(self):
+        """
+        GET /assets/?all=True returns assets belonging to the user's organization
+        that the user does not personally own
+        """
+        org = Organization.objects.create(name='TestOrg', creator=self.smm.user1)
+        OrganizationMember.objects.create(
+            organization=org, user=self.smm.user1, added_by=self.smm.user1, role='A'
+        )
+        org_asset = self.assets.create_asset(name='org_asset', owner=self.smm.user2)
+        OrganizationAsset.objects.create(
+            organization=org, asset=org_asset, added_by=self.smm.user1
+        )
+        response = self.assets.get_my_asset_list(all_assets=True)
+        self.assertEqual(response.status_code, 200)
+        names = [a['name'] for a in response.json()['assets']]
+        self.assertIn('org_asset', names)
 
     def test_asset_command_set_form_error(self):
         """

--- a/assets/tests.py
+++ b/assets/tests.py
@@ -324,6 +324,17 @@ class AssetTestCase(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('errors', response.json())
 
+    def test_asset_command_set_form_error(self):
+        """
+        POST to AssetCommandSetView with invalid form data returns 400 with errors
+        """
+        asset = self.assets.create_asset()
+        self.add_asset_to_mission(asset=asset)
+        asset_set_command_url = f'/mission/{self.mission.pk}/assets/command/set/'
+        response = self.smm.client1.post(asset_set_command_url, {})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('errors', response.json())
+
     def test_asset_record_position_not_other(self):
         """
         Check only the owner of the asset can record the position


### PR DESCRIPTION
## Summary by Sourcery

Expand automated test coverage for asset-related functionality, including access control decorators, asset icon resolution, organization asset visibility, and error responses.

Tests:
- Add coverage to ensure the assets list endpoint with all=True includes organization assets not owned by the user.
- Add tests verifying Asset.icon_url() prioritizes an asset’s own icon and falls back to its asset_type icon.
- Add a test for the string representation of AssetStatus instances.
- Introduce a dedicated test suite for asset access-control decorators and asset_id_in_get_post behavior, covering allowed and forbidden access paths and HTTP method handling.