### PR TITLE
Allow Asset.as_object() to accept a pre-fetched status to avoid N+1

### DIFF
--- a/assets/models.py
+++ b/assets/models.py
@@ -65,10 +65,17 @@ class Asset(models.Model):
             return self.asset_type.icon.get_url()
         return None
 
-    def as_object(self):
+    _UNSET = object()
+
+    def as_object(self, status=_UNSET):
         """
         Convert this asset to an object that is suitable for returning via JsonResponse
+
+        Pass status=None to skip the status lookup entirely, or pass a pre-fetched
+        AssetStatus instance to avoid an extra query when listing many assets.
         """
+        if status is type(self)._UNSET:
+            status = AssetStatus.current_for_asset(self)
         data = {
             'id': self.pk,
             'name': self.name,
@@ -76,7 +83,7 @@ class Asset(models.Model):
             'type_name': self.asset_type.name,
             'owner': str(self.owner)
         }
-        if status := AssetStatus.current_for_asset(self):
+        if status:
             data['status'] = str(status.status)
             data['status_inop'] = status.status.inop
             data['status_since'] = status.since


### PR DESCRIPTION
## Description

Add an optional status parameter so callers listing many assets can pass a pre-fetched AssetStatus and avoid one query per asset. Passing None skips the status lookup entirely. Existing callers with no argument continue to work unchanged via a lazy default.

## Summary by Sourcery

Enhancements:
- Add an optional status parameter to Asset.as_object to support passing a pre-fetched AssetStatus or skipping status lookup entirely while preserving existing behavior by default.