### PR TITLE
Merge image_priority_set/unset FBVs into ImagePriorityView CBV with PATCH

### DIFF
--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -95,6 +95,23 @@ function smmPostBody(url: string, body: FormData | URLSearchParams, success?: (d
   )
 }
 
+function smmPatch(url: string, data: Record<string, unknown>, success?: (data: unknown) => void, error?: (data?: unknown) => void) {
+  return request(
+    url,
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': cookieJar.get('csrftoken') ?? ''
+      },
+      body: JSON.stringify(data)
+    },
+    (r) => r.text(),
+    success,
+    error
+  )
+}
+
 function smmDelete(url: string, success?: (data: void) => void, error?: (data?: unknown) => void) {
   return request<void>(
     url,
@@ -110,4 +127,4 @@ function smmDelete(url: string, success?: (data: void) => void, error?: (data?: 
   )
 }
 
-export { smmGet, smmGetJSON, smmPost, smmPostBody, smmDelete }
+export { smmGet, smmGetJSON, smmPost, smmPostBody, smmPatch, smmDelete }

--- a/frontend/image/map.tsx
+++ b/frontend/image/map.tsx
@@ -4,7 +4,7 @@ import * as ReactDOM from 'react-dom/client'
 
 import { SMMRealtime } from '../smmmap'
 import { SMMImageGeoJSON } from './types'
-import { smmGet } from '../ajax'
+import { smmPatch } from '../ajax'
 import { ImagePopup } from './ImagePopup'
 
 abstract class SMMImage extends SMMRealtime {
@@ -50,8 +50,8 @@ abstract class SMMImage extends SMMRealtime {
         coords={image.geometry.coordinates}
         priority={image.properties.priority}
         missionId={this.missionId}
-        onPrioritize={() => smmGet(`/image/${imageID}/priority/set/`)}
-        onDeprioritize={() => smmGet(`/image/${imageID}/priority/unset/`)}
+        onPrioritize={() => smmPatch(`/image/${imageID}/priority/`, { priority: true })}
+        onDeprioritize={() => smmPatch(`/image/${imageID}/priority/`, { priority: false })}
       />
     )
     layer.bindPopup(container)

--- a/images/urls.py
+++ b/images/urls.py
@@ -13,8 +13,7 @@ urlpatterns = [
     re_path(r'^mission/(?P<mission_id>\d+)/image/list/important/$', views.images_list_important, name='images_list_important'),
     re_path(r'^image/(?P<image_id>\d+)/full/$', views.image_get_full, name='image_get_full'),
     re_path(r'^image/(?P<image_id>\d+)/thumbnail/$', views.image_get_thumbnail, name='image_get_thumbnail'),
-    re_path(r'^image/(?P<image_id>\d+)/priority/set/$', views.image_priority_set, name='image_priority_set'),
-    re_path(r'^image/(?P<image_id>\d+)/priority/unset/$', views.image_priority_unset, name='image_priority_unset'),
+    re_path(r'^image/(?P<image_id>\d+)/priority/$', views.ImagePriorityView.as_view(), name='image_priority'),
 
     re_path(r'^mission/all/image/list/all/$', views.images_list_all_user, {'current_only': False}),
     re_path(r'^mission/all/image/list/important/$', views.images_list_important_user, {'current_only': False}),

--- a/images/views.py
+++ b/images/views.py
@@ -3,6 +3,8 @@ Views for dealing with images uploaded by users
 
 """
 
+import json
+
 from django.http import HttpResponseBadRequest, HttpResponseRedirect, FileResponse, HttpResponse
 from django.contrib.auth.decorators import login_required
 from django.contrib.gis.geos import Point
@@ -104,31 +106,21 @@ def image_get_thumbnail(request, image):
     return FileResponse(open(f'images/thumbnail/{image.pk}.data', 'rb'), filename=f'thumbnail-{image.pk}.{image.original_format}')
 
 
-@login_required
-@image_from_id
-@data_get_mission_id(arg_name='image')
-@mission_is_member
-def image_priority_set(request, image, mission_user):
-    """
-    Set the priority flag on an image
-    """
-    image.priority = True
-    image.save()
-    timeline_record_image_priority_changed(mission_user.mission, mission_user.user, image)
+@method_decorator(login_required, name="dispatch")
+@method_decorator(image_from_id, name="dispatch")
+@method_decorator(data_get_mission_id(arg_name='image'), name="dispatch")
+@method_decorator(mission_is_member, name="dispatch")
+class ImagePriorityView(View):
+    """Set or unset the priority flag on an image via PATCH."""
 
-    return HttpResponse("Done")
-
-
-@login_required
-@image_from_id
-@data_get_mission_id(arg_name='image')
-@mission_is_member
-def image_priority_unset(request, image, mission_user):
-    """
-    UnSet the priority flag on an image
-    """
-    image.priority = False
-    image.save()
-    timeline_record_image_priority_changed(mission_user.mission, mission_user.user, image)
-
-    return HttpResponse("Done")
+    def patch(self, request, image, mission_user):
+        """Update image priority from JSON body {"priority": true/false}."""
+        try:
+            body = json.loads(request.body)
+            priority = bool(body.get('priority'))
+        except (ValueError, KeyError):
+            return HttpResponseBadRequest('Expected JSON body with {"priority": true/false}')
+        image.priority = priority
+        image.save()
+        timeline_record_image_priority_changed(mission_user.mission, mission_user.user, image)
+        return HttpResponse("Done")


### PR DESCRIPTION
## Description

- Two GET-based /priority/set/ and /priority/unset/ endpoints replaced by a single PATCH /priority/ endpoint accepting {"priority": true/false}
- Add smmPatch() to ajax.ts for JSON-body PATCH requests
- Frontend updated to use smmPatch instead of smmGet

## Summary by Sourcery

Consolidate image priority toggling into a single PATCH-based endpoint and update the frontend to use a new JSON PATCH helper for changing image priority.

New Features:
- Introduce ImagePriorityView class-based view to set or unset image priority via a PATCH request with a JSON body.
- Add smmPatch helper in the frontend for sending JSON-body PATCH requests.

Enhancements:
- Replace separate image priority set/unset endpoints with a single unified /priority/ URL.
- Update image map UI interactions to use the new PATCH endpoint for prioritizing and deprioritizing images.