### PR TITLE
Improve test coverage of data view helpers

### DIFF
--- a/data/test_view_helpers.py
+++ b/data/test_view_helpers.py
@@ -1,0 +1,157 @@
+"""
+Tests for data view helpers
+"""
+
+from django.contrib.gis.geos import Point
+from django.test import TestCase, RequestFactory
+from django.http import HttpResponse
+
+from mission.models import Mission
+from smm.tests import SMMTestUsers
+
+from .view_helpers import to_geojson, to_kml, geotimelabel_replace, point_label_make, user_polygon_make, user_line_make
+from .models import GeoTimeLabel
+
+
+class ViewHelpersTestCase(TestCase):
+    """Tests for the data view helper functions."""
+
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        self.factory = RequestFactory()
+        # create a mission for objects
+        self.mission = Mission.objects.create(mission_name='m', creator=self.smm.user1)
+
+    def test_to_geojson_and_kml(self):
+        """to_geojson and to_kml return correct content types and include label data."""
+        # create a simple GeoTimeLabel
+        ptl = GeoTimeLabel.objects.create(geo=Point(174.0, -41.0), label='here', created_by=self.smm.user1, mission=self.mission, geo_type='poi')
+
+        # geojson
+        resp = to_geojson(GeoTimeLabel, [ptl])
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp['Content-Type'], 'application/geo+json')
+        self.assertIn('here', resp.content.decode('utf-8'))
+
+        # kml
+        resp2 = to_kml(GeoTimeLabel, [ptl])
+        self.assertEqual(resp2.status_code, 200)
+        self.assertEqual(resp2['Content-Type'], 'application/vnd.google-earth.kml+xml')
+        self.assertIn('<kml', resp2.content.decode('utf-8'))
+
+    def test_geotimelabel_replace_checks(self):
+        """geotimelabel_replace returns 404 for deleted or replaced objects."""
+        # make an object and mark deleted
+        ptl = GeoTimeLabel.objects.create(geo=Point(174.0, -41.0), label='x', created_by=self.smm.user1, mission=self.mission, geo_type='poi')
+        ptl.deleted_at = ptl.created_at
+        ptl.deleted_by = self.smm.user1
+        ptl.save()
+
+        resp = geotimelabel_replace(None, 'POI', ptl, self.mission, lambda r, mission=None, replaces=None: None)
+        self.assertEqual(resp.status_code, 404)
+
+        # now mark replaced
+        ptl2 = GeoTimeLabel.objects.create(geo=Point(174.1, -41.1), label='y', created_by=self.smm.user1, mission=self.mission, geo_type='poi')
+        ptl2.replaced_by = ptl
+        ptl2.save()
+        resp2 = geotimelabel_replace(None, 'POI', ptl2, self.mission, lambda r, mission=None, replaces=None: None)
+        self.assertEqual(resp2.status_code, 404)
+
+    def test_point_label_make_missing_and_create(self):
+        """point_label_make returns 400 on missing params and 200 on valid POST."""
+        # missing params should return bad request
+        req = self.factory.get('/')
+        req.user = self.smm.user1
+        resp = point_label_make(req, mission=self.mission)
+        self.assertEqual(resp.status_code, 400)
+
+        # valid post should create and return geojson
+        req2 = self.factory.post('/', data={'lat': '-41.0', 'lon': '174.0', 'label': 'created'})
+        req2.user = self.smm.user1
+        resp2 = point_label_make(req2, mission=self.mission)
+        self.assertEqual(resp2.status_code, 200)
+        self.assertIn('created', resp2.content.decode('utf-8'))
+
+    def test_user_polygon_and_line_make(self):  # pylint: disable=too-many-locals
+        """user_polygon_make and user_line_make handle GET rejection, creation, and replace failure."""
+        # polygon should reject non-POST
+        req = self.factory.get('/')
+        req.user = self.smm.user1
+        resp = user_polygon_make(req, mission=self.mission)
+        self.assertEqual(resp.status_code, 400)
+
+        # valid polygon create
+        data = {
+            'label': 'poly',
+            'points': '3',
+            'point0_lat': '-41.0', 'point0_lng': '174.0',
+            'point1_lat': '-41.1', 'point1_lng': '174.1',
+            'point2_lat': '-41.2', 'point2_lng': '174.2',
+        }
+        req2 = self.factory.post('/', data=data)
+        req2.user = self.smm.user1
+        resp2 = user_polygon_make(req2, mission=self.mission)
+        self.assertEqual(resp2.status_code, 200)
+        self.assertIn('poly', resp2.content.decode('utf-8'))
+
+        # replace failure should delete and return bad request
+        class Dummy:  # pylint: disable=too-few-public-methods
+            """Stub replaceable object whose replace() always fails."""
+
+            def replace(self, _obj):
+                """Always report replacement failure."""
+                return False
+
+        req3 = self.factory.post('/', data=data)
+        req3.user = self.smm.user1
+        resp3 = user_polygon_make(req3, mission=self.mission, replaces=Dummy())
+        self.assertEqual(resp3.status_code, 400)
+
+        # line should reject non-POST
+        resp_line = user_line_make(self.factory.get('/'), mission=self.mission)
+        self.assertEqual(resp_line.status_code, 400)
+
+        # valid line create
+        data_line = {
+            'label': 'line',
+            'points': '2',
+            'point0_lat': '-41.0', 'point0_lng': '174.0',
+            'point1_lat': '-41.1', 'point1_lng': '174.1',
+        }
+        reql = self.factory.post('/', data=data_line)
+        reql.user = self.smm.user1
+        resp_l = user_line_make(reql, mission=self.mission)
+        self.assertEqual(resp_l.status_code, 200)
+        self.assertIn('line', resp_l.content.decode('utf-8'))
+
+        # replace failure for line
+        reql2 = self.factory.post('/', data=data_line)
+        reql2.user = self.smm.user1
+        resp_l2 = user_line_make(reql2, mission=self.mission, replaces=Dummy())
+        self.assertEqual(resp_l2.status_code, 400)
+
+    def test_geotimelabel_replace_success(self):
+        """geotimelabel_replace calls the provided function when the object is live."""
+        ptl = GeoTimeLabel.objects.create(geo=Point(174.2, -41.2), label='ok', created_by=self.smm.user1, mission=self.mission, geo_type='poi')
+
+        def myfunc(_r, mission=None, replaces=None):  # pylint: disable=unused-argument
+            return HttpResponse('ok')
+        req = self.factory.get('/')
+        req.user = self.smm.user1
+        resp = geotimelabel_replace(req, 'POI', ptl, self.mission, myfunc)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('ok', resp.content.decode('utf-8'))
+
+    def test_point_label_make_replace_failure(self):
+        """point_label_make returns 400 and cleans up when replace() fails."""
+        # replace failure should delete created point and return 400
+        class DummyReplace:  # pylint: disable=too-few-public-methods
+            """Stub replaceable object whose replace() always fails."""
+
+            def replace(self, _obj):
+                """Always report replacement failure."""
+                return False
+        req = self.factory.post('/', data={'lat': '-41.3', 'lon': '174.3', 'label': 'pt'})
+        req.user = self.smm.user1
+        resp = point_label_make(req, mission=self.mission, replaces=DummyReplace())
+        self.assertEqual(resp.status_code, 400)

--- a/search/test_views_additional.py
+++ b/search/test_views_additional.py
@@ -1,0 +1,107 @@
+"""
+Tests for additional search view logic not covered by the main test suite.
+"""
+
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+from django.utils import timezone
+
+from smm.tests import SMMTestUsers
+from assets.tests import AssetsHelpers
+from mission.tests import MissionFunctions
+from data.models import GeoTimeLabel
+
+from .models import Search, SearchParams
+from .views import check_search_state
+
+
+class SearchViewsAdditionalTest(TestCase):
+    """Tests for check_search_state and find_next_search view helpers."""
+
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        self.assets = AssetsHelpers(self.smm)
+        self.missions = MissionFunctions(self.smm)
+        self.asset_type = self.assets.create_asset_type()
+        self.asset1 = self.assets.create_asset(asset_type=self.asset_type)
+        self.asset2 = self.assets.create_asset(asset_type=self.asset_type)
+        self.mission = self.missions.create_mission('test mission')
+        self.mission.add_asset(self.asset1)
+        self.mission.add_asset(self.asset2)
+
+    def create_poi(self, lat, long, user=None, mission=None):
+        """Create a GeoTimeLabel POI at the given coordinates."""
+        if user is None:
+            user = self.smm.user1
+        if mission is None:
+            mission = self.mission
+        return GeoTimeLabel.objects.create(geo=Point(long, lat), created_by=user, label='t', geo_type='poi', mission=mission.get_object())
+
+    def test_check_search_state_deleted(self):
+        """Deleted search returns 403."""
+        poi = self.create_poi(-43.5, 172.5)
+        search = Search.create_sector_search(SearchParams(poi, self.asset_type, self.smm.user1, 100), save=True)
+        # deleted
+        search.deleted_at = timezone.now()
+        resp = check_search_state(search, 'begin', self.asset1)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_check_search_state_replaced(self):
+        """Replaced search returns 404."""
+        poi = self.create_poi(-43.5, 172.5)
+        search = Search.create_sector_search(SearchParams(poi, self.asset_type, self.smm.user1, 100), save=True)
+        # mark as replaced (attribute access is sufficient for the check)
+        search.replaced_by = object()
+        resp = check_search_state(search, 'begin', self.asset1)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_check_search_state_completed(self):
+        """Completed search cannot be begun again; returns 403."""
+        poi = self.create_poi(-43.5, 172.5)
+        search = Search.create_sector_search(SearchParams(poi, self.asset_type, self.smm.user1, 100), save=True)
+        search.completed_at = timezone.now()
+        resp = check_search_state(search, 'begin', self.asset1)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_check_search_state_begin_conflict(self):
+        """Beginning a search already in progress by another asset returns 403."""
+        poi = self.create_poi(-43.5, 172.5)
+        search = Search.create_sector_search(SearchParams(poi, self.asset_type, self.smm.user1, 100), save=True)
+        # someone else has it in progress
+        search.inprogress_by = self.asset2
+        resp = check_search_state(search, 'begin', self.asset1)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_check_search_state_delete_inprogress(self):
+        """Deleting a search that is in progress returns 403."""
+        poi = self.create_poi(-43.5, 172.5)
+        search = Search.create_sector_search(SearchParams(poi, self.asset_type, self.smm.user1, 100), save=True)
+        search.inprogress_by = self.asset2
+        resp = check_search_state(search, 'delete', None)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_check_search_state_complete_not_inprogress(self):
+        """Completing a search that is not in progress returns 403."""
+        poi = self.create_poi(-43.5, 172.5)
+        search = Search.create_sector_search(SearchParams(poi, self.asset_type, self.smm.user1, 100), save=True)
+        # not in progress -> cannot complete
+        resp = check_search_state(search, 'complete', self.asset1)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_find_next_search_no_search_and_invalid_lat(self):
+        """find_next_search returns 404 when no searches exist and 400 for invalid coords."""
+        # no searches exist -> should return 404
+        response = self.smm.client1.get('/search/find/closest/', data={
+            'latitude': -43.5,
+            'longitude': 172.5,
+            'asset_id': self.asset1.pk,
+        })
+        self.assertEqual(response.status_code, 404)
+
+        # invalid latitude -> 400
+        response = self.smm.client1.get('/search/find/closest/', data={
+            'latitude': 'not-a-number',
+            'longitude': 172.5,
+            'asset_id': self.asset1.pk,
+        })
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
## Summary by Sourcery

Add additional automated tests to improve coverage of data and search view helper behaviours.

Tests:
- Add tests for data view helper functions covering GeoJSON/KML responses, validation errors, replacement handling, and cleanup on failure.
- Add tests for search view helpers covering search state validation and closest-search lookup edge cases, including deleted, replaced, completed, and invalid coordinate scenarios.