### PR TITLE
Convert map.tsx and asset/map.tsx ajax calls to typed generics; inline assetListCB

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -155,7 +155,6 @@ class SMMAssets extends SMMRealtime {
     this.assetUpdate = this.assetUpdate.bind(this)
     this.assetLayer = this.assetLayer.bind(this)
     this.updateAssetNameMap = this.updateAssetNameMap.bind(this)
-    this.assetListCB = this.assetListCB.bind(this)
     this.assetNameMap = {}
     this.assetIconMap = {}
     this.assetStatusMap = {}
@@ -166,7 +165,8 @@ class SMMAssets extends SMMRealtime {
     return `/mission/${this.missionId}/data/assets/positions/latest/`
   }
 
-  assetListCB(data: { assets: Array<MissionAssetData> }) {
+  async updateAssetNameMap() {
+    const data = await smmGetJSON<{ assets: Array<MissionAssetData> }>(`/mission/${this.missionId}/assets/?include_removed=true`, {})
     for (const asset of data.assets) {
       this.assetNameMap[asset.id] = asset.name
       if (asset.status) {
@@ -176,10 +176,6 @@ class SMMAssets extends SMMRealtime {
         this.assetIconMap[asset.id] = asset.icon_url
       }
     }
-  }
-
-  updateAssetNameMap() {
-    smmGetJSON(`/mission/${this.missionId}/assets/?include_removed=true`, {}, this.assetListCB)
   }
 
   realtime() {

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -121,7 +121,7 @@ class SMMMap {
     L.Icon.Default.prototype.options.iconRetinaUrl = markerIcon2x
     L.Icon.Default.prototype.options.shadowUrl = markerIconShadow
 
-    smmGetJSON('/map/tile/layers/', {}, this.mapLayersCallback)
+    smmGetJSON<Parameters<typeof this.mapLayersCallback>[0]>('/map/tile/layers/', {}).then(this.mapLayersCallback)
 
     this.layerControl.addTo(this.map)
     this.layerControlMaps.addTo(this.map)


### PR DESCRIPTION
## Summary by Sourcery

Refactor map-related AJAX calls to use typed generic smmGetJSON promises and inline the asset list callback into the asset name map updater.

Enhancements:
- Update asset map initialization to fetch and process mission assets via a typed, async smmGetJSON call instead of a separate bound callback.
- Change map layer loading to use a typed smmGetJSON promise resolved directly into the existing mapLayersCallback.