### PR TITLE
Move asset decorators from assets to organization.decorators

### DIFF
--- a/assets/decorators.py
+++ b/assets/decorators.py
@@ -1,78 +1,10 @@
 """
-Function decorators for assets
+Re-exports for backwards compatibility — decorators live in organization.decorators.
 """
 
-from django.shortcuts import get_object_or_404
-from django.http import HttpResponseForbidden, HttpResponseNotAllowed
-
-from organization.helpers import organization_user_is_asset_recorder, organization_user_is_asset_radio_operator
-
-from .models import Asset
-
-
-def asset_is_recorder(view_func):
-    """
-    Make sure the current user is allowed to record (positions) for this asset.
-    """
-    def recorder_check(*args, **kwargs):
-        allowed = False
-        asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
-        if asset.owner == args[0].user or organization_user_is_asset_recorder(args[0].user, asset):
-            allowed = True
-        if not allowed:
-            return HttpResponseForbidden("Not Authorized to record the position of this asset")
-        kwargs.pop('asset_id')
-        return view_func(*args, asset=asset, **kwargs)
-    return recorder_check
-
-
-def asset_is_operator(view_func):
-    """
-    Make sure the current user is allowed to act on behalf of this asset.
-    """
-    def recorder_check(*args, **kwargs):
-        allowed = False
-        asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
-        if asset.owner == args[0].user or organization_user_is_asset_radio_operator(args[0].user, asset):
-            allowed = True
-        if not allowed:
-            return HttpResponseForbidden("Not Authorized to record the position of this asset")
-        kwargs.pop('asset_id')
-        return view_func(*args, asset=asset, **kwargs)
-    return recorder_check
-
-
-def asset_is_owner(view_func):
-    """
-    Make sure the current user is the owner of this asset.
-    """
-    def asset_owner_check(*args, **kwargs):
-        asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
-        if asset.owner != args[0].user:
-            return HttpResponseForbidden("Not Authorized, this is not your asset")
-        kwargs.pop('asset_id')
-        return view_func(*args, asset=asset, **kwargs)
-    return asset_owner_check
-
-
-def asset_id_in_get_post(view_func):
-    """
-    Make sure the asset_id in the GET/POST is a valid asset and this user can act as them.
-    """
-    def asset_id_check(*args, **kwargs):
-        request = args[0]
-        if request.method == 'GET':
-            asset_id = request.GET.get('asset_id')
-        elif request.method == 'POST':
-            asset_id = request.POST.get('asset_id')
-        else:
-            return HttpResponseNotAllowed("Only GET and POST are supported")
-        asset = get_object_or_404(Asset, pk=asset_id)
-        allowed = False
-        if asset.owner == request.user or organization_user_is_asset_radio_operator(args[0].user, asset):
-            allowed = True
-        if not allowed:
-            return HttpResponseForbidden("Wrong User for Asset")
-
-        return view_func(*args, asset=asset, **kwargs)
-    return asset_id_check
+from organization.decorators import (  # noqa: F401
+    asset_is_recorder,
+    asset_is_operator,
+    asset_is_owner,
+    asset_id_in_get_post,
+)

--- a/assets/decorators.py
+++ b/assets/decorators.py
@@ -2,7 +2,7 @@
 Re-exports for backwards compatibility — decorators live in organization.decorators.
 """
 
-from organization.decorators import (  # noqa: F401
+from organization.decorators import (  # noqa: F401  # pylint: disable=unused-import
     asset_is_recorder,
     asset_is_operator,
     asset_is_owner,

--- a/assets/test_decorators.py
+++ b/assets/test_decorators.py
@@ -7,15 +7,15 @@ from unittest.mock import patch
 from django.test import TestCase, RequestFactory
 from django.http import HttpResponse
 
-from smm.tests import SMMTestUsers
-
-from .models import Asset, AssetType
 from organization.decorators import (
     asset_is_recorder,
     asset_is_operator,
     asset_is_owner,
     asset_id_in_get_post,
 )
+from smm.tests import SMMTestUsers
+
+from .models import Asset, AssetType
 
 
 class AssetDecoratorsTestCase(TestCase):

--- a/assets/test_decorators.py
+++ b/assets/test_decorators.py
@@ -10,7 +10,7 @@ from django.http import HttpResponse
 from smm.tests import SMMTestUsers
 
 from .models import Asset, AssetType
-from .decorators import (
+from organization.decorators import (
     asset_is_recorder,
     asset_is_operator,
     asset_is_owner,
@@ -53,7 +53,7 @@ class AssetDecoratorsTestCase(TestCase):
 
         req = self.factory.get('/')
         req.user = self.smm.user1
-        with patch('assets.decorators.organization_user_is_asset_recorder', return_value=True):
+        with patch('organization.decorators.organization_user_is_asset_recorder', return_value=True):
             resp = view(req, asset_id=asset.pk)
         self.assertEqual(resp.status_code, 200)
 
@@ -67,10 +67,10 @@ class AssetDecoratorsTestCase(TestCase):
 
         req = self.factory.get('/')
         req.user = self.smm.user1
-        with patch('assets.decorators.organization_user_is_asset_recorder', return_value=True):
+        with patch('organization.decorators.organization_user_is_asset_recorder', return_value=True):
             resp = view(req, asset_id=asset.pk)
         self.assertEqual(resp.status_code, 200)
-        with patch('assets.decorators.organization_user_is_asset_recorder', return_value=False):
+        with patch('organization.decorators.organization_user_is_asset_recorder', return_value=False):
             resp = view(req, asset_id=asset.pk)
         self.assertEqual(resp.status_code, 403)
 
@@ -85,12 +85,12 @@ class AssetDecoratorsTestCase(TestCase):
         req = self.factory.get('/')
         req.user = self.smm.user1
         # org operator allowed
-        with patch('assets.decorators.organization_user_is_asset_radio_operator', return_value=True):
+        with patch('organization.decorators.organization_user_is_asset_radio_operator', return_value=True):
             resp = view(req, asset_id=asset.pk)
         self.assertEqual(resp.status_code, 200)
 
         # forbidden when not owner and not org operator
-        with patch('assets.decorators.organization_user_is_asset_radio_operator', return_value=False):
+        with patch('organization.decorators.organization_user_is_asset_radio_operator', return_value=False):
             resp2 = view(req, asset_id=asset.pk)
         self.assertEqual(resp2.status_code, 403)
 
@@ -150,9 +150,9 @@ class AssetDecoratorsTestCase(TestCase):
 
         req = self.factory.get('/', data={'asset_id': asset.pk})
         req.user = self.smm.user1
-        with patch('assets.decorators.organization_user_is_asset_radio_operator', return_value=True):
+        with patch('organization.decorators.organization_user_is_asset_radio_operator', return_value=True):
             resp = view(req)
         self.assertEqual(resp.status_code, 200)
-        with patch('assets.decorators.organization_user_is_asset_radio_operator', return_value=False):
+        with patch('organization.decorators.organization_user_is_asset_radio_operator', return_value=False):
             resp = view(req)
         self.assertEqual(resp.status_code, 403)

--- a/assets/views.py
+++ b/assets/views.py
@@ -18,7 +18,7 @@ from organization.models import OrganizationAsset, OrganizationMember
 from search.models import Search
 from search.view_helpers import check_searches_in_progress
 
-from .decorators import asset_is_operator
+from organization.decorators import asset_is_operator
 from .models import AssetType, Asset, AssetStatusValue, AssetStatus
 from .forms import AssetCommandForm
 

--- a/assets/views.py
+++ b/assets/views.py
@@ -12,13 +12,11 @@ from django.views import View
 from mission.decorators import mission_is_member, mission_asset_get
 from mission.models import AssetCommand, MissionAsset
 
+from organization.decorators import asset_is_operator
 from organization.helpers import organization_user_is_asset_recorder
-
 from organization.models import OrganizationAsset, OrganizationMember
 from search.models import Search
 from search.view_helpers import check_searches_in_progress
-
-from organization.decorators import asset_is_operator
 from .models import AssetType, Asset, AssetStatusValue, AssetStatus
 from .forms import AssetCommandForm
 

--- a/data/views.py
+++ b/data/views.py
@@ -22,7 +22,7 @@ from django.views import View
 
 from smm.settings import TIME_ZONE
 from assets.models import Asset
-from assets.decorators import asset_is_recorder
+from organization.decorators import asset_is_recorder
 from mission.decorators import mission_is_member, mission_asset_get
 from mission.models import Mission, AssetCommand
 from .decorators import geotimelabel_from_type_id, geotimelabel_from_id, data_get_mission_id

--- a/mission/views.py
+++ b/mission/views.py
@@ -15,7 +15,7 @@ from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from assets.models import Asset
-from assets.decorators import asset_is_operator
+from organization.decorators import asset_is_operator
 from mission.helpers import get_my_assets_not_in_mission
 from organization.decorators import get_organization_from_id
 from organization.models import Organization, OrganizationMember, OrganizationAsset

--- a/mission/views.py
+++ b/mission/views.py
@@ -15,9 +15,8 @@ from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from assets.models import Asset
-from organization.decorators import asset_is_operator
 from mission.helpers import get_my_assets_not_in_mission
-from organization.decorators import get_organization_from_id
+from organization.decorators import asset_is_operator, get_organization_from_id
 from organization.models import Organization, OrganizationMember, OrganizationAsset
 from timeline.models import TimeLineEntry
 from timeline.helpers import timeline_record_create, \

--- a/organization/decorators.py
+++ b/organization/decorators.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from django.contrib.auth import get_user_model
 from django.http import HttpResponseForbidden, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404
@@ -71,72 +73,70 @@ def get_target_user(view_func):
     return wrapper_get_target_user
 
 
+def user_can_operate_asset(user, asset):
+    return asset.owner == user or organization_user_is_asset_radio_operator(user, asset)
+
+
+def asset_permission_required(check_fn, error_message):
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapper(request, *args, **kwargs):
+            asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
+            if not check_fn(request.user, asset):
+                return HttpResponseForbidden(error_message)
+            kwargs.pop('asset_id')
+            return view_func(request, *args, asset=asset, **kwargs)
+        return wrapper
+    return decorator
+
+
 def asset_is_recorder(view_func):
     """
     Make sure the current user is allowed to record (positions) for this asset.
     """
-    def recorder_check(*args, **kwargs):
-        allowed = False
-        asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
-        if asset.owner == args[0].user or organization_user_is_asset_recorder(args[0].user, asset):
-            allowed = True
-        if not allowed:
-            return HttpResponseForbidden("Not Authorized to record the position of this asset")
-        kwargs.pop('asset_id')
-        return view_func(*args, asset=asset, **kwargs)
-    return recorder_check
+    return asset_permission_required(
+        lambda user, asset: asset.owner == user or organization_user_is_asset_recorder(user, asset),
+        "Not Authorized to record the position of this asset",
+    )(view_func)
 
 
 def asset_is_operator(view_func):
     """
     Make sure the current user is allowed to act on behalf of this asset.
     """
-    def recorder_check(*args, **kwargs):
-        allowed = False
-        asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
-        if asset.owner == args[0].user or organization_user_is_asset_radio_operator(args[0].user, asset):
-            allowed = True
-        if not allowed:
-            return HttpResponseForbidden("Not Authorized to record the position of this asset")
-        kwargs.pop('asset_id')
-        return view_func(*args, asset=asset, **kwargs)
-    return recorder_check
+    return asset_permission_required(
+        user_can_operate_asset,
+        "Not Authorized to act on behalf of this asset",
+    )(view_func)
 
 
 def asset_is_owner(view_func):
     """
     Make sure the current user is the owner of this asset.
     """
-    def asset_owner_check(*args, **kwargs):
-        asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
-        if asset.owner != args[0].user:
-            return HttpResponseForbidden("Not Authorized, this is not your asset")
-        kwargs.pop('asset_id')
-        return view_func(*args, asset=asset, **kwargs)
-    return asset_owner_check
+    return asset_permission_required(
+        lambda user, asset: asset.owner == user,
+        "Not Authorized, this is not your asset",
+    )(view_func)
 
 
 def asset_id_in_get_post(view_func):
     """
     Make sure the asset_id in the GET/POST is a valid asset and this user can act as them.
     """
-    def asset_id_check(*args, **kwargs):
-        request = args[0]
+    @wraps(view_func)
+    def wrapper(request, *args, **kwargs):
         if request.method == 'GET':
             asset_id = request.GET.get('asset_id')
         elif request.method == 'POST':
             asset_id = request.POST.get('asset_id')
         else:
-            return HttpResponseNotAllowed("Only GET and POST are supported")
+            return HttpResponseNotAllowed(['GET', 'POST'])
         asset = get_object_or_404(Asset, pk=asset_id)
-        allowed = False
-        if asset.owner == request.user or organization_user_is_asset_radio_operator(args[0].user, asset):
-            allowed = True
-        if not allowed:
+        if not user_can_operate_asset(request.user, asset):
             return HttpResponseForbidden("Wrong User for Asset")
-
-        return view_func(*args, asset=asset, **kwargs)
-    return asset_id_check
+        return view_func(request, *args, asset=asset, **kwargs)
+    return wrapper
 
 
 def get_organization_from_id(view_func):

--- a/organization/decorators.py
+++ b/organization/decorators.py
@@ -1,7 +1,10 @@
 from django.contrib.auth import get_user_model
-from django.http import HttpResponseForbidden
+from django.http import HttpResponseForbidden, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404
 
+from assets.models import Asset
+
+from .helpers import organization_user_is_asset_recorder, organization_user_is_asset_radio_operator
 from .models import Organization, OrganizationMember
 
 
@@ -66,6 +69,74 @@ def get_target_user(view_func):
         kwargs.pop('username')
         return view_func(*args, target_user=target_user, **kwargs)
     return wrapper_get_target_user
+
+
+def asset_is_recorder(view_func):
+    """
+    Make sure the current user is allowed to record (positions) for this asset.
+    """
+    def recorder_check(*args, **kwargs):
+        allowed = False
+        asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
+        if asset.owner == args[0].user or organization_user_is_asset_recorder(args[0].user, asset):
+            allowed = True
+        if not allowed:
+            return HttpResponseForbidden("Not Authorized to record the position of this asset")
+        kwargs.pop('asset_id')
+        return view_func(*args, asset=asset, **kwargs)
+    return recorder_check
+
+
+def asset_is_operator(view_func):
+    """
+    Make sure the current user is allowed to act on behalf of this asset.
+    """
+    def recorder_check(*args, **kwargs):
+        allowed = False
+        asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
+        if asset.owner == args[0].user or organization_user_is_asset_radio_operator(args[0].user, asset):
+            allowed = True
+        if not allowed:
+            return HttpResponseForbidden("Not Authorized to record the position of this asset")
+        kwargs.pop('asset_id')
+        return view_func(*args, asset=asset, **kwargs)
+    return recorder_check
+
+
+def asset_is_owner(view_func):
+    """
+    Make sure the current user is the owner of this asset.
+    """
+    def asset_owner_check(*args, **kwargs):
+        asset = get_object_or_404(Asset, pk=kwargs['asset_id'])
+        if asset.owner != args[0].user:
+            return HttpResponseForbidden("Not Authorized, this is not your asset")
+        kwargs.pop('asset_id')
+        return view_func(*args, asset=asset, **kwargs)
+    return asset_owner_check
+
+
+def asset_id_in_get_post(view_func):
+    """
+    Make sure the asset_id in the GET/POST is a valid asset and this user can act as them.
+    """
+    def asset_id_check(*args, **kwargs):
+        request = args[0]
+        if request.method == 'GET':
+            asset_id = request.GET.get('asset_id')
+        elif request.method == 'POST':
+            asset_id = request.POST.get('asset_id')
+        else:
+            return HttpResponseNotAllowed("Only GET and POST are supported")
+        asset = get_object_or_404(Asset, pk=asset_id)
+        allowed = False
+        if asset.owner == request.user or organization_user_is_asset_radio_operator(args[0].user, asset):
+            allowed = True
+        if not allowed:
+            return HttpResponseForbidden("Wrong User for Asset")
+
+        return view_func(*args, asset=asset, **kwargs)
+    return asset_id_check
 
 
 def get_organization_from_id(view_func):

--- a/organization/views.py
+++ b/organization/views.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views import View
 
-from assets.decorators import asset_is_owner
+from .decorators import asset_is_owner
 
 from .models import Organization, OrganizationMember, OrganizationAsset
 from .decorators import organization_is_admin, organization_assets_admin, organization_is_radio_operator, get_target_user

--- a/search/views.py
+++ b/search/views.py
@@ -21,7 +21,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 
 from assets.models import AssetType, Asset
-from assets.decorators import asset_id_in_get_post
+from organization.decorators import asset_id_in_get_post
 from data.decorators import data_get_mission_id
 from data.models import GeoTimeLabel
 from data.view_helpers import to_kml, to_geojson


### PR DESCRIPTION
## Description

The four asset access-control decorators (asset_is_recorder, asset_is_operator, asset_is_owner, asset_id_in_get_post) belong in organization since their logic depends on org-role helpers. This breaks the assets → organization import in assets/decorators.py.

assets/decorators.py is kept as a re-export shim for now.

## Summary by Sourcery

Move asset access-control decorators into the organization app and update code to use the new location.

Enhancements:
- Centralize asset access-control decorators in organization.decorators to align them with organization role helpers and avoid cross-app imports.

Tests:
- Update asset decorator tests to import decorators and organization role helpers from organization.decorators.