### PR TITLE
Bump marine-total-drift-vector to 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@canterbury-air-patrol/leaflet-dialog": "^1.2.1",
         "@canterbury-air-patrol/marine-leeway-data": "^0.2.2",
         "@canterbury-air-patrol/marine-search-area-coverage": "^0.6.2",
-        "@canterbury-air-patrol/marine-total-drift-vector": "^0.4.2",
+        "@canterbury-air-patrol/marine-total-drift-vector": "^0.4.3",
         "@canterbury-air-patrol/sar-search-patterns": "0.1.4",
         "@canterbury-air-patrol/sar-search-runner": "0.1.3",
         "bootstrap": "^5.3.8",
@@ -114,12 +114,12 @@
       "license": "PDDL-1.0"
     },
     "node_modules/@canterbury-air-patrol/marine-total-drift-vector": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/marine-total-drift-vector/-/marine-total-drift-vector-0.4.2.tgz",
-      "integrity": "sha512-Cg19yQLDWg/y7q5wtE2khMkZHyx/cP0b2q+3PC1fxGNlrSPuw1T8x6mXIC+yTIMzcWvPTy9opjCNsIbm7PiWSA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/marine-total-drift-vector/-/marine-total-drift-vector-0.4.3.tgz",
+      "integrity": "sha512-eDt5AvyjjLqXj7NJ33T1AG/oSvUbxhQG/9N+7LAOpNE8fGJ73BV9wMERQu7B+jXxPxnlPQkbM8fFWfZD65RuZQ==",
       "license": "MIT",
       "dependencies": {
-        "@canterbury-air-patrol/deg-converter": "^0.2.0",
+        "@canterbury-air-patrol/deg-converter": "^0.3.0",
         "@canterbury-air-patrol/marine-leeway-data": "^0.2.1",
         "@types/react": "^19.0.1",
         "@types/react-dom": "^19.0.2",
@@ -132,12 +132,6 @@
         "react": "~19.2.0",
         "react-dom": "~19.2.0"
       }
-    },
-    "node_modules/@canterbury-air-patrol/marine-total-drift-vector/node_modules/@canterbury-air-patrol/deg-converter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/deg-converter/-/deg-converter-0.2.0.tgz",
-      "integrity": "sha512-yGEya6smb1RszuoXmG77q4Zh3HsW3AxZBo7fNQt73cxt+Gbvs2N2DwL+ua0ClyrNjQCF1QqpcDV7GX7vBvkikg==",
-      "license": "MIT"
     },
     "node_modules/@canterbury-air-patrol/sar-search-patterns": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@canterbury-air-patrol/leaflet-dialog": "^1.2.1",
     "@canterbury-air-patrol/marine-leeway-data": "^0.2.2",
     "@canterbury-air-patrol/marine-search-area-coverage": "^0.6.2",
-    "@canterbury-air-patrol/marine-total-drift-vector": "^0.4.2",
+    "@canterbury-air-patrol/marine-total-drift-vector": "^0.4.3",
     "@canterbury-air-patrol/sar-search-patterns": "0.1.4",
     "@canterbury-air-patrol/sar-search-runner": "0.1.3",
     "bootstrap": "^5.3.8",


### PR DESCRIPTION
## Description

0.4.3 fixes the prototype-stripping bug in updateCurrentData/updateWindData by using Object.assign with Object.create(getPrototypeOf(...)) instead of object spread, making the workaround in CustomMarineVectors unnecessary.

## Summary by Sourcery

Build:
- Update @canterbury-air-patrol/marine-total-drift-vector dependency version from 0.4.2 to 0.4.3.