### PR TITLE
Remove mission_user_add FBV: duplicate of MissionUsersView.post()

### DIFF
--- a/mission/tests.py
+++ b/mission/tests.py
@@ -41,7 +41,7 @@ class MissionTestWrapper:
             client = self.smm.client1
         if user is None:
             user = self.smm.user2
-        return client.post(f'/mission/{self.mission_pk}/users/add/', data={
+        return client.post(f'/mission/{self.mission_pk}/users/', data={
             'user': user.pk,
         })
 

--- a/mission/urls.py
+++ b/mission/urls.py
@@ -13,7 +13,6 @@ urlpatterns = [
     re_path(r'^mission/(?P<mission_id>\d+)/organizations/$', views.MissionOrganizationsView.as_view(), name='mission_organizations'),
     re_path(r'^mission/(?P<mission_id>\d+)/organizations/(?P<organization_id>\d+)/$', views.MissionOrganizationView.as_view(), name='mission_organization'),
     re_path(r'^mission/(?P<mission_id>\d+)/users/$', views.MissionUsersView.as_view(), name='mission_users'),
-    re_path(r'^mission/(?P<mission_id>\d+)/users/add/$', views.mission_user_add, name='mission_user_add'),
     re_path(r'^mission/(?P<mission_id>\d+)/users/(?P<user_id>\d+)/$', views.MissionUserView.as_view(), name='mission_user'),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/$', views.MissionAssetsView.as_view()),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/(?P<asset_id>\d+)/$', views.MissionAssetView.as_view(), name='mission_asset'),

--- a/mission/views.py
+++ b/mission/views.py
@@ -404,34 +404,6 @@ class MissionUsersView(View):
         return render(request, 'mission_user_add.html', {'form': form})
 
 
-@login_required
-@mission_is_member
-@mission_can_add_user
-def mission_user_add(request, mission_user):
-    """
-    Add a User to a Mission
-    """
-    form = None
-    if request.method == 'POST':
-        form = MissionUserForm(request.POST)
-        if form.is_valid():
-            # Check if this user is already in this mission
-            try:
-                mission_user = MissionUser.objects.get(user=form.cleaned_data['user'], mission=mission_user.mission)
-                return HttpResponseForbidden("User is already in this Mission")
-            except ObjectDoesNotExist:
-                # Create the new mission<->user
-                mission_user = MissionUser(mission=mission_user.mission, user=form.cleaned_data['user'], creator=request.user)
-                mission_user.save()
-                timeline_record_mission_user_add(mission_user.mission, request.user, form.cleaned_data['user'])
-                return HttpResponseRedirect(f'/mission/{mission_user.mission.pk}/details/')
-
-    if form is None:
-        form = MissionUserForm()
-
-    return render(request, 'mission_user_add.html', {'form': form})
-
-
 @method_decorator(login_required, name="dispatch")
 @method_decorator(get_user_from_id, name="dispatch")
 @method_decorator(mission_is_member, name="dispatch")


### PR DESCRIPTION
## Description

Both views share identical logic and the same permission decorators (login_required, mission_is_member, mission_can_add_user on POST). Update test helper to POST to .../users/ instead of .../users/add/.

## Summary by Sourcery

Remove the deprecated function-based mission user add view in favor of the existing class-based MissionUsersView endpoint and align tests and routing accordingly.

Enhancements:
- Remove the duplicate mission_user_add function-based view in favor of the MissionUsersView POST handler.
- Simplify mission user routing by relying solely on the /mission/<id>/users/ endpoint.

Tests:
- Update mission test helper to post new users to the /mission/<id>/users/ endpoint instead of the removed /users/add/ route.

Chores:
- Clean up URL patterns by deleting the unused /mission/<id>/users/add/ route.