### PR TITLE
Move assets/test_asset_command.py to mission/

### DIFF
--- a/mission/test_asset_command.py
+++ b/mission/test_asset_command.py
@@ -6,11 +6,11 @@ from django.test import TestCase
 from django.contrib.auth import get_user_model
 
 from assets.tests import AssetsHelpers
-from mission.models import AssetCommand
-from mission.tests import MissionFunctions
+from assets.models import Asset, AssetType
 from smm.tests import SMMTestUsers
 
-from .models import Asset, AssetType
+from .models import AssetCommand
+from .tests import MissionFunctions
 
 
 class AssetCommandTestCase(TestCase):


### PR DESCRIPTION
## Description

AssetCommand lives in mission.models, so tests for it belong in mission/. Updated .models import to assets.models and mission.tests import to .tests.

## Summary by Sourcery

Relocate the AssetCommand test to the mission app and align its imports with the correct models and test helpers.

Tests:
- Move AssetCommand test module from the assets app into the mission app, updating references to mission and assets models accordingly.

Chores:
- Adjust import paths in the moved test to reference Asset and AssetType from assets.models and AssetCommand and MissionFunctions from mission modules.