### PR TITLE
Convert mission_asset_remove FBV to MissionAssetView CBV, update URL and frontend

### DIFF
--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -5,7 +5,7 @@ import { Table, Button, ButtonGroup } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import { smmGet, smmGetJSON, smmPost, smmDelete } from '../ajax'
+import { smmGetJSON, smmPost, smmDelete } from '../ajax'
 
 import { SMMMissionTopBar } from '../menu/topbar'
 
@@ -693,7 +693,7 @@ class MissionDetailsAssetRow extends React.Component<MissionDetailsAssetRowProps
   }
 
   remove() {
-    smmGet(`/mission/${this.props.missionAsset.mission}/assets/${this.props.missionAsset.asset.id}/remove/`)
+    smmDelete(`/mission/${this.props.missionAsset.mission}/assets/${this.props.missionAsset.asset.id}/`)
   }
 
   render() {

--- a/mission/test_mission_org_asset.py
+++ b/mission/test_mission_org_asset.py
@@ -36,7 +36,7 @@ class MissionOrganizationsAssetsTestCase(MissionOrganizationBaseTestCase):
         self.assertEqual(response.redirect_chain[0][1], 302)
         # Check a user in the organization can remove the asset
         response = mission.remove_asset(asset, client=self.smm.client2)
-        self.assertEqual(response.redirect_chain[0][1], 302)
+        self.assertEqual(response.status_code, 200)
         response = mission.get_asset_list(client=self.smm.client2)
         self.assertEqual(response.status_code, 200)
         assets_data = response.json()
@@ -62,7 +62,7 @@ class MissionOrganizationsAssetsTestCase(MissionOrganizationBaseTestCase):
         self.assertEqual(response.redirect_chain[0][1], 302)
         # Check a user in the organization can remove the asset
         response = mission.remove_asset(asset, client=self.smm.client2)
-        self.assertEqual(response.redirect_chain[0][1], 302)
+        self.assertEqual(response.status_code, 200)
         response = mission.get_asset_list(client=self.smm.client2)
         self.assertEqual(response.status_code, 200)
         assets_data = response.json()

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -89,7 +89,7 @@ class MissionTestWrapper:
         """
         if client is None:
             client = self.smm.client1
-        return client.get(f'/mission/{self.mission_pk}/assets/{asset.pk}/remove/', follow=True)
+        return client.delete(f'/mission/{self.mission_pk}/assets/{asset.pk}/', follow=True)
 
     def get_asset_list(self, client=None, include_removed=False):
         """

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -89,7 +89,7 @@ class MissionTestWrapper:
         """
         if client is None:
             client = self.smm.client1
-        return client.delete(f'/mission/{self.mission_pk}/assets/{asset.pk}/', follow=True)
+        return client.delete(f'/mission/{self.mission_pk}/assets/{asset.pk}/')
 
     def get_asset_list(self, client=None, include_removed=False):
         """
@@ -408,7 +408,7 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         self.assertEqual(response.redirect_chain[0][1], 302)
         # Remove the asset
         response = mission.remove_asset(self.asset, client=self.smm.client1)
-        self.assertEqual(response.redirect_chain[0][1], 302)
+        self.assertEqual(response.status_code, 200)
         mission_asset = MissionAsset.objects.get(mission=mission.get_object(), asset=self.asset)
         self.assertIsNotNone(mission_asset.removed)
         self.assertEqual(mission_asset.remover.username, self.smm.user1.username)
@@ -433,7 +433,7 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         self.assertEqual(assets_data['assets'][0]['type_name'], self.asset_type.name)
         # Remove the asset
         response = mission.remove_asset(self.asset, client=self.smm.client1)
-        self.assertEqual(response.redirect_chain[0][1], 302)
+        self.assertEqual(response.status_code, 200)
         response = mission.get_asset_list(client=self.smm.client1)
         self.assertEqual(response.status_code, 200)
         assets_data = response.json()

--- a/mission/urls.py
+++ b/mission/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
     re_path(r'^mission/(?P<mission_id>\d+)/users/add/$', views.mission_user_add, name='mission_user_add'),
     re_path(r'^mission/(?P<mission_id>\d+)/users/(?P<user_id>\d+)/$', views.MissionUserView.as_view(), name='mission_user'),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/$', views.MissionAssetsView.as_view()),
-    re_path(r'^mission/(?P<mission_id>\d+)/assets/(?P<asset_id>\d+)/remove/$', views.mission_asset_remove, name='mission_assets_remove'),
+    re_path(r'^mission/(?P<mission_id>\d+)/assets/(?P<asset_id>\d+)/$', views.MissionAssetView.as_view(), name='mission_asset'),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/(?P<asset_id>\d+)/status/$', views.MissionAssetStatusView.as_view()),
     re_path(r'^mission/(?P<mission_id>\d+)/externalreferences/$', views.MissionExternalReferencesView.as_view(), name='mission_external_references'),
     re_path(r'^mission/(?P<mission_id>\d+)/externalreferences/(?P<ext_ref_id>\d+)/$', views.MissionExternalReferenceView.as_view(), name='mission_external_reference'),

--- a/mission/views.py
+++ b/mission/views.py
@@ -573,28 +573,23 @@ def mission_asset_is_owner(mission_user, asset, user):
     return False
 
 
-@login_required
-@mission_is_member
-def mission_asset_remove(request, mission_user, asset_id):
-    """
-    Cease using an asset as part of this Mission
-    """
-    asset = get_object_or_404(Asset, pk=asset_id)
-    mission_asset = get_object_or_404(MissionAsset, mission=mission_user.mission, asset=asset, removed__isnull=True)
+@method_decorator(login_required, name="dispatch")
+@method_decorator(mission_is_member, name="dispatch")
+class MissionAssetView(View):
+    """Manage a single asset within a mission."""
 
-    if not mission_asset_is_owner(mission_user, asset, request.user):
-        return HttpResponseForbidden('Only assets owners or a mission admin can remove assets')
-    mission_asset.remover = request.user
-    mission_asset.removed = timezone.now()
-    mission_asset.save()
-
-    timeline_record_mission_asset_remove(mission_user.mission, request.user, asset=asset)
-
-    # Tell the asset
-    command = AssetCommand(asset=mission_asset.asset, issued_by=mission_user.user, command='MC', reason='Removed from Mission', mission=mission_user.mission)
-    command.save()
-
-    return HttpResponseRedirect(f'/mission/{mission_user.mission.pk}/details/')
+    def delete(self, request, mission_user, asset_id):
+        """Remove an asset from the mission."""
+        asset = get_object_or_404(Asset, pk=asset_id)
+        mission_asset = get_object_or_404(MissionAsset, mission=mission_user.mission, asset=asset, removed__isnull=True)
+        if not mission_asset_is_owner(mission_user, asset, request.user):
+            return HttpResponseForbidden('Only assets owners or a mission admin can remove assets')
+        mission_asset.remover = request.user
+        mission_asset.removed = timezone.now()
+        mission_asset.save()
+        timeline_record_mission_asset_remove(mission_user.mission, request.user, asset=asset)
+        AssetCommand(asset=mission_asset.asset, issued_by=mission_user.user, command='MC', reason='Removed from Mission', mission=mission_user.mission).save()
+        return HttpResponse('')
 
 
 @method_decorator(login_required, name="dispatch")


### PR DESCRIPTION
## Description

- URL changes from .../assets/<id>/remove/ to .../assets/<id>/ (DELETE)
- Frontend uses smmDelete instead of smmGet, removes unused smmGet import
- Test helper updated to client.delete on new URL
- Response changed from redirect to empty 200

## Summary by Sourcery

Convert mission asset removal to a class-based view and align backend, URLs, frontend, and tests with a DELETE-based API.

Bug Fixes:
- Return a 200 response instead of a redirect when removing a mission asset via the API.

Enhancements:
- Replace the mission_asset_remove function view with a MissionAssetView class-based view handling asset deletion.
- Update mission asset URL routing to use a REST-style asset detail endpoint for DELETE requests.
- Adjust frontend mission asset removal to use a DELETE request via smmDelete against the updated asset URL.

Tests:
- Update mission test helper to issue DELETE requests against the new mission asset endpoint.