### PR TITLE
Inline async/await callbacks in asset/ui.tsx and marine/leaflet.tsx

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -405,7 +405,6 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
       notes: ''
     }
 
-    this.updateStatusValuesResponse = this.updateStatusValuesResponse.bind(this)
     this.updateSelectedStateValue = this.updateSelectedStateValue.bind(this)
     this.updateNotes = this.updateNotes.bind(this)
     this.resetForm = this.resetForm.bind(this)
@@ -422,20 +421,12 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
     this.timer = undefined
   }
 
-  updateStatusValuesResponse(data: { values: AssetStatusValueData[] }) {
-    this.setState(function (oldState) {
-      const newState: AssetStatusState = {
-        statusValues: data.values
-      }
-      if (oldState.selectedValueId === null && data.values.length > 0) {
-        newState.selectedValueId = data.values[0].id
-      }
-      return newState
-    })
-  }
-
   async updateStatusValues() {
-    await smmGetJSON('/assets/status/values/', {}, this.updateStatusValuesResponse)
+    const data = await smmGetJSON<{ values: AssetStatusValueData[] }>('/assets/status/values/', {})
+    this.setState((oldState) => ({
+      statusValues: data.values,
+      ...(oldState.selectedValueId === null && data.values.length > 0 ? { selectedValueId: data.values[0].id } : {})
+    }))
   }
 
   updateSelectedStateValue(event: React.ChangeEvent<HTMLSelectElement>) {
@@ -457,15 +448,12 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
     })
   }
 
-  setStatus() {
-    smmPost(
-      `/assets/${this.props.asset}/status/`,
-      {
-        value_id: this.state.selectedValueId,
-        notes: this.state.notes
-      },
-      this.resetForm
-    )
+  async setStatus() {
+    await smmPost(`/assets/${this.props.asset}/status/`, {
+      value_id: this.state.selectedValueId,
+      notes: this.state.notes
+    })
+    this.resetForm()
   }
 
   render() {

--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -64,39 +64,23 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
     return data
   }
 
-  add() {
-    smmPostBody(
-      `/mission/${this.props.missionId}/sar/marine/vectors/create/`,
-      URLSearchParams(this.getData()),
-      () => {
-        if (this.onMap) {
-          this.props.map.removeLayer(this.onMap)
-          this.onMap = undefined
-        }
-        this.props.dialog.remove()
-      },
-      () => {
-        console.error('Error fetching data:')
-      }
-    )
-  }
-
-  preview() {
+  async add() {
+    await smmPostBody(`/mission/${this.props.missionId}/sar/marine/vectors/create/`, URLSearchParams(this.getData()))
     if (this.onMap) {
       this.props.map.removeLayer(this.onMap)
       this.onMap = undefined
     }
-    smmGetJSON(
-      `/mission/${this.props.missionId}/sar/marine/vectors/create/`,
-      this.getData(),
-      (data) => {
-        this.onMap = L.geoJSON(data, { color: 'yellow' })
-        this.onMap.addTo(this.props.map)
-      },
-      () => {
-        console.error('Error fetching data:')
-      }
-    )
+    this.props.dialog.remove()
+  }
+
+  async preview() {
+    if (this.onMap) {
+      this.props.map.removeLayer(this.onMap)
+      this.onMap = undefined
+    }
+    const data = await smmGetJSON<GeoJSON.GeoJsonObject>(`/mission/${this.props.missionId}/sar/marine/vectors/create/`, this.getData())
+    this.onMap = L.geoJSON(data, { color: 'yellow' })
+    this.onMap.addTo(this.props.map)
   }
 
   cancel() {


### PR DESCRIPTION
## Summary by Sourcery

Refactor frontend asset and marine UI components to use async/await-based HTTP helpers instead of callback-style APIs while preserving existing behavior.

Enhancements:
- Convert marine vector add and preview actions to async/await-style smmPostBody and smmGetJSON calls and simplify error handling.
- Inline asset status value fetch and state update logic into an async method using smmGetJSON, removing the separate response handler and binding.
- Update asset status submission to use an async smmPost call followed by a form reset instead of a callback-based flow.