### PR TITLE
Move AssetView from assets to mission to eliminate assets → mission/search imports

### DIFF
--- a/assets/tests.py
+++ b/assets/tests.py
@@ -185,7 +185,10 @@ class AssetTestCase(TestCase):
         asset_name = 'test_asset'
         asset = self.assets.create_asset(name=asset_name, asset_type=asset_type)
         asset_details_url = f'/assets/{asset.pk}/'
+        asset_mission_url = f'/assets/{asset.pk}/mission/'
         mission_asset = self.add_asset_to_mission(asset=asset)
+
+        # Pure asset data comes from the asset endpoint
         response = self.smm.client1.get(asset_details_url, HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)
         json_data = response.json()
@@ -193,31 +196,33 @@ class AssetTestCase(TestCase):
         self.assertEqual(json_data['name'], asset_name)
         self.assertEqual(json_data['asset_type'], asset_type.name)
         self.assertEqual(json_data['owner'], asset.owner.username)
+
+        # Mission/search context comes from the mission endpoint
+        response = self.smm.client1.get(asset_mission_url, HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
+        json_data = response.json()
         self.assertEqual(json_data['mission_id'], mission_asset.mission.id)
         self.assertEqual(json_data['mission_name'], mission_asset.mission.mission_name)
 
         # Create a search and check this doesn't automatically queue it
         search_id = self.create_search(asset=asset, client=self.smm.client1)
-        response = self.smm.client1.get(asset_details_url, HTTP_ACCEPT='application/json')
+        response = self.smm.client1.get(asset_mission_url, HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)
         json_data = response.json()
-        self.assertEqual(json_data['asset_id'], asset.id)
         self.assertTrue('current_search_id' not in json_data)
         self.assertTrue('queued_search_id' not in json_data)
         # Now check the search for the asset and check it is listed as queued
         self.queue_search_for_asset(asset=asset, search_id=search_id, client=self.smm.client1)
-        response = self.smm.client1.get(asset_details_url, HTTP_ACCEPT='application/json')
+        response = self.smm.client1.get(asset_mission_url, HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)
         json_data = response.json()
-        self.assertEqual(json_data['asset_id'], asset.id)
         self.assertTrue('current_search_id' not in json_data)
         self.assertEqual(json_data['queued_search_id'], search_id)
         # Start the search and check it moves from queued to current
         self.begin_search_for_asset(asset=asset, search_id=search_id, client=self.smm.client1)
-        response = self.smm.client1.get(asset_details_url, HTTP_ACCEPT='application/json')
+        response = self.smm.client1.get(asset_mission_url, HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)
         json_data = response.json()
-        self.assertEqual(json_data['asset_id'], asset.id)
         self.assertEqual(json_data['current_search_id'], search_id)
         self.assertTrue('queued_search_id' not in json_data)
 
@@ -247,11 +252,12 @@ class AssetTestCase(TestCase):
         """
         asset = self.assets.create_asset()
         asset_details_url = f'/assets/{asset.pk}/'
+        asset_mission_url = f'/assets/{asset.pk}/mission/'
         asset_report_position_url = f'/data/assets/{asset.pk}/position/add/'
         asset_set_command_url = f'/mission/{self.mission.pk}/assets/command/set/'
 
-        # Check the initial case (no command)
-        response = self.smm.client1.get(asset_details_url, HTTP_ACCEPT='application/json')
+        # Check the initial case (no command) — last_command lives on the mission endpoint
+        response = self.smm.client1.get(asset_mission_url, HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)
         json_data = response.json()
         self.assertEqual(len(json_data['last_command']), 0)
@@ -278,8 +284,8 @@ class AssetTestCase(TestCase):
             'reason': 'testing',
         })
         self.assertEqual(response.status_code, 200)
-        # Check this command is now showing
-        response = self.smm.client1.get(asset_details_url, HTTP_ACCEPT='application/json')
+        # Check this command is now showing on the mission endpoint
+        response = self.smm.client1.get(asset_mission_url, HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)
         json_data = response.json()
         self.assertEqual(json_data['last_command']['action'], 'RON')
@@ -305,8 +311,8 @@ class AssetTestCase(TestCase):
             'longitude': 172.5,
         })
         self.assertEqual(response.status_code, 200)
-        # Check the GOTO is now showing
-        response = self.smm.client1.get(asset_details_url, HTTP_ACCEPT='application/json')
+        # Check the GOTO is now showing on the mission endpoint
+        response = self.smm.client1.get(asset_mission_url, HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)
         json_data = response.json()
         self.assertEqual(json_data['last_command']['action'], 'GOTO')

--- a/assets/tests.py
+++ b/assets/tests.py
@@ -251,7 +251,6 @@ class AssetTestCase(TestCase):
         in response to reporting their position
         """
         asset = self.assets.create_asset()
-        asset_details_url = f'/assets/{asset.pk}/'
         asset_mission_url = f'/assets/{asset.pk}/mission/'
         asset_report_position_url = f'/data/assets/{asset.pk}/position/add/'
         asset_set_command_url = f'/mission/{self.mission.pk}/assets/command/set/'

--- a/assets/urls.py
+++ b/assets/urls.py
@@ -10,6 +10,7 @@ from . import views
 urlpatterns = [
     re_path(r'^assets/assettypes/$', views.AssetsTypeView.as_view(), name='asset_types_view'),
     re_path(r'^assets/$', views.AssetsView.as_view(), name='assets_view'),
+    re_path(r'^assets/(?P<asset_id>\d+)/$', views.AssetView.as_view(), name='asset_view'),
     re_path(r'^assets/(?P<asset_id>\d+)/status/$', views.AssetStatusView.as_view(), name='assets_status'),
     re_path(r'^assets/status/values/$', views.assets_status_value_list, name='asset_status_values_list'),
 ]

--- a/assets/urls.py
+++ b/assets/urls.py
@@ -10,7 +10,6 @@ from . import views
 urlpatterns = [
     re_path(r'^assets/assettypes/$', views.AssetsTypeView.as_view(), name='asset_types_view'),
     re_path(r'^assets/$', views.AssetsView.as_view(), name='assets_view'),
-    re_path(r'^assets/(?P<asset_id>\d+)/$', views.AssetView.as_view(), name='asset_view'),
     re_path(r'^assets/(?P<asset_id>\d+)/status/$', views.AssetStatusView.as_view(), name='assets_status'),
     re_path(r'^assets/status/values/$', views.assets_status_value_list, name='asset_status_values_list'),
 ]

--- a/assets/views.py
+++ b/assets/views.py
@@ -26,6 +26,9 @@ class AssetView(View):
     View of a specific asset (pure asset data only)
     """
     def as_json(self, request, asset):
+        """
+        Return asset identity and status as JSON.
+        """
         data = {
             'asset_id': asset.pk,
             'name': asset.name,
@@ -38,6 +41,9 @@ class AssetView(View):
         return JsonResponse(data)
 
     def get(self, request, asset):
+        """
+        Return asset details as JSON or render the asset UI page.
+        """
         if "application/json" in request.META.get('HTTP_ACCEPT', ''):
             return self.as_json(request, asset)
         return render(request, 'assets/ui.html', {'assetId': asset.pk, 'assetName': asset.name})

--- a/assets/views.py
+++ b/assets/views.py
@@ -7,12 +7,7 @@ from django.shortcuts import get_object_or_404, render
 from django.utils.decorators import method_decorator
 from django.views import View
 
-from mission.decorators import mission_asset_get
-from mission.models import AssetCommand
-
-from organization.decorators import asset_is_operator, asset_is_recorder
-from search.models import Search
-from search.view_helpers import check_searches_in_progress
+from organization.decorators import asset_is_recorder
 from .models import AssetType, Asset, AssetStatusValue, AssetStatus
 
 
@@ -22,51 +17,6 @@ def assets_status_value_list(request):
     List all of the asset status values
     """
     return JsonResponse({'values': [v.as_object() for v in AssetStatusValue.objects.all()]})
-
-
-@method_decorator(login_required, name="dispatch")
-@method_decorator(asset_is_operator, name="dispatch")
-class AssetView(View):
-    """
-    View of a specific asset
-    """
-    def as_json(self, request, asset):
-        """
-        Provide the details of an asset
-        """
-        data = {
-            'asset_id': asset.pk,
-            'name': asset.name,
-            'asset_type': asset.asset_type.name,
-            'owner': str(asset.owner),
-            'last_command': AssetCommand.last_command_for_asset_to_json(asset),
-        }
-
-        mission_asset = mission_asset_get(asset)
-        if mission_asset is not None:
-            data['mission_id'] = mission_asset.mission.pk
-            data['mission_name'] = mission_asset.mission.mission_name
-
-            current_search = check_searches_in_progress(mission_asset.mission, asset)
-            if current_search is not None:
-                data['current_search_id'] = current_search.pk
-            queued_search = Search.oldest_queued_for_asset(mission_asset.mission, asset)
-            if queued_search is not None:
-                data['queued_search_id'] = queued_search.pk
-
-        status = AssetStatus.current_for_asset(asset)
-        if status is not None:
-            data['status'] = status.as_object()
-
-        return JsonResponse(data)
-
-    def get(self, request, asset):
-        """
-        View of the specific asset
-        """
-        if "application/json" in request.META.get('HTTP_ACCEPT', ''):
-            return self.as_json(request, asset)
-        return render(request, 'assets/ui.html', {'assetId': asset.pk, 'assetName': asset.name})
 
 
 @method_decorator(login_required, name="dispatch")

--- a/assets/views.py
+++ b/assets/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import get_object_or_404, render
 from django.utils.decorators import method_decorator
 from django.views import View
 
-from organization.decorators import asset_is_recorder
+from organization.decorators import asset_is_operator, asset_is_recorder
 from .models import AssetType, Asset, AssetStatusValue, AssetStatus
 
 
@@ -17,6 +17,30 @@ def assets_status_value_list(request):
     List all of the asset status values
     """
     return JsonResponse({'values': [v.as_object() for v in AssetStatusValue.objects.all()]})
+
+
+@method_decorator(login_required, name="dispatch")
+@method_decorator(asset_is_operator, name="dispatch")
+class AssetView(View):
+    """
+    View of a specific asset (pure asset data only)
+    """
+    def as_json(self, request, asset):
+        data = {
+            'asset_id': asset.pk,
+            'name': asset.name,
+            'asset_type': asset.asset_type.name,
+            'owner': str(asset.owner),
+        }
+        status = AssetStatus.current_for_asset(asset)
+        if status is not None:
+            data['status'] = status.as_object()
+        return JsonResponse(data)
+
+    def get(self, request, asset):
+        if "application/json" in request.META.get('HTTP_ACCEPT', ''):
+            return self.as_json(request, asset)
+        return render(request, 'assets/ui.html', {'assetId': asset.pk, 'assetName': asset.name})
 
 
 @method_decorator(login_required, name="dispatch")

--- a/frontend/asset/types.ts
+++ b/frontend/asset/types.ts
@@ -28,6 +28,14 @@ interface AssetFullStatusData {
   status?: AssetStatusData
 }
 
+interface AssetMissionData {
+  last_command?: AssetCommandData
+  mission_id?: number
+  mission_name?: string
+  current_search_id?: number
+  queued_search_id?: number
+}
+
 interface AssetCommandData {
   id?: number
   action?: string
@@ -88,4 +96,4 @@ interface AssetPointTime {
   fix?: number
 }
 
-export { AssetTypeData, AssetData, AssetFullStatusData, AssetCommandData, AssetStatusValueData, AssetStatusData, MissionAssetData, AssetPointTime }
+export { AssetTypeData, AssetData, AssetFullStatusData, AssetMissionData, AssetCommandData, AssetStatusValueData, AssetStatusData, MissionAssetData, AssetPointTime }

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -571,7 +571,7 @@ class AssetUI extends React.Component<AssetUIProps, AssetUIState> {
   async updateData() {
     const [assetData, missionData] = await Promise.all([
       smmGetJSON(`/assets/${this.props.asset}/`) as Promise<AssetFullStatusData>,
-      (smmGetJSON(`/assets/${this.props.asset}/mission/`) as Promise<AssetMissionData>).catch(() => ({} as AssetMissionData)),
+      (smmGetJSON(`/assets/${this.props.asset}/mission/`) as Promise<AssetMissionData>).catch(() => ({}) as AssetMissionData)
     ])
     this.updateDataResponse({ ...assetData, ...missionData })
   }

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -10,7 +10,7 @@ import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { SMMTopBar } from '../menu/topbar'
 import { MissionAssetStatus } from '../mission/asset/status'
 
-import { AssetCommandData, AssetFullStatusData, AssetStatusValueData } from './types'
+import { AssetCommandData, AssetFullStatusData, AssetMissionData, AssetStatusValueData } from './types'
 
 interface AssetTrackAsProps {
   asset: number
@@ -569,7 +569,11 @@ class AssetUI extends React.Component<AssetUIProps, AssetUIState> {
   }
 
   async updateData() {
-    await smmGetJSON(`/assets/${this.props.asset}/`, {}, this.updateDataResponse)
+    const [assetData, missionData] = await Promise.all([
+      smmGetJSON(`/assets/${this.props.asset}/`) as Promise<AssetFullStatusData>,
+      (smmGetJSON(`/assets/${this.props.asset}/mission/`) as Promise<AssetMissionData>).catch(() => ({} as AssetMissionData)),
+    ])
+    this.updateDataResponse({ ...assetData, ...missionData })
   }
 
   render() {

--- a/mission/urls.py
+++ b/mission/urls.py
@@ -27,4 +27,5 @@ urlpatterns = [
     re_path(r'^$', views.mission_list, name='mission_list'),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/command/set/$', views.AssetCommandSetView.as_view(), name='asset_command_set'),
     re_path(r'^assets/(?P<asset_id>\d+)/command/$', views.AssetCommandView.as_view(), name='assets_command'),
+    re_path(r'^assets/(?P<asset_id>\d+)/$', views.AssetView.as_view(), name='asset_view'),
 ]

--- a/mission/urls.py
+++ b/mission/urls.py
@@ -27,5 +27,5 @@ urlpatterns = [
     re_path(r'^$', views.mission_list, name='mission_list'),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/command/set/$', views.AssetCommandSetView.as_view(), name='asset_command_set'),
     re_path(r'^assets/(?P<asset_id>\d+)/command/$', views.AssetCommandView.as_view(), name='assets_command'),
-    re_path(r'^assets/(?P<asset_id>\d+)/$', views.AssetView.as_view(), name='asset_view'),
+    re_path(r'^assets/(?P<asset_id>\d+)/mission/$', views.AssetMissionView.as_view(), name='asset_mission_view'),
 ]

--- a/mission/views.py
+++ b/mission/views.py
@@ -15,9 +15,11 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
 
-from assets.models import Asset
+from assets.models import Asset, AssetStatus
 from mission.helpers import get_my_assets_not_in_mission
 from organization.decorators import asset_is_operator, get_organization_from_id
+from search.models import Search
+from search.view_helpers import check_searches_in_progress
 from organization.models import Organization, OrganizationMember, OrganizationAsset
 from timeline.models import TimeLineEntry
 from timeline.helpers import timeline_record_create, \
@@ -28,7 +30,7 @@ from timeline.helpers import timeline_record_create, \
 
 from .models import Mission, MissionExternalReference, MissionUser, MissionAsset, MissionAssetType, MissionOrganization, MissionAssetStatus, MissionAssetStatusValue, AssetCommand
 from .forms import AssetCommandForm, MissionForm, MissionUserForm, MissionAssetForm, MissionOrganizationForm
-from .decorators import get_user_from_id, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin
+from .decorators import get_user_from_id, mission_asset_get, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin
 
 
 @method_decorator(login_required, name="dispatch")
@@ -722,6 +724,45 @@ class MissionExternalReferenceView(View):
         extref.save()
         timeline_record_external_reference_remove(mission=mission_user.mission, user=mission_user.user, external_reference=extref)
         return HttpResponse("Done")
+
+
+@method_decorator(login_required, name="dispatch")
+@method_decorator(asset_is_operator, name="dispatch")
+class AssetView(View):
+    """
+    View of a specific asset
+    """
+    def as_json(self, request, asset):
+        data = {
+            'asset_id': asset.pk,
+            'name': asset.name,
+            'asset_type': asset.asset_type.name,
+            'owner': str(asset.owner),
+            'last_command': AssetCommand.last_command_for_asset_to_json(asset),
+        }
+
+        mission_asset = mission_asset_get(asset)
+        if mission_asset is not None:
+            data['mission_id'] = mission_asset.mission.pk
+            data['mission_name'] = mission_asset.mission.mission_name
+
+            current_search = check_searches_in_progress(mission_asset.mission, asset)
+            if current_search is not None:
+                data['current_search_id'] = current_search.pk
+            queued_search = Search.oldest_queued_for_asset(mission_asset.mission, asset)
+            if queued_search is not None:
+                data['queued_search_id'] = queued_search.pk
+
+        status = AssetStatus.current_for_asset(asset)
+        if status is not None:
+            data['status'] = status.as_object()
+
+        return JsonResponse(data)
+
+    def get(self, request, asset):
+        if "application/json" in request.META.get('HTTP_ACCEPT', ''):
+            return self.as_json(request, asset)
+        return render(request, 'assets/ui.html', {'assetId': asset.pk, 'assetName': asset.name})
 
 
 @method_decorator(login_required, name='dispatch')

--- a/mission/views.py
+++ b/mission/views.py
@@ -18,9 +18,9 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from assets.models import Asset
 from mission.helpers import get_my_assets_not_in_mission
 from organization.decorators import asset_is_operator, get_organization_from_id
+from organization.models import Organization, OrganizationMember, OrganizationAsset
 from search.models import Search
 from search.view_helpers import check_searches_in_progress
-from organization.models import Organization, OrganizationMember, OrganizationAsset
 from timeline.models import TimeLineEntry
 from timeline.helpers import timeline_record_create, \
     timeline_record_external_reference_add, timeline_record_external_reference_remove, timeline_record_external_reference_update, \
@@ -733,6 +733,9 @@ class AssetMissionView(View):
     Mission/search context for an asset: last command, active mission, and searches.
     """
     def get(self, request, asset):
+        """
+        Return mission/search context for this asset as JSON.
+        """
         data = {
             'last_command': AssetCommand.last_command_for_asset_to_json(asset),
         }

--- a/mission/views.py
+++ b/mission/views.py
@@ -15,7 +15,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
 
-from assets.models import Asset, AssetStatus
+from assets.models import Asset
 from mission.helpers import get_my_assets_not_in_mission
 from organization.decorators import asset_is_operator, get_organization_from_id
 from search.models import Search
@@ -728,19 +728,14 @@ class MissionExternalReferenceView(View):
 
 @method_decorator(login_required, name="dispatch")
 @method_decorator(asset_is_operator, name="dispatch")
-class AssetView(View):
+class AssetMissionView(View):
     """
-    View of a specific asset
+    Mission/search context for an asset: last command, active mission, and searches.
     """
-    def as_json(self, request, asset):
+    def get(self, request, asset):
         data = {
-            'asset_id': asset.pk,
-            'name': asset.name,
-            'asset_type': asset.asset_type.name,
-            'owner': str(asset.owner),
             'last_command': AssetCommand.last_command_for_asset_to_json(asset),
         }
-
         mission_asset = mission_asset_get(asset)
         if mission_asset is not None:
             data['mission_id'] = mission_asset.mission.pk
@@ -753,16 +748,7 @@ class AssetView(View):
             if queued_search is not None:
                 data['queued_search_id'] = queued_search.pk
 
-        status = AssetStatus.current_for_asset(asset)
-        if status is not None:
-            data['status'] = status.as_object()
-
         return JsonResponse(data)
-
-    def get(self, request, asset):
-        if "application/json" in request.META.get('HTTP_ACCEPT', ''):
-            return self.as_json(request, asset)
-        return render(request, 'assets/ui.html', {'assetId': asset.pk, 'assetName': asset.name})
 
 
 @method_decorator(login_required, name='dispatch')


### PR DESCRIPTION
## Summary by Sourcery

Separate pure asset data from mission/search context by introducing a dedicated mission endpoint for assets and updating consumers accordingly.

New Features:
- Add a mission-focused endpoint for assets that returns last command, mission details, and search queue state as JSON.

Enhancements:
- Restrict the asset details endpoint to return only identity and status data, removing mission and search-related fields.
- Update the frontend asset UI to fetch asset and mission context in parallel from separate endpoints and merge the results.
- Clarify asset tests to distinguish between asset-only data and mission/search context sourced from the new endpoint.

Tests:
- Adjust asset tests to validate mission/search behaviour against the new mission-specific asset endpoint instead of the generic asset endpoint.