### PR TITLE
Convert mission new to cbv

### DIFF
--- a/mission/templates/mission_create.html
+++ b/mission/templates/mission_create.html
@@ -6,14 +6,14 @@
         <link rel="stylesheet" href="pretty.css">
         <script type="module" src="pretty.js"></script>
         <script>
-            $(window).on('pageshow', function(){
-                 $("#mission_create_btn").attr("disabled", false);
+            window.addEventListener('pageshow', function(){
+                document.getElementById('mission_create_btn').disabled = false;
             });
         </script>
         <meta name="viewport" content="width=device-width, initial-scale=1">
     </head>
     <body style="height: 100%">
-        <form method="POST" onsubmit='$("#mission_create_btn").attr("disabled", true)'>
+        <form method="POST" onsubmit='document.getElementById("mission_create_btn").disabled = true'>
             {% csrf_token %}
             <table>
                 {{ form.as_table }}

--- a/mission/urls.py
+++ b/mission/urls.py
@@ -21,7 +21,7 @@ urlpatterns = [
     re_path(r'^mission/(?P<mission_id>\d+)/externalreferences/$', views.MissionExternalReferencesView.as_view(), name='mission_external_references'),
     re_path(r'^mission/(?P<mission_id>\d+)/externalreferences/(?P<ext_ref_id>\d+)/$', views.MissionExternalReferenceView.as_view(), name='mission_external_reference'),
     re_path(r'^mission/(?P<mission_id>\d+)/close/$', views.mission_close, name='mission_close'),
-    re_path(r'^mission/new/$', views.mission_new, name='mission_new'),
+    re_path(r'^mission/new/$', views.MissionNewView.as_view(), name='mission_new'),
     re_path(r'^mission/list/$', views.mission_list_data, name='mission_list_data'),
     re_path(r'^mission/asset/status/values/$', views.MissionAssetStatusValuesView.as_view()),
     re_path(r'^$', views.mission_list, name='mission_list'),

--- a/mission/views.py
+++ b/mission/views.py
@@ -172,26 +172,27 @@ def mission_list_data(request):
     return JsonResponse(data)
 
 
-@login_required
-def mission_new(request):
-    """
-    Create a new mission.
-    """
-    form = None
-    if request.method == 'POST':
+@method_decorator(login_required, name="dispatch")
+class MissionNewView(View):
+    """Create a new mission."""
+
+    def get(self, request):
+        """Render the mission creation form."""
+        return render(request, 'mission_create.html', {'form': MissionForm()})
+
+    def post(self, request):
+        """Handle mission creation form submission."""
         form = MissionForm(request.POST)
         if form.is_valid():
-            # Create the new mission
-            mission = Mission(mission_name=form.cleaned_data['mission_name'], mission_description=form.cleaned_data['mission_description'], creator=request.user)
+            mission = Mission(
+                mission_name=form.cleaned_data['mission_name'],
+                mission_description=form.cleaned_data['mission_description'],
+                creator=request.user,
+            )
             mission.save()
-            # Give the user who created this mission admin permissions
             MissionUser(mission=mission, user=request.user, permissions_admin=True, creator=request.user).save()
             return redirect(f'/mission/{mission.pk}/details/')
-
-    if form is None:
-        form = MissionForm()
-
-    return render(request, 'mission_create.html', {'form': form})
+        return render(request, 'mission_create.html', {'form': form})
 
 
 @method_decorator(login_required, name="dispatch")


### PR DESCRIPTION
## Summary by Sourcery

Convert the mission creation endpoint to a class-based view and modernize the associated template behavior.

Enhancements:
- Replace the function-based mission_new view with a login-protected class-based MissionNewView handling GET and POST for mission creation.
- Update mission creation form handling to always re-render the form on validation errors without reinitializing it.
- Switch mission new URL routing to use the new class-based view.
- Modernize mission_create template JavaScript by replacing jQuery-based button disabling/enabling with vanilla DOM event listeners.