### PR TITLE
Convert organization asset modify to class based view

### DIFF
--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -98,11 +98,22 @@ class OrganizationMemberRow extends React.Component<OrganizationMemberRowProps, 
 }
 
 interface OrganizationAssetRowProps {
+  organizationId: number
   organization_asset: OrganizationAssetData
   showButtons: boolean
 }
 
 class OrganizationAssetRow extends React.Component<OrganizationAssetRowProps, never> {
+  constructor(props: OrganizationAssetRowProps) {
+    super(props)
+    this.delete = this.delete.bind(this)
+  }
+
+  delete() {
+    const { organization_asset } = this.props
+    smmDelete(`/organization/${this.props.organizationId}/assets/${organization_asset.asset.id}/`)
+  }
+
   render() {
     const organizationAsset = this.props.organization_asset
     const dataFields = []
@@ -257,13 +268,14 @@ class OrganizationMemberAdd extends React.Component<OrganizationMemberAddProps, 
 }
 
 interface OrganizationAssetListProps {
+  organizationId: number
   organization_assets?: OrganizationAssetData[]
 }
 
 class OrganizationAssetList extends React.Component<OrganizationAssetListProps, never> {
   render() {
     const organizationAssetRows = this.props.organization_assets?.map((organizationAsset) => (
-      <OrganizationAssetRow key={organizationAsset.id} organization_asset={organizationAsset} showButtons />
+      <OrganizationAssetRow key={organizationAsset.id} organizationId={this.props.organizationId} organization_asset={organizationAsset} showButtons />
     ))
     return (
       <Table responsive>
@@ -462,7 +474,7 @@ class OrganizationDetailsPage extends React.Component<OrganizationDetailsPagePro
     if (this.state.organizationDetails.role === 'Admin') {
       organizationSections.push(<OrganizationMemberAdd key="org_add_member" organizationId={this.props.organizationId} />)
     }
-    organizationSections.push(<OrganizationAssetList key="org_assets" organization_assets={this.state.organizationDetails.assets} />)
+    organizationSections.push(<OrganizationAssetList key="org_assets" organizationId={this.props.organizationId} organization_assets={this.state.organizationDetails.assets} />)
     organizationSections.push(<OrganizationAssetAdd key="org_asset_add" organizationId={this.props.organizationId} />)
 
     return <div>{organizationSections}</div>

--- a/organization/urls.py
+++ b/organization/urls.py
@@ -8,6 +8,6 @@ urlpatterns = [
     re_path(r'^organization/(?P<organization_id>\d+)/user/(?P<username>.*)/$', views.OrganizationUserView.as_view(), name='organization_user_modify'),
     re_path(r'^organization/(?P<organization_id>\d+)/users/notmember/', views.organization_not_members, name='organization_not_members'),
     re_path(r'^organization/(?P<organization_id>\d+)/assets/$', views.organization_asset_list, name='organization_asset_list'),
-    re_path(r'^organization/(?P<organization_id>\d+)/assets/(?P<asset_id>\d+)/$', views.organization_asset_modify, name='organization_asset_modify'),
+    re_path(r'^organization/(?P<organization_id>\d+)/assets/(?P<asset_id>\d+)/$', views.OrganizationAssetView.as_view(), name='organization_asset_modify'),
     re_path(r'^organization/(?P<organization_id>\d+)/radio/operator/$', views.organization_radio_operator, name='organization_radio_operator'),
 ]

--- a/organization/views.py
+++ b/organization/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotAllowed, JsonResponse, HttpResponse
+from django.http import HttpResponseBadRequest, HttpResponseForbidden, JsonResponse, HttpResponse
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist
@@ -140,23 +140,24 @@ def organization_asset_list(request, organization_id):
     return JsonResponse({'assets': [oa.as_object() for oa in organization_assets]})
 
 
-@login_required
-@organization_assets_admin
-@asset_is_owner
-def organization_asset_modify(request, organization_member, asset):
-    """
-    Modify the role/membership of an asset
-    """
-    if request.method == 'POST':
-        # Create/modify the membership
+@method_decorator(login_required, name="dispatch")
+@method_decorator(organization_assets_admin, name="dispatch")
+@method_decorator(asset_is_owner, name="dispatch")
+class OrganizationAssetView(View):
+    def post(self, request, organization_member, asset):
         try:
             oa = OrganizationAsset.objects.get(organization=organization_member.organization, asset=asset)
         except ObjectDoesNotExist:
             oa = OrganizationAsset(organization=organization_member.organization, asset=asset, added_by=request.user)
             oa.save()
         return JsonResponse(oa.as_object())
-    else:
-        return HttpResponseNotAllowed(['POST'])
+
+    def delete(self, request, organization_member, asset):
+        oa = get_object_or_404(OrganizationAsset, organization=organization_member.organization, asset=asset, removed__isnull=True)
+        oa.removed = timezone.now()
+        oa.removed_by = request.user
+        oa.save()
+        return HttpResponse('')
 
 
 @login_required


### PR DESCRIPTION
## Summary by Sourcery

Convert the organization asset modify endpoint to a class-based view and wire it through to the frontend, including support for deleting organization assets.

New Features:
- Add DELETE support for organization assets to allow marking assets as removed from an organization via the API.

Enhancements:
- Replace the function-based organization_asset_modify view with a class-based OrganizationAssetView using method-specific handlers.
- Pass organizationId into organization asset React components and add a delete handler that calls the new DELETE endpoint.