### PR TITLE
Fix URLSearchParams missing 'new' in marine vectors add()

### DIFF
--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -65,7 +65,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   }
 
   async add() {
-    await smmPostBody(`/mission/${this.props.missionId}/sar/marine/vectors/create/`, URLSearchParams(this.getData()))
+    await smmPostBody(`/mission/${this.props.missionId}/sar/marine/vectors/create/`, new URLSearchParams(this.getData()))
     if (this.onMap) {
       this.props.map.removeLayer(this.onMap)
       this.onMap = undefined


### PR DESCRIPTION
## Description

The URLSearchParams constructor requires 'new' — calling it without caused a TypeError that was previously swallowed by an error callback. The async refactor made the error visible.

## Summary by Sourcery

Bug Fixes:
- Fix marine vector creation by instantiating URLSearchParams with 'new' to avoid TypeError during add().