### PR TITLE
Convert marine_vectors_create/delete FBVs to MarineVectorCreateView/DetailView CBVs

### DIFF
--- a/frontend/marine/vectors.tsx
+++ b/frontend/marine/vectors.tsx
@@ -1,6 +1,6 @@
 import { SMMRealtime } from '../smmmap'
 import { TotalDriftVectorData } from './types'
-import { smmGet } from '../ajax'
+import { smmDelete } from '../ajax'
 
 class SMMMarineVector extends SMMRealtime {
   constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
@@ -37,7 +37,7 @@ class SMMMarineVector extends SMMRealtime {
           {
             label: 'Delete',
             onclick: function () {
-              smmGet(`/sar/marine/vectors/${tdvID}/delete/`)
+              smmDelete(`/sar/marine/vectors/${tdvID}/`)
             },
             btnClass: 'btn-danger'
           }

--- a/marinesar/urls.py
+++ b/marinesar/urls.py
@@ -8,8 +8,8 @@ from . import views
 
 urlpatterns = [
     re_path(r'^mission/(?P<mission_id>\d+)/sar/marine/vectors/$', views.marine_vectors, name='marine_vectors'),
-    re_path(r'^mission/(?P<mission_id>\d+)/sar/marine/vectors/create/$', views.marine_vectors_create, name='marine_vectors_create'),
-    re_path(r'^sar/marine/vectors/(?P<tdv_id>\d+)/delete/$', views.marine_vectors_delete, name='marine_vectors_delete'),
+    re_path(r'^mission/(?P<mission_id>\d+)/sar/marine/vectors/create/$', views.MarineVectorCreateView.as_view(), name='marine_vectors_create'),
+    re_path(r'^sar/marine/vectors/(?P<tdv_id>\d+)/$', views.MarineVectorDetailView.as_view(), name='marine_vector'),
     re_path(r'^mission/(?P<mission_id>\d+)/sar/marine/vectors/current/$', views.marine_vectors_all, name='marine_vectors_all'),
     re_path(r'^mission/(?P<mission_id>\d+)/sar/marine/sac/$', views.marine_sac, name='marine_sac'),
 

--- a/marinesar/views.py
+++ b/marinesar/views.py
@@ -10,6 +10,8 @@ from django.contrib.gis.geos import GEOSGeometry, LineString, Point
 from django.http import HttpResponseNotFound, HttpResponse
 from django.shortcuts import render, get_object_or_404
 from django.utils import timezone
+from django.utils.decorators import method_decorator
+from django.views import View
 
 from data.decorators import data_get_mission_id
 from data.models import GeoTimeLabel
@@ -42,107 +44,106 @@ def marine_vectors(request, mission_user):
     return render(request, 'marinesar_vectors.html', data)
 
 
-@login_required
-@mission_is_member
-def marine_vectors_create(request, mission_user):
-    """
-    Create a Marine Total Drift Vector
-    """
-    # pylint: disable=R0914,R0915
+@method_decorator(login_required, name="dispatch")
+@method_decorator(mission_is_member, name="dispatch")
+class MarineVectorCreateView(View):
+    """Create a Marine Total Drift Vector (GET previews, POST saves)."""
 
-    user_data = None
-    save = False
-    if request.method == "POST":
-        user_data = request.POST
-        save = True
-    if request.method == "GET":
-        user_data = request.GET
-    else:
-        HttpResponseNotFound('Unknown Method')
+    def _compute_vector(self, user_data, mission_user, save):  # pylint: disable=R0914,R0915
+        """Build the drift vector from user_data; persist it if save=True."""
+        vectors = []
+        current_vectors = []
+        wind_vectors = []
+        poi_id = user_data.get('poi_id')
+        poi = get_object_or_404(GeoTimeLabel, pk=poi_id, geo_type='poi')
+        lat = user_data.get('from_lat')
+        lng = user_data.get('from_lng')
+        start_point = Point(float(lng), float(lat))
+        leeway_multiplier = float(user_data.get('leeway_multiplier'))
+        leeway_modifier = float(user_data.get('leeway_modifier'))
+        curr_count = int(user_data.get('curr_total'))
+        for i in range(curr_count):
+            time_from = user_data.get(f'curr_{i}_from')
+            time_to = user_data.get(f'curr_{i}_to')
+            bearing = int(user_data.get(f'curr_{i}_direction'))
+            distance = float(user_data.get(f'curr_{i}_distance')) * 1852
+            speed = float(user_data.get(f'curr_{i}_speed'))
+            vector = {'order': i + 1, 'from': time_from, 'to': time_to, 'bearing': bearing, 'speed': speed, 'distance': distance}
+            current_vectors.append(vector)
+            vectors.append(vector)
+        wind_count = int(user_data.get('wind_total'))
+        for i in range(wind_count):
+            time_from = user_data.get(f'wind_{i}_from')
+            time_to = user_data.get(f'wind_{i}_to')
+            wind_from = user_data.get(f'wind_{i}_from_direction')
+            wind_speed = float(user_data.get(f'wind_{i}_speed'))
+            bearing = int(user_data.get(f'wind_{i}_direction'))
+            distance = float(user_data.get(f'wind_{i}_distance')) * 1852
+            vector = {'order': i + 1, 'from': time_from, 'to': time_to, 'wind_direction_from': wind_from, 'speed': wind_speed, 'bearing': bearing, 'distance': distance}
+            wind_vectors.append(vector)
+            vectors.append(vector)
+        points = [start_point]
+        current_point = start_point
+        query = (
+            "SELECT ST_Project("
+            "ST_SetSRID(ST_Point(%s, %s), 4326)::geography, %s, radians(%s)"
+            ")"
+        )
+        for vector in vectors:
+            with dbconn.cursor() as cursor:
+                cursor.execute(query, [
+                    float(current_point.x),
+                    float(current_point.y),
+                    float(vector['distance']),
+                    float(vector['bearing'])
+                ])
+                reference_points = cursor.fetchone()
+            current_point = GEOSGeometry(reference_points[0])
+            points.append(current_point)
+        total_drift_vector = MarineTotalDriftVector(
+            geo=LineString(points), leeway_multiplier=leeway_multiplier, leeway_modifier=leeway_modifier,
+            mission=mission_user.mission, created_by=mission_user.user, created_at=timezone.now(), datum=poi,
+        )
+        if save:
+            total_drift_vector.save()
+            for current in current_vectors:
+                start_time = convert_time(str(current['from']))
+                end_time = convert_time(str(current['to']))
+                MarineTotalDriftVectorCurrent(total_drift=total_drift_vector, order=current['order'], start_time=start_time, end_time=end_time, direction=current['bearing'], speed=current['speed']).save()
+            for wind in wind_vectors:
+                start_time = convert_time(str(wind['from']))
+                end_time = convert_time(str(wind['to']))
+                MarineTotalDriftVectorWind(total_drift=total_drift_vector, order=wind['order'], start_time=start_time, end_time=end_time, wind_from_direction=wind['wind_direction_from'], wind_speed=wind['speed']).save()
+        return total_drift_vector
 
-    vectors = []
-    current_vectors = []
-    wind_vectors = []
-    poi_id = user_data.get('poi_id')
-    poi = get_object_or_404(GeoTimeLabel, pk=poi_id, geo_type='poi')
-    lat = user_data.get('from_lat')
-    lng = user_data.get('from_lng')
-    start_point = Point(float(lng), float(lat))
-    leeway_multiplier = float(user_data.get('leeway_multiplier'))
-    leeway_modifier = float(user_data.get('leeway_modifier'))
-    curr_count = int(user_data.get('curr_total'))
-    for i in range(curr_count):
-        time_from = user_data.get(f'curr_{i}_from')
-        time_to = user_data.get(f'curr_{i}_to')
-        bearing = int(user_data.get(f'curr_{i}_direction'))
-        distance = float(user_data.get(f'curr_{i}_distance')) * 1852
-        speed = float(user_data.get(f'curr_{i}_speed'))
-        vector = {'order': i + 1, 'from': time_from, 'to': time_to, 'bearing': bearing, 'speed': speed, 'distance': distance}
-        current_vectors.append(vector)
-        vectors.append(vector)
-    wind_count = int(user_data.get('wind_total'))
-    for i in range(wind_count):
-        time_from = user_data.get(f'wind_{i}_from')
-        time_to = user_data.get(f'wind_{i}_to')
-        wind_from = user_data.get(f'wind_{i}_from_direction')
-        wind_speed = float(user_data.get(f'wind_{i}_speed'))
-        bearing = int(user_data.get(f'wind_{i}_direction'))
-        distance = float(user_data.get(f'wind_{i}_distance')) * 1852
-        vector = {'order': i + 1, 'from': time_from, 'to': time_to, 'wind_direction_from': wind_from, 'speed': wind_speed, 'bearing': bearing, 'distance': distance}
-        wind_vectors.append(vector)
-        vectors.append(vector)
+    def get(self, request, mission_user):
+        """Preview drift vector without saving."""
+        return to_geojson(MarineTotalDriftVector, [self._compute_vector(request.GET, mission_user, save=False)])
 
-    points = [start_point]
-    current_point = start_point
-    query = (
-        "SELECT ST_Project("
-        "ST_SetSRID(ST_Point(%s, %s), 4326)::geography, %s, radians(%s)"
-        ")"
-    )
-    for vector in vectors:
-        with dbconn.cursor() as cursor:
-            cursor.execute(query, [
-                float(current_point.x),
-                float(current_point.y),
-                float(vector['distance']),
-                float(vector['bearing'])
-            ])
-            reference_points = cursor.fetchone()
-
-        current_point = GEOSGeometry(reference_points[0])
-        points.append(current_point)
-
-    total_drift_vector = MarineTotalDriftVector(geo=LineString(points), leeway_multiplier=leeway_multiplier, leeway_modifier=leeway_modifier, mission=mission_user.mission, created_by=mission_user.user, created_at=timezone.now(), datum=poi)
-    if save:
-        total_drift_vector.save()
-        for current in current_vectors:
-            start_time = convert_time(str(current['from']))
-            end_time = convert_time(str(current['to']))
-            current_vector = MarineTotalDriftVectorCurrent(total_drift=total_drift_vector, order=current['order'], start_time=start_time, end_time=end_time, direction=current['bearing'], speed=current['speed'])
-            current_vector.save()
-        for wind in wind_vectors:
-            start_time = convert_time(str(wind['from']))
-            end_time = convert_time(str(wind['to']))
-            wind_vector = MarineTotalDriftVectorWind(total_drift=total_drift_vector, order=wind['order'], start_time=start_time, end_time=end_time, wind_from_direction=wind['wind_direction_from'], wind_speed=wind['speed'])
-            wind_vector.save()
-
-    return to_geojson(MarineTotalDriftVector, [total_drift_vector])
+    def post(self, request, mission_user):
+        """Compute and save drift vector."""
+        return to_geojson(MarineTotalDriftVector, [self._compute_vector(request.POST, mission_user, save=True)])
 
 
-@login_required
-@total_drift_from_type_id
-@data_get_mission_id('tdv')
-@mission_is_member
-def marine_vectors_delete(request, tdv, mission_user):
-    """
-    Delete a Marine Total Drift Vector
-    """
-    if not tdv.delete(mission_user.user):
-        if tdv.deleted_at:
-            return HttpResponseNotFound("Drift Vector has already been deleted")
-        if tdv.replaced_by is not None:
-            return HttpResponseNotFound("Drift Vector has been replaced")
-    return HttpResponse('Deleted')
+@method_decorator(login_required, name="dispatch")
+@method_decorator(total_drift_from_type_id, name="dispatch")
+@method_decorator(data_get_mission_id('tdv'), name="dispatch")
+@method_decorator(mission_is_member, name="dispatch")
+class MarineVectorDetailView(View):
+    """Get or delete a specific Marine Total Drift Vector."""
+
+    def get(self, request, tdv, mission_user):  # pylint: disable=unused-argument
+        """Return the vector as GeoJSON."""
+        return to_geojson(MarineTotalDriftVector, [tdv])
+
+    def delete(self, request, tdv, mission_user):
+        """Delete the vector."""
+        if not tdv.delete(mission_user.user):
+            if tdv.deleted_at:
+                return HttpResponseNotFound("Drift Vector has already been deleted")
+            if tdv.replaced_by is not None:
+                return HttpResponseNotFound("Drift Vector has been replaced")
+        return HttpResponse('Deleted')
 
 
 @login_required


### PR DESCRIPTION
## Description

- marine_vectors_create split into get() (preview) and post() (save) via shared _compute_vector() helper; pylint R0914/R0915 moved to helper method
- marine_vectors_delete becomes MarineVectorDetailView.delete(); also adds get() to return the vector as GeoJSON
- Delete URL changes from .../delete/ to .../<id>/ (DELETE method)
- Frontend: smmGet(.../delete/) → smmDelete(.../<id>/)

## Summary by Sourcery

Convert marine vector create/delete endpoints to class-based views and align frontend and URLs with RESTful patterns.

Enhancements:
- Replace function-based marine vector create view with a class-based view that supports GET previews and POST saves via a shared computation helper.
- Introduce a detail class-based view for marine drift vectors that supports GeoJSON retrieval via GET and soft deletion via DELETE, preserving existing validation logic.
- Update marine vector delete URL to a REST-style resource endpoint and switch the frontend to issue DELETE requests against it.