### PR TITLE
Move AssetCommandView from assets to mission

### DIFF
--- a/assets/urls.py
+++ b/assets/urls.py
@@ -12,6 +12,5 @@ urlpatterns = [
     re_path(r'^assets/$', views.AssetsView.as_view(), name='assets_view'),
     re_path(r'^assets/(?P<asset_id>\d+)/$', views.AssetView.as_view(), name='asset_view'),
     re_path(r'^assets/(?P<asset_id>\d+)/status/$', views.AssetStatusView.as_view(), name='assets_status'),
-    re_path(r'^assets/(?P<asset_id>\d+)/command/$', views.AssetCommandView.as_view(), name='assets_command'),
     re_path(r'^assets/status/values/$', views.assets_status_value_list, name='asset_status_values_list'),
 ]

--- a/assets/views.py
+++ b/assets/views.py
@@ -4,7 +4,6 @@ Views for assets
 from django.http import JsonResponse
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, render
-from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views import View
 
@@ -110,45 +109,6 @@ class AssetsView(View):
         if "application/json" in request.META.get('HTTP_ACCEPT', ''):
             return self.as_json(request)
         return render(request, 'assets/list.html', {})
-
-
-@method_decorator(login_required, name="dispatch")
-@method_decorator(asset_is_operator, name="dispatch")
-class AssetCommandView(View):
-    """
-    View the current asset command
-    """
-    def as_json(self, request, asset):
-        """
-        Return the current asset command as json
-        """
-        asset_command = AssetCommand.last_command_for_asset_to_json(asset)
-        data = {
-            'command': asset_command,
-        }
-        return JsonResponse(data)
-
-    def get(self, request, asset):
-        """
-        Get the current asset command
-        """
-        return self.as_json(request, asset)
-
-    def post(self, request, asset):
-        """
-        Allow setting the asset command response
-        """
-        command_id = request.POST.get('command_id')
-        asset_command = get_object_or_404(AssetCommand, pk=command_id, asset=asset)
-        type_str = request.POST.get('type')
-        message = request.POST.get('message')
-        if asset_command.responded_at is None:
-            asset_command.responded_at = timezone.now()
-            asset_command.responded_by = request.user
-            asset_command.response_message = message
-            asset_command.response_type = type_str
-            asset_command.save()
-        return self.as_json(request, asset)
 
 
 @method_decorator(login_required, name='dispatch')

--- a/mission/urls.py
+++ b/mission/urls.py
@@ -26,4 +26,5 @@ urlpatterns = [
     re_path(r'^mission/asset/status/values/$', views.MissionAssetStatusValuesView.as_view()),
     re_path(r'^$', views.mission_list, name='mission_list'),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/command/set/$', views.AssetCommandSetView.as_view(), name='asset_command_set'),
+    re_path(r'^assets/(?P<asset_id>\d+)/command/$', views.AssetCommandView.as_view(), name='assets_command'),
 ]

--- a/mission/views.py
+++ b/mission/views.py
@@ -766,3 +766,39 @@ class AssetCommandSetView(View):
             mission=mission_user.mission,
         ).save()
         return JsonResponse({'status': 'Created'})
+
+
+@method_decorator(login_required, name="dispatch")
+@method_decorator(asset_is_operator, name="dispatch")
+class AssetCommandView(View):
+    """
+    View the current asset command
+    """
+    def as_json(self, request, asset):
+        """
+        Return the current asset command as json
+        """
+        asset_command = AssetCommand.last_command_for_asset_to_json(asset)
+        return JsonResponse({'command': asset_command})
+
+    def get(self, request, asset):
+        """
+        Get the current asset command
+        """
+        return self.as_json(request, asset)
+
+    def post(self, request, asset):
+        """
+        Allow setting the asset command response
+        """
+        command_id = request.POST.get('command_id')
+        asset_command = get_object_or_404(AssetCommand, pk=command_id, asset=asset)
+        type_str = request.POST.get('type')
+        message = request.POST.get('message')
+        if asset_command.responded_at is None:
+            asset_command.responded_at = timezone.now()
+            asset_command.responded_by = request.user
+            asset_command.response_message = message
+            asset_command.response_type = type_str
+            asset_command.save()
+        return self.as_json(request, asset)


### PR DESCRIPTION
## Description

AssetCommandView reads and writes AssetCommand records — a mission concern. Move it to mission/views.py and its URL to mission/urls.py (keeping name='assets_command'). Remove the now-unused timezone import from assets/views.py.

## Summary by Sourcery

Move the AssetCommandView from the assets app to the mission app and update routing accordingly.

Enhancements:
- Relocate AssetCommandView to mission/views.py to align asset command handling with mission concerns.

Chores:
- Update URL configuration so the asset command endpoint is now registered under mission/urls.py while preserving its public path and name.