### PR TITLE
Convert SearchQueueDialog to async/await (completes modernize-ajax)

### DIFF
--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -16,20 +16,18 @@ export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: 
   const [selectedAssetId, setSelectedAssetId] = useState('')
 
   useEffect(() => {
-    smmGetJSON(`/mission/${missionId}/assets/`, {}, (data) => {
-      const d = data as { assets: Array<MissionAssetData> }
-      if ('assets' in d) {
-        const filtered = d.assets.filter((a) => a.type_name === createdFor)
-        setAssets(filtered)
-        if (filtered.length > 0) setSelectedAssetId(String(filtered[0].id))
-      }
+    smmGetJSON<{ assets: Array<MissionAssetData> }>(`/mission/${missionId}/assets/`, {}).then((d) => {
+      const filtered = d.assets.filter((a) => a.type_name === createdFor)
+      setAssets(filtered)
+      if (filtered.length > 0) setSelectedAssetId(String(filtered[0].id))
     })
   }, [])
 
-  function handleQueue() {
+  async function handleQueue() {
     const data: { asset?: string } = {}
     if (selectType === 'asset') data.asset = selectedAssetId
-    smmPost(`/search/${searchPk}/queue/`, data, onClose)
+    await smmPost(`/search/${searchPk}/queue/`, data)
+    onClose()
   }
 
   return (


### PR DESCRIPTION
## Description

Replace smmGetJSON callback with .then() and typed generic. Replace smmPost(..., onClose) callback with await + explicit onClose().

## Summary by Sourcery

Modernize the SearchQueueDialog component to use promise-based and async/await patterns for search asset loading and queuing actions.

Enhancements:
- Replace callback-based smmGetJSON usage with a typed promise-based call when loading mission assets.
- Convert the search queue submission flow to use async/await and invoke the close handler explicitly after a successful post.