### PR TITLE
Convert organization_details FBV to OrganizationDetailView CBV

### DIFF
--- a/organization/urls.py
+++ b/organization/urls.py
@@ -4,7 +4,7 @@ from . import views
 urlpatterns = [
     re_path(r'^organization/$', views.OrganizationView.as_view()),
     re_path(r'^organization/assets/$', views.OrganizationAssetsView.as_view(), name='organization_assets'),
-    re_path(r'^organization/(?P<organization_id>\d+)/$', views.organization_details, name='organization_details'),
+    re_path(r'^organization/(?P<organization_id>\d+)/$', views.OrganizationDetailView.as_view(), name='organization_details'),
     re_path(r'^organization/(?P<organization_id>\d+)/user/(?P<username>.*)/$', views.OrganizationUserView.as_view(), name='organization_user_modify'),
     re_path(r'^organization/(?P<organization_id>\d+)/users/notmember/', views.organization_not_members, name='organization_not_members'),
     re_path(r'^organization/(?P<organization_id>\d+)/assets/$', views.organization_asset_list, name='organization_asset_list'),

--- a/organization/views.py
+++ b/organization/views.py
@@ -57,28 +57,18 @@ class OrganizationView(View):
         return JsonResponse(organization.as_object(request.user))
 
 
-@login_required
-def organization_details(request, organization_id):
-    """
-    Dislay or provide the asset details
-    """
-    if request.method != 'GET':
-        return HttpResponseNotAllowed(['GET'])
-
-    organization = get_object_or_404(Organization, pk=organization_id)
-
-    # if json is requested, then send all the data this user is allowed to see
-    if "application/json" in request.META.get('HTTP_ACCEPT', ''):
-        organization_data = organization.as_object(request.user)
-
-        organization_assets = OrganizationAsset.objects.filter(organization=organization, removed__isnull=True)
-        organization_data['assets'] = [oa.as_object(org=False) for oa in organization_assets]
-        organization_members = OrganizationMember.objects.filter(organization=organization, removed__isnull=True)
-        organization_data['members'] = [om.as_object(org=False) for om in organization_members]
-
-        return JsonResponse(organization_data)
-
-    return render(request, 'organization/details.html', {'organization': organization})
+@method_decorator(login_required, name="dispatch")
+class OrganizationDetailView(View):
+    def get(self, request, organization_id):
+        organization = get_object_or_404(Organization, pk=organization_id)
+        if "application/json" in request.META.get('HTTP_ACCEPT', ''):
+            organization_data = organization.as_object(request.user)
+            organization_assets = OrganizationAsset.objects.filter(organization=organization, removed__isnull=True)
+            organization_data['assets'] = [oa.as_object(org=False) for oa in organization_assets]
+            organization_members = OrganizationMember.objects.filter(organization=organization, removed__isnull=True)
+            organization_data['members'] = [om.as_object(org=False) for om in organization_members]
+            return JsonResponse(organization_data)
+        return render(request, 'organization/details.html', {'organization': organization})
 
 
 @method_decorator(login_required, name="dispatch")


### PR DESCRIPTION
## Description

HttpResponseNotAllowed fallthrough is now handled by View.dispatch().

## Summary by Sourcery

Convert the organization details function-based view to a class-based OrganizationDetailView and update routing accordingly.

Bug Fixes:
- Rely on View.dispatch() to correctly handle non-GET methods with HttpResponseNotAllowed rather than manual method checks in the view.

Enhancements:
- Unify HTML and JSON organization detail responses under a login-protected class-based view for consistency with other organization views.