### PR TITLE
Change MissionUserView.post() to patch() for permission updates

### DIFF
--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -5,7 +5,7 @@ import { Table, Button, ButtonGroup } from 'react-bootstrap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import { smmGetJSON, smmPost, smmDelete } from '../ajax'
+import { smmGetJSON, smmPost, smmPatch, smmDelete } from '../ajax'
 
 import { SMMMissionTopBar } from '../menu/topbar'
 
@@ -486,27 +486,27 @@ class MissionDetailsUserRow extends React.Component<MissionDetailsUserRowProps, 
   }
 
   removeAdmin() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: false })
+    smmPatch(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: false })
   }
 
   makeAdmin() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: true })
+    smmPatch(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { admin: true })
   }
 
   disableOrgAdd() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: false })
+    smmPatch(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: false })
   }
 
   enableOrgAdd() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: true })
+    smmPatch(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_organization: true })
   }
 
   disableUserAdd() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: false })
+    smmPatch(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: false })
   }
 
   enableUserAdd() {
-    smmPost(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: true })
+    smmPatch(`/mission/${this.props.mission}/users/${this.props.missionUser.user_id}/`, { add_user: true })
   }
 
   render() {

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -63,9 +63,7 @@ class MissionTestWrapper:
             client = self.smm.client1
         if user is None:
             user = self.smm.user2
-        return client.post(f'/mission/{self.mission_pk}/users/{user.pk}/', data={
-            'admin': True,
-        })
+        return client.patch(f'/mission/{self.mission_pk}/users/{user.pk}/', data='{"admin": true}', content_type='application/json')
 
     def close(self, client=None):
         """
@@ -261,7 +259,7 @@ class MissionTestCase(MissionBaseTestCase):
         mission_user = MissionUser.objects.get(mission=mission_obj, user=self.smm.user2)
         self.assertFalse(mission_user.is_admin())
         response = mission.make_admin(client=self.smm.client1, user=self.smm.user2)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
         mission_user = MissionUser.objects.get(mission=mission_obj, user=self.smm.user2)
         self.assertTrue(mission_user.is_admin())
 

--- a/mission/views.py
+++ b/mission/views.py
@@ -1,6 +1,7 @@
 """
 Mission Create/Management Views.
 """
+import json
 
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist
@@ -437,7 +438,7 @@ class MissionUserView(View):
         setattr(target_mission_user, f"permissions_{permission_type}", value)
         timeline_record_mission_user_update(mission_user.mission, mission_user.user, target_mission_user, permission_type, value)
 
-    def post(self, request, mission_user, user):
+    def patch(self, request, mission_user, user):
         """
         Update the permissions of a user
         """
@@ -445,20 +446,24 @@ class MissionUserView(View):
             return HttpResponseForbidden("Not an admin")
         if mission_user.user == user:
             return HttpResponseForbidden("Cannot modify yourself")
-        admin = request.POST.get('admin', None)
-        add_organization = request.POST.get('add_organization', None)
-        add_user = request.POST.get('add_user', None)
+        try:
+            body = json.loads(request.body)
+        except ValueError:
+            return HttpResponseBadRequest('Expected JSON body')
+        admin = body.get('admin', None)
+        add_organization = body.get('add_organization', None)
+        add_user = body.get('add_user', None)
 
         if admin is not None or add_organization is not None or add_user is not None:
             target_mission_user = get_object_or_404(MissionUser, mission=mission_user.mission, user=user)
             if admin is not None:
-                self._update_user_permissions(mission_user, target_mission_user, 'admin', admin.lower() == "true")
+                self._update_user_permissions(mission_user, target_mission_user, 'admin', bool(admin))
             if add_organization is not None:
-                self._update_user_permissions(mission_user, target_mission_user, 'organization_add', add_organization.lower() == "true")
+                self._update_user_permissions(mission_user, target_mission_user, 'organization_add', bool(add_organization))
             if add_user is not None:
-                self._update_user_permissions(mission_user, target_mission_user, 'user_add', add_user.lower() == "true")
+                self._update_user_permissions(mission_user, target_mission_user, 'user_add', bool(add_user))
             target_mission_user.save()
-        return HttpResponseRedirect(f'/mission/{mission_user.mission.pk}/details/')
+        return HttpResponse('')
 
 
 @method_decorator(login_required, name="dispatch")


### PR DESCRIPTION
## Description

Permission updates are partial — only the fields sent change — so PATCH is the correct HTTP verb. Backend now reads JSON body instead of form data; frontend updated to use smmPatch. Test helper updated to PATCH with JSON and to expect 200 instead of a 302 redirect.

## Summary by Sourcery

Switch mission user permission updates to use PATCH with JSON payloads instead of POSTing form data, and align frontend and tests with the new API behavior.

Bug Fixes:
- Ensure mission user permission updates correctly handle boolean fields from JSON rather than relying on string form values.

Enhancements:
- Change MissionUserView to expose a PATCH endpoint for partial permission updates and return an empty 200 OK response instead of a redirect.

Tests:
- Update mission test helpers and assertions to use PATCH with JSON and expect a 200 OK response instead of a redirect.