### PR TITLE
Move AssetCommandSetView from assets to mission

### DIFF
--- a/assets/urls.py
+++ b/assets/urls.py
@@ -14,5 +14,4 @@ urlpatterns = [
     re_path(r'^assets/(?P<asset_id>\d+)/status/$', views.AssetStatusView.as_view(), name='assets_status'),
     re_path(r'^assets/(?P<asset_id>\d+)/command/$', views.AssetCommandView.as_view(), name='assets_command'),
     re_path(r'^assets/status/values/$', views.assets_status_value_list, name='asset_status_values_list'),
-    re_path(r'^mission/(?P<mission_id>\d+)/assets/command/set/$', views.AssetCommandSetView.as_view(), name='asset_command_set'),
 ]

--- a/assets/views.py
+++ b/assets/views.py
@@ -3,15 +3,13 @@ Views for assets
 """
 from django.http import JsonResponse
 from django.contrib.auth.decorators import login_required
-from django.contrib.gis.geos import Point
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views import View
 
-from mission.decorators import mission_is_member, mission_asset_get
-from mission.forms import AssetCommandForm
-from mission.models import AssetCommand, MissionAsset
+from mission.decorators import mission_asset_get
+from mission.models import AssetCommand
 
 from organization.decorators import asset_is_operator, asset_is_recorder
 from search.models import Search
@@ -25,50 +23,6 @@ def assets_status_value_list(request):
     List all of the asset status values
     """
     return JsonResponse({'values': [v.as_object() for v in AssetStatusValue.objects.all()]})
-
-
-@method_decorator(login_required, name='dispatch')
-@method_decorator(mission_is_member, name='dispatch')
-class AssetCommandSetView(View):
-    """
-    JSON API for reading form data and setting an asset command for a mission.
-    """
-
-    def get(self, request, mission_user):
-        """
-        Return the available assets, command choices, and which commands require a position.
-        """
-        mission_assets = MissionAsset.objects.filter(
-            mission=mission_user.mission, removed__isnull=True
-        ).select_related('asset')
-        return JsonResponse({
-            'assets': [{'id': ma.asset.pk, 'name': ma.asset.name} for ma in mission_assets],
-            'commands': [{'value': v, 'label': l} for v, l in AssetCommand.COMMAND_CHOICES],
-            'requires_position': list(AssetCommand.REQUIRES_POSITION),
-        })
-
-    def post(self, request, mission_user):
-        """
-        Validate and create an AssetCommand; returns JSON status or field errors.
-        """
-        form = AssetCommandForm(request.POST, mission=mission_user.mission)
-        if not form.is_valid():
-            return JsonResponse({'errors': form.errors}, status=400)
-        point = None
-        if form.cleaned_data['command'] in AssetCommand.REQUIRES_POSITION:
-            try:
-                point = Point(float(request.POST.get('longitude')), float(request.POST.get('latitude')))
-            except (ValueError, TypeError):
-                return JsonResponse({'errors': {'position': ['Invalid lat/long']}}, status=400)
-        AssetCommand(
-            asset=form.cleaned_data['asset'],
-            command=form.cleaned_data['command'],
-            issued_by=request.user,
-            reason=form.cleaned_data['reason'],
-            position=point,
-            mission=mission_user.mission,
-        ).save()
-        return JsonResponse({'status': 'Created'})
 
 
 @method_decorator(login_required, name="dispatch")

--- a/mission/urls.py
+++ b/mission/urls.py
@@ -25,4 +25,5 @@ urlpatterns = [
     re_path(r'^mission/list/$', views.mission_list_data, name='mission_list_data'),
     re_path(r'^mission/asset/status/values/$', views.MissionAssetStatusValuesView.as_view()),
     re_path(r'^$', views.mission_list, name='mission_list'),
+    re_path(r'^mission/(?P<mission_id>\d+)/assets/command/set/$', views.AssetCommandSetView.as_view(), name='asset_command_set'),
 ]

--- a/mission/views.py
+++ b/mission/views.py
@@ -2,6 +2,7 @@
 Mission Create/Management Views.
 """
 
+from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import get_user_model
@@ -26,7 +27,7 @@ from timeline.helpers import timeline_record_create, \
     timeline_record_mission_asset_add, timeline_record_mission_asset_remove, timeline_record_mission_asset_status
 
 from .models import Mission, MissionExternalReference, MissionUser, MissionAsset, MissionAssetType, MissionOrganization, MissionAssetStatus, MissionAssetStatusValue, AssetCommand
-from .forms import MissionForm, MissionUserForm, MissionAssetForm, MissionOrganizationForm
+from .forms import AssetCommandForm, MissionForm, MissionUserForm, MissionAssetForm, MissionOrganizationForm
 from .decorators import get_user_from_id, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin
 
 
@@ -721,3 +722,47 @@ class MissionExternalReferenceView(View):
         extref.save()
         timeline_record_external_reference_remove(mission=mission_user.mission, user=mission_user.user, external_reference=extref)
         return HttpResponse("Done")
+
+
+@method_decorator(login_required, name='dispatch')
+@method_decorator(mission_is_member, name='dispatch')
+class AssetCommandSetView(View):
+    """
+    JSON API for reading form data and setting an asset command for a mission.
+    """
+
+    def get(self, request, mission_user):
+        """
+        Return the available assets, command choices, and which commands require a position.
+        """
+        mission_assets = MissionAsset.objects.filter(
+            mission=mission_user.mission, removed__isnull=True
+        ).select_related('asset')
+        return JsonResponse({
+            'assets': [{'id': ma.asset.pk, 'name': ma.asset.name} for ma in mission_assets],
+            'commands': [{'value': v, 'label': l} for v, l in AssetCommand.COMMAND_CHOICES],
+            'requires_position': list(AssetCommand.REQUIRES_POSITION),
+        })
+
+    def post(self, request, mission_user):
+        """
+        Validate and create an AssetCommand; returns JSON status or field errors.
+        """
+        form = AssetCommandForm(request.POST, mission=mission_user.mission)
+        if not form.is_valid():
+            return JsonResponse({'errors': form.errors}, status=400)
+        point = None
+        if form.cleaned_data['command'] in AssetCommand.REQUIRES_POSITION:
+            try:
+                point = Point(float(request.POST.get('longitude')), float(request.POST.get('latitude')))
+            except (ValueError, TypeError):
+                return JsonResponse({'errors': {'position': ['Invalid lat/long']}}, status=400)
+        AssetCommand(
+            asset=form.cleaned_data['asset'],
+            command=form.cleaned_data['command'],
+            issued_by=request.user,
+            reason=form.cleaned_data['reason'],
+            position=point,
+            mission=mission_user.mission,
+        ).save()
+        return JsonResponse({'status': 'Created'})


### PR DESCRIPTION
## Description

The command-set endpoint is a mission feature; it uses mission_is_member, AssetCommand, MissionAsset, and AssetCommandForm. Moving it to mission/views.py and mission/urls.py (keeping name='asset_command_set') removes mission_is_member, MissionAsset, AssetCommandForm, and Point from assets/views.py imports.

## Summary by Sourcery

Move the asset command-set API view into the mission app to align it with mission-specific logic and routing.

Enhancements:
- Relocate AssetCommandSetView from the assets app to the mission app without changing its behavior.
- Update URL routing so the asset command-set endpoint is registered under mission URLs instead of assets URLs.