### PR TITLE
Batch-fetch asset statuses in MissionDetailsView to eliminate N+1

### DIFF
--- a/mission/models.py
+++ b/mission/models.py
@@ -117,6 +117,9 @@ class MissionUser(models.Model):
         ]
 
 
+_UNSET = object()
+
+
 class MissionAsset(models.Model):
     """
     An asset/mission association.
@@ -130,14 +133,21 @@ class MissionAsset(models.Model):
     remover = models.ForeignKey(get_user_model(), on_delete=models.PROTECT, related_name='remover%(app_label)s_%(class)s_related', null=True, blank=True)
     removed = models.DateTimeField(null=True, blank=True)
 
-    def as_object(self):
+    def as_object(self, asset_status=_UNSET):
         """
         return this mission asset as a json object
+
+        Pass a pre-fetched AssetStatus (or None) as asset_status to avoid a
+        per-asset query when serializing many mission assets.
         """
+        if asset_status is _UNSET:
+            asset_obj = self.asset.as_object()
+        else:
+            asset_obj = self.asset.as_object(status=asset_status)
         return {
             'id': self.pk,
             'mission': self.mission.pk,
-            'asset': self.asset.as_object(),
+            'asset': asset_obj,
             'creator': str(self.creator) if self.creator else None,
             'added': self.added,
             'remover': str(self.remover) if self.remover else None,

--- a/mission/views.py
+++ b/mission/views.py
@@ -9,13 +9,13 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseBadRequest, JsonResponse, HttpResponseRedirect, HttpResponseForbidden, HttpResponseNotFound, HttpResponse
 from django.db import transaction
-from django.db.models import OuterRef, Subquery, Exists
+from django.db.models import OuterRef, Prefetch, Subquery, Exists
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
 
-from assets.models import Asset
+from assets.models import Asset, AssetStatus
 from mission.helpers import get_my_assets_not_in_mission
 from organization.decorators import asset_is_operator, get_organization_from_id
 from organization.models import Organization, OrganizationMember, OrganizationAsset
@@ -45,10 +45,27 @@ class MissionDetailsView(View):
         """
         latest_status_subquery = MissionAssetStatus.objects.filter(mission_asset=OuterRef('pk')).order_by('-since').values('status__name')[:1]
         latest_since_subquery = MissionAssetStatus.objects.filter(mission_asset=OuterRef('pk')).order_by('-since').values('since')[:1]
-        mission_assets = MissionAsset.objects.filter(mission=mission_user.mission).annotate(status=Subquery(latest_status_subquery), status_since=Subquery(latest_since_subquery))
+        mission_assets = (
+            MissionAsset.objects.filter(mission=mission_user.mission)
+            .annotate(
+                status=Subquery(latest_status_subquery),
+                status_since=Subquery(latest_since_subquery),
+            )
+            .prefetch_related(
+                Prefetch(
+                    'asset__assetstatus_set',
+                    queryset=AssetStatus.objects.select_related('status')
+                    .order_by('asset', '-since')
+                    .distinct('asset'),
+                    to_attr='prefetched_statuses',
+                )
+            )
+        )
         assets_json = []
         for ma in mission_assets:
-            ma_json = ma.as_object()
+            prefetched = getattr(ma.asset, 'prefetched_statuses', [])
+            asset_status = prefetched[0] if prefetched else None
+            ma_json = ma.as_object(asset_status=asset_status)
             ma_json['status'] = {
                 'name': getattr(ma, 'status'),
                 'since': getattr(ma, 'status_since'),


### PR DESCRIPTION
## Description

MissionAsset.as_object() now accepts an optional asset_status parameter forwarded to asset.as_object(), so callers can provide a pre-fetched AssetStatus. MissionDetailsView.as_json uses prefetch_related on asset__assetstatus_set to load all statuses in one query and passes the latest to each as_object() call instead of querying per asset.

## Summary by Sourcery

Batch prefetch asset statuses in mission details serialization to remove per-asset queries and support passing pre-fetched statuses into MissionAsset serialization.

Enhancements:
- Allow MissionAsset.as_object to accept an optional pre-fetched AssetStatus to reuse existing status data when serializing assets.
- Use prefetch_related on mission assets to load latest AssetStatus records in bulk and pass them into MissionAsset.as_object during MissionDetailsView JSON generation.