### PR TITLE
Fix MissionOrganization.mission_user to use a single ORM subquery

### DIFF
--- a/mission/models.py
+++ b/mission/models.py
@@ -428,8 +428,11 @@ class MissionOrganization(models.Model):
         """
         Get all the missions a user is in because they are in an organization
         """
-        user_organizations = OrganizationMember.user_current(user)
-        return Mission.objects.filter(missionorganization__organization__in=[user_org.organization for user_org in user_organizations], missionorganization__removed__isnull=True)
+        org_ids = OrganizationMember.objects.filter(user=user, removed__isnull=True).values('organization')
+        return Mission.objects.filter(
+            missionorganization__organization__in=org_ids,
+            missionorganization__removed__isnull=True,
+        )
 
     class Meta:
         indexes = [


### PR DESCRIPTION
## Description

The previous implementation evaluated OrganizationMember into a Python list before filtering, forcing two round-trips to the database. Using .values('organization') as a subquery lets the database resolve the entire lookup in one query.

## Summary by Sourcery

Bug Fixes:
- Eliminate multiple database round-trips when resolving missions for a user via organization memberships by using a subquery on organization IDs.