### PR TITLE
Update @canterbury-air-patrol dependencies and handle deg-converter API changes

### DIFF
--- a/frontend/LatLngMarkerInput.tsx
+++ b/frontend/LatLngMarkerInput.tsx
@@ -10,8 +10,8 @@ interface Props {
 }
 
 export function LatLngMarkerInput({ map, initialPos, showLabels = true, onChange }: Props) {
-  const [latText, setLatText] = useState(degreesToDM(initialPos.lat, true))
-  const [lngText, setLngText] = useState(degreesToDM(initialPos.lng, false))
+  const [latText, setLatText] = useState(degreesToDM(initialPos.lat, 'lat'))
+  const [lngText, setLngText] = useState(degreesToDM(initialPos.lng, 'lon'))
   const markerRef = useRef<L.Marker | null>(null)
 
   useEffect(() => {
@@ -19,8 +19,8 @@ export function LatLngMarkerInput({ map, initialPos, showLabels = true, onChange
     markerRef.current = marker
     marker.on('dragend', () => {
       const pos = marker.getLatLng()
-      setLatText(degreesToDM(pos.lat, true))
-      setLngText(degreesToDM(pos.lng, false))
+      setLatText(degreesToDM(pos.lat, 'lat'))
+      setLngText(degreesToDM(pos.lng, 'lon'))
       onChange?.(pos)
     })
     return () => {

--- a/frontend/asset/AssetPopup.tsx
+++ b/frontend/asset/AssetPopup.tsx
@@ -14,8 +14,8 @@ interface Props {
 export function AssetPopup({ assetName, coords, alt, heading, fix, status }: Props) {
   const items = [
     { label: 'Asset', value: assetName },
-    { label: 'Lat', value: degreesToDM(coords[1], true) },
-    { label: 'Long', value: degreesToDM(coords[0], false) }
+    { label: 'Lat', value: degreesToDM(coords[1], 'lat') },
+    { label: 'Long', value: degreesToDM(coords[0], 'lon') }
   ]
   if (alt) {
     items.push({ label: 'Altitude', value: alt.toString() })

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -122,8 +122,8 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
         </thead>
         <tbody>
           <tr>
-            <td>{degreesToDM(this.state.latitude, true)}</td>
-            <td>{degreesToDM(this.state.longitude, false)}</td>
+            <td>{degreesToDM(this.state.latitude, 'lat')}</td>
+            <td>{degreesToDM(this.state.longitude, 'lon')}</td>
             <td>{this.state.altitude}</td>
           </tr>
           <tr>
@@ -233,10 +233,10 @@ class AssetCommandView extends React.Component<AssetCommandViewProps, AssetComma
       gotoRow.push(
         <tr key="goto_pos">
           <td>
-            <b>{this.props.lastCommand.latitude ? degreesToDM(this.props.lastCommand.latitude, true) : ''}</b>
+            <b>{this.props.lastCommand.latitude ? degreesToDM(this.props.lastCommand.latitude, 'lat') : ''}</b>
           </td>
           <td>
-            <b>{this.props.lastCommand.longitude ? degreesToDM(this.props.lastCommand.longitude, false) : ''}</b>
+            <b>{this.props.lastCommand.longitude ? degreesToDM(this.props.lastCommand.longitude, 'lon') : ''}</b>
           </td>
           <td></td>
         </tr>

--- a/frontend/geometry/details.tsx
+++ b/frontend/geometry/details.tsx
@@ -41,8 +41,8 @@ class GeometryPoints extends React.Component<GeometryPointsProps, never> {
 
     const tableRows = points.map((point, index) => (
       <tr key={index}>
-        <td>{degreesToDM(point.lng, false)}</td>
-        <td>{degreesToDM(point.lat, true)}</td>
+        <td>{degreesToDM(point.lng, 'lon')}</td>
+        <td>{degreesToDM(point.lat, 'lat')}</td>
       </tr>
     ))
     return (

--- a/frontend/image/ImagePopup.tsx
+++ b/frontend/image/ImagePopup.tsx
@@ -15,8 +15,8 @@ interface Props {
 export function ImagePopup({ description, pk, coords, priority, missionId, onPrioritize, onDeprioritize }: Props) {
   const items = [
     { label: 'Image', value: description },
-    { label: 'Lat', value: degreesToDM(coords[1], true) },
-    { label: 'Long', value: degreesToDM(coords[0], false) }
+    { label: 'Lat', value: degreesToDM(coords[1], 'lat') },
+    { label: 'Long', value: degreesToDM(coords[0], 'lon') }
   ]
   const buttons =
     missionId !== 'current' && missionId !== 'all'

--- a/frontend/search/details.tsx
+++ b/frontend/search/details.tsx
@@ -126,7 +126,7 @@ interface SearchDetailsPageProps {
 
 interface SearchDetailsPageState {
   data?: SMMSearchObjectDetailsData
-  search?: object
+  search?: SearchPattern
   geometry?: {
     type: string
     coordinates: [number, number] | [number, number][] | [number, number][][]

--- a/frontend/user/UserPopup.tsx
+++ b/frontend/user/UserPopup.tsx
@@ -14,8 +14,8 @@ export function UserPopup({ userName, coords, alt }: Props) {
   }
   const items = [
     { label: 'User', value: userName },
-    { label: 'Lat', value: degreesToDM(coords[1], true) },
-    { label: 'Long', value: degreesToDM(coords[0], false) }
+    { label: 'Lat', value: degreesToDM(coords[1], 'lat') },
+    { label: 'Long', value: degreesToDM(coords[0], 'lon') }
   ]
   if (alt) {
     items.push({ label: 'Altitude', value: alt.toString() })

--- a/frontend/usergeo/POIPopup.tsx
+++ b/frontend/usergeo/POIPopup.tsx
@@ -16,8 +16,8 @@ interface Props {
 export function POIPopup({ label, coords, pk, missionId, onEdit, onDelete, onCreateSearch, onCalculateTDV }: Props) {
   const items = [
     { label: 'POI', value: label },
-    { label: 'Lat', value: degreesToDM(coords[1], true) },
-    { label: 'Long', value: degreesToDM(coords[0], false) }
+    { label: 'Lat', value: degreesToDM(coords[1], 'lat') },
+    { label: 'Long', value: degreesToDM(coords[0], 'lon') }
   ]
   const buttons: ButtonItem[] =
     missionId !== 'current' && missionId !== 'all'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "search-management-map-map",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search-management-map-map",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
-        "@canterbury-air-patrol/deg-converter": "^0.2.0",
+        "@canterbury-air-patrol/deg-converter": "^0.3.0",
         "@canterbury-air-patrol/leaflet-dialog": "^1.2.1",
-        "@canterbury-air-patrol/marine-leeway-data": "^0.2.1",
+        "@canterbury-air-patrol/marine-leeway-data": "^0.2.2",
         "@canterbury-air-patrol/marine-search-area-coverage": "^0.6.2",
-        "@canterbury-air-patrol/marine-total-drift-vector": "^0.4.1",
-        "@canterbury-air-patrol/sar-search-patterns": "0.1.3",
-        "@canterbury-air-patrol/sar-search-runner": "0.1.2",
+        "@canterbury-air-patrol/marine-total-drift-vector": "^0.4.2",
+        "@canterbury-air-patrol/sar-search-patterns": "0.1.4",
+        "@canterbury-air-patrol/sar-search-runner": "0.1.3",
         "bootstrap": "^5.3.8",
         "esbuild": "^0.28.0",
         "esbuild-config": "^1.0.1",
@@ -42,8 +42,8 @@
         "typescript-eslint": "^8.59.3"
       },
       "peerDependencies": {
-        "react": "19.0.0",
-        "react-dom": "19.0.0"
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@canterbury-air-patrol/deg-converter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/deg-converter/-/deg-converter-0.2.0.tgz",
-      "integrity": "sha512-yGEya6smb1RszuoXmG77q4Zh3HsW3AxZBo7fNQt73cxt+Gbvs2N2DwL+ua0ClyrNjQCF1QqpcDV7GX7vBvkikg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/deg-converter/-/deg-converter-0.3.0.tgz",
+      "integrity": "sha512-97fAfJ2X0SxTkbHg2NJbEoRYY2ur4x9kIBTSJajJwCYQsKb4KGibqKWnPGtE0O+hCn3pLGX6IJECIU5/cXjFnQ==",
       "license": "MIT"
     },
     "node_modules/@canterbury-air-patrol/leaflet-dialog": {
@@ -80,9 +80,9 @@
       "license": "MIT"
     },
     "node_modules/@canterbury-air-patrol/marine-leeway-data": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/marine-leeway-data/-/marine-leeway-data-0.2.1.tgz",
-      "integrity": "sha512-kNTLBINSHGU26lEJIJuEiLArmEdSeOpXxsXWAJwvmqzBh59PpNXHc+9uB+e9Ysp3F4Vchftwzo2V4kWQxU8ktA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/marine-leeway-data/-/marine-leeway-data-0.2.2.tgz",
+      "integrity": "sha512-op7uG57VZIH5kw/pV/9jgL221CpUVvCnE8+kcQVcRIixF7x4if2lP5wBZvxZHvC5VZVVz+GWdFMmCuhGdkyrqg==",
       "license": "PDDL-1.0"
     },
     "node_modules/@canterbury-air-patrol/marine-search-area-coverage": {
@@ -114,9 +114,9 @@
       "license": "PDDL-1.0"
     },
     "node_modules/@canterbury-air-patrol/marine-total-drift-vector": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/marine-total-drift-vector/-/marine-total-drift-vector-0.4.1.tgz",
-      "integrity": "sha512-GQZNuOeh87iyHZmNpRkMcpF3daL9YvY1remSPdgAYuZCuSTwf/xjcpFzSRITkSjVNGg6UrsBzjyyKKLbMhrg+Q==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/marine-total-drift-vector/-/marine-total-drift-vector-0.4.2.tgz",
+      "integrity": "sha512-Cg19yQLDWg/y7q5wtE2khMkZHyx/cP0b2q+3PC1fxGNlrSPuw1T8x6mXIC+yTIMzcWvPTy9opjCNsIbm7PiWSA==",
       "license": "MIT",
       "dependencies": {
         "@canterbury-air-patrol/deg-converter": "^0.2.0",
@@ -126,217 +126,23 @@
         "bootstrap": "~5.3.0",
         "http-server": "~14.1.1",
         "react-bootstrap": "~2.10.0",
-        "react-datetime-picker": "^6.0.1"
+        "react-datetime-picker": "^7.0.1"
       },
       "peerDependencies": {
-        "react": "~19.0.0",
-        "react-dom": "~19.0.0"
+        "react": "~19.2.0",
+        "react-dom": "~19.2.0"
       }
     },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/@wojtekmaj/date-utils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
-      "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
-      }
-    },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/detect-element-overflow": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/detect-element-overflow/-/detect-element-overflow-1.4.2.tgz",
-      "integrity": "sha512-4m6cVOtvm/GJLjo7WFkPfwXoEIIbM7GQwIh4WEa4g7IsNi1YzwUsGL5ApNLrrHL29bHeNeQ+/iZhw+YHqgE2Fw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/wojtekmaj/detect-element-overflow?sponsor=1"
-      }
-    },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/get-user-locale": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
-      "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mem": "^8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
-      }
-    },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/make-event-props": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.6.2.tgz",
-      "integrity": "sha512-iDwf7mA03WPiR8QxvcVHmVWEPfMY1RZXerDVNCRYW7dUr2ppH3J58Rwb39/WG39yTZdRSxr3x+2v22tvI0VEvA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
-      }
-    },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/react-calendar": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-5.1.0.tgz",
-      "integrity": "sha512-09o/rQHPZGEi658IXAJtWfra1N69D1eFnuJ3FQm9qUVzlzNnos1+GWgGiUeSs22QOpNm32aoVFOimq0p3Ug9Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wojtekmaj/date-utils": "^1.1.3",
-        "clsx": "^2.0.0",
-        "get-user-locale": "^2.2.1",
-        "warning": "^4.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/react-clock": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-clock/-/react-clock-5.1.0.tgz",
-      "integrity": "sha512-DKmr29VOK6M8wpbzGUZZa9PwGnG9uC6QXtDLwGwcc2r3vdS/HxNhf5xMMjudXLk7m096mNJQf7AgfjiDpzAYYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wojtekmaj/date-utils": "^1.5.0",
-        "clsx": "^2.0.0",
-        "get-user-locale": "^2.2.1"
-      },
-      "funding": {
-        "url": "https://github.com/wojtekmaj/react-clock?sponsor=1"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/react-date-picker": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/react-date-picker/-/react-date-picker-11.0.0.tgz",
-      "integrity": "sha512-l+siu5HSZ/ciGL1293KCAHl4o9aD5rw16V4tB0C43h7QbMv2dWGgj7Dxgt8iztLaPVtEfOt/+sxNiTYw4WVq6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@wojtekmaj/date-utils": "^1.1.3",
-        "clsx": "^2.0.0",
-        "get-user-locale": "^2.2.1",
-        "make-event-props": "^1.6.0",
-        "react-calendar": "^5.0.0",
-        "react-fit": "^2.0.0",
-        "update-input-width": "^1.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/wojtekmaj/react-date-picker?sponsor=1"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/react-datetime-picker": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/react-datetime-picker/-/react-datetime-picker-6.0.1.tgz",
-      "integrity": "sha512-G7W8bK0SLuO66RVWYGD2q1bD4Wk4pUOpJCq9r44A4P33uq0aAtd3dT1HNEu2fvlmMpYxC4J571ZPI9bUG46pDA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wojtekmaj/date-utils": "^1.1.3",
-        "clsx": "^2.0.0",
-        "get-user-locale": "^2.2.1",
-        "make-event-props": "^1.6.0",
-        "react-calendar": "^5.0.0",
-        "react-clock": "^5.0.0",
-        "react-date-picker": "^11.0.0",
-        "react-fit": "^2.0.0",
-        "react-time-picker": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/wojtekmaj/react-datetime-picker?sponsor=1"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/react-fit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-fit/-/react-fit-2.0.1.tgz",
-      "integrity": "sha512-Eip6ALs/+6Jv82Si0I9UnfysdwVlAhkkZRycgmMdnj7jwUg69SVFp84ICxwB8zszkfvJJ2MGAAo9KAYM8ZUykQ==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-element-overflow": "^1.4.0",
-        "warning": "^4.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/wojtekmaj/react-fit?sponsor=1"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/react-time-picker": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-time-picker/-/react-time-picker-7.0.0.tgz",
-      "integrity": "sha512-k6mUjkI+OsY73mg0yjMxqkLXv/UXR1LN7AARNqfyGZOwqHqo1JrjL3lLHTHWQ86HmPTBL/dZACbIX/fV1NLmWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wojtekmaj/date-utils": "^1.1.3",
-        "clsx": "^2.0.0",
-        "get-user-locale": "^2.2.1",
-        "make-event-props": "^1.6.0",
-        "react-clock": "^5.0.0",
-        "react-fit": "^2.0.0",
-        "update-input-width": "^1.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/wojtekmaj/react-time-picker?sponsor=1"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
+    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/@canterbury-air-patrol/deg-converter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/deg-converter/-/deg-converter-0.2.0.tgz",
+      "integrity": "sha512-yGEya6smb1RszuoXmG77q4Zh3HsW3AxZBo7fNQt73cxt+Gbvs2N2DwL+ua0ClyrNjQCF1QqpcDV7GX7vBvkikg==",
+      "license": "MIT"
     },
     "node_modules/@canterbury-air-patrol/sar-search-patterns": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/sar-search-patterns/-/sar-search-patterns-0.1.3.tgz",
-      "integrity": "sha512-upUczKGZ6nC39yRYM2VXLZkE/Xlqf1MjzSjhRVZCgE0+h1X/AUejrZJ9nPi+V2YVEia8ekB/Hmq9BOwfP2HrKQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/sar-search-patterns/-/sar-search-patterns-0.1.4.tgz",
+      "integrity": "sha512-smSfSM9xCPuiNLDdwlAbher7Ille7Qmh0aPMzrF4u3/zH8UEbC6inQAqaU3cEAUPKJK2IaEWR39jMIv8W1oeMw==",
       "license": "MIT",
       "dependencies": {
         "bootstrap": "~5.3.1",
@@ -347,13 +153,13 @@
       }
     },
     "node_modules/@canterbury-air-patrol/sar-search-runner": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/sar-search-runner/-/sar-search-runner-0.1.2.tgz",
-      "integrity": "sha512-sG0hLyhlk/+TOKWVIgS8+Scx/CHnC9iiyTy4fJjBZspI+GsgM7yy2onywwO+09S4XCAEHQcI5oQBNXNV9zVQSg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/sar-search-runner/-/sar-search-runner-0.1.3.tgz",
+      "integrity": "sha512-oGZp4DS39aylHhWikjy9UEEtt6ExzCCvV4LGkprOjo/yYYNENs1ALRa9fshF3ABL2FobYQEh3WA03JcIndHd4A==",
       "license": "MIT",
       "dependencies": {
-        "@canterbury-air-patrol/sar-search-patterns": "0.1.3",
-        "@canterbury-air-patrol/speed-time-distance": "0.1.2",
+        "@canterbury-air-patrol/sar-search-patterns": "0.1.4",
+        "@canterbury-air-patrol/speed-time-distance": "0.1.3",
         "bootstrap": "~5.3.1",
         "react-bootstrap": "~2.10.0"
       },
@@ -362,9 +168,9 @@
       }
     },
     "node_modules/@canterbury-air-patrol/speed-time-distance": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/speed-time-distance/-/speed-time-distance-0.1.2.tgz",
-      "integrity": "sha512-NaW6+fc85KJwpM3cywGZWdrxbZSC1QEkSm4xnfEHzakm89oU7vsimgKP7Gjc2pOci+1zm1LX6g4wk3+PreXYfg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/speed-time-distance/-/speed-time-distance-0.1.3.tgz",
+      "integrity": "sha512-dIEQEQsAh+kwxBY4guJGdZUC/ZjuFxgA673Mk0nPH2URcrMlHi7lOrO/y+i39ESp7x3ygTNYOx434qVS1Ap99Q==",
       "license": "MIT",
       "dependencies": {
         "bootstrap": "~5.3.1",
@@ -3622,18 +3428,6 @@
         "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
       }
     },
-    "node_modules/map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-defer": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
@@ -3647,22 +3441,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/mem": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
-      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
-      "license": "MIT",
-      "dependencies": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/mem?sponsor=1"
       }
     },
     "node_modules/memoize": {
@@ -3690,15 +3468,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/mimic-function": {
@@ -3899,15 +3668,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4092,9 +3852,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -4268,16 +4028,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "scheduler": "^0.25.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-fit": {
@@ -4534,9 +4294,9 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
   "license": "",
   "description": "",
   "dependencies": {
-    "@canterbury-air-patrol/deg-converter": "^0.2.0",
+    "@canterbury-air-patrol/deg-converter": "^0.3.0",
     "@canterbury-air-patrol/leaflet-dialog": "^1.2.1",
-    "@canterbury-air-patrol/marine-leeway-data": "^0.2.1",
+    "@canterbury-air-patrol/marine-leeway-data": "^0.2.2",
     "@canterbury-air-patrol/marine-search-area-coverage": "^0.6.2",
-    "@canterbury-air-patrol/marine-total-drift-vector": "^0.4.1",
-    "@canterbury-air-patrol/sar-search-patterns": "0.1.3",
-    "@canterbury-air-patrol/sar-search-runner": "0.1.2",
+    "@canterbury-air-patrol/marine-total-drift-vector": "^0.4.2",
+    "@canterbury-air-patrol/sar-search-patterns": "0.1.4",
+    "@canterbury-air-patrol/sar-search-runner": "0.1.3",
     "bootstrap": "^5.3.8",
     "esbuild": "^0.28.0",
     "esbuild-config": "^1.0.1",
@@ -37,8 +37,8 @@
     "universal-cookie": "^8.1.2"
   },
   "peerDependencies": {
-    "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",


### PR DESCRIPTION
## Description

Updates @canterbury-air-patrol packages to their latest versions, including:
- deg-converter 0.2.0 -> 0.3.0
- marine-leeway-data 0.2.1 -> 0.2.2
- marine-total-drift-vector 0.4.1 -> 0.4.2
- sar-search-patterns 0.1.3 -> 0.1.4
- sar-search-runner 0.1.2 -> 0.1.3

Also updates react and react-dom to ^19.2.0 to satisfy peer dependency requirements.

Refactors degreesToDM calls to use 'lat'/'lon' strings instead of booleans, and fixes a type error in search details.

## Summary by Sourcery

Update @canterbury-air-patrol dependencies and align coordinate formatting with the latest deg-converter API.

Bug Fixes:
- Fix SearchDetailsPage state typing by using the concrete SearchPattern type for the search field.

Enhancements:
- Switch all degreesToDM usage to the new 'lat'/'lon' string arguments required by the updated deg-converter package.

Build:
- Bump @canterbury-air-patrol deg-converter, marine-leeway-data, marine-total-drift-vector, sar-search-patterns, and sar-search-runner dependencies to their latest patch versions.
- Relax react and react-dom peer dependency versions to ^19.2.0 to satisfy updated peer requirements.