### PR TITLE
Refactor SMMPOI/SMMLine/SMMPolygon to use abstract base classes

### DIFF
--- a/frontend/usergeo/line.tsx
+++ b/frontend/usergeo/line.tsx
@@ -1,83 +1,57 @@
 import L from 'leaflet'
 import React from 'react'
-import * as ReactDOM from 'react-dom/client'
 
-import { SMMRealtime } from '../smmmap'
-import { SMMUserGeoLabelData, SMMUserGeoLineGeoJSON } from './types'
-import { smmDelete } from '../ajax'
+import { SMMUserGeoLineGeoJSON } from './types'
 import { LinePopup } from './LinePopup'
+import { SMMUserGeoLayer, SMMUserGeoCollection } from './base'
 
-class SMMLine {
-  parent: SMMLines
+class SMMLine extends SMMUserGeoLayer {
   coords: [number, number][]
-  data: SMMUserGeoLabelData
-  constructor(parent: SMMLines, line: SMMUserGeoLineGeoJSON) {
-    this.parent = parent
+
+  constructor(map: L.Map, missionId: number | string, line: SMMUserGeoLineGeoJSON) {
+    super(map, missionId, line.properties)
     this.coords = line.geometry.coordinates
-    this.data = line.properties
-    this.editCallback = this.editCallback.bind(this)
-    this.deleteCallback = this.deleteCallback.bind(this)
-    this.createSearchCallback = this.createSearchCallback.bind(this)
   }
 
   editCallback() {
     L.LineAdder(
-      this.parent.map,
-      this.parent.missionId,
+      this.map,
+      this.missionId,
       this.coords.map((x) => L.latLng(x[1], x[0])),
       this.data.pk,
       this.data.label
     )
   }
 
-  deleteCallback() {
-    smmDelete(`/data/usergeo/${this.data.pk}/`)
-  }
-
   createSearchCallback() {
-    L.SearchAdder(this.parent.map, 'line', this.data.pk)
+    L.SearchAdder(this.map, 'line', this.data.pk)
   }
 
-  createPopup(layer: L.Layer) {
-    const container = document.createElement('div')
-    const root = ReactDOM.createRoot(container)
-    root.render(
+  getPopupOptions(): L.PopupOptions {
+    return { minWidth: 200 }
+  }
+
+  renderPopup() {
+    return (
       <LinePopup
         label={this.data.label}
         pk={this.data.pk}
-        missionId={this.parent.missionId}
+        missionId={this.missionId}
         onEdit={this.editCallback}
         onDelete={this.deleteCallback}
         onCreateSearch={this.createSearchCallback}
       />
     )
-    layer.bindPopup(container, { minWidth: 200 })
-    layer.on('remove', () => root.unmount())
   }
 }
 
-class SMMLines extends SMMRealtime {
-  lineObjects: { [key: number]: SMMLine }
-  constructor(map: L.Map, missionId: number | string, interval: number, color: hex) {
-    super(map, missionId, interval, color)
-    this.lineObjects = {}
-    this.createPopup = this.createPopup.bind(this)
-  }
-
+class SMMLines extends SMMUserGeoCollection<SMMUserGeoLineGeoJSON, SMMLine> {
   getUrl() {
     return `/mission/${this.missionId}/data/userlines/current/`
   }
 
-  getObject(pk: number, line: SMMUserGeoLineGeoJSON) {
-    if (!(pk in this.lineObjects)) {
-      const lineObject = new SMMLine(this, line)
-      this.lineObjects[pk] = lineObject
-    }
-    return this.lineObjects[pk]
-  }
-
-  createPopup(line: SMMUserGeoLineGeoJSON, layer: L.Layer) {
-    this.getObject(line.properties.pk, line).createPopup(layer)
+  createObject(line: SMMUserGeoLineGeoJSON) {
+    return new SMMLine(this.map, this.missionId, line)
   }
 }
 

--- a/frontend/usergeo/poi.tsx
+++ b/frontend/usergeo/poi.tsx
@@ -1,88 +1,56 @@
 import L from 'leaflet'
-import '@canterbury-air-patrol/leaflet-dialog'
+
 import React from 'react'
-import * as ReactDOM from 'react-dom/client'
-
-import { smmDelete } from '../ajax'
-
-import { SMMRealtime } from '../smmmap'
 
 import { MarineVectorsLeaflet } from '../marine/leaflet'
-import { SMMUserGeoLabelData, SMMUserGeoPOIGeoJSON } from './types'
+import { SMMUserGeoPOIGeoJSON } from './types'
 import { POIPopup } from './POIPopup'
+import { SMMUserGeoLayer, SMMUserGeoCollection } from './base'
 
-class SMMPOI {
-  parent: SMMPOIs
+class SMMPOI extends SMMUserGeoLayer {
   coords: [number, number]
-  data: SMMUserGeoLabelData
-  constructor(parent: SMMPOIs, poi: SMMUserGeoPOIGeoJSON) {
-    this.parent = parent
+
+  constructor(map: L.Map, missionId: number | string, poi: SMMUserGeoPOIGeoJSON) {
+    super(map, missionId, poi.properties)
     this.coords = poi.geometry.coordinates
-    this.data = poi.properties
-    this.editCallback = this.editCallback.bind(this)
-    this.deleteCallback = this.deleteCallback.bind(this)
-    this.createSearchCallback = this.createSearchCallback.bind(this)
     this.calculateTDVCallback = this.calculateTDVCallback.bind(this)
   }
 
   editCallback() {
-    L.POIAdder(this.parent.map, this.parent.missionId, L.latLng(this.coords[1], this.coords[0]), this.data.pk, this.data.label)
-  }
-
-  deleteCallback() {
-    smmDelete(`/data/usergeo/${this.data.pk}/`)
+    L.POIAdder(this.map, this.missionId, L.latLng(this.coords[1], this.coords[0]), this.data.pk, this.data.label)
   }
 
   createSearchCallback() {
-    L.SearchAdder(this.parent.map, 'point', this.data.pk)
+    L.SearchAdder(this.map, 'point', this.data.pk)
   }
 
   calculateTDVCallback() {
-    MarineVectorsLeaflet(this.parent.map, this.parent.missionId, this.data.label, L.latLng(this.coords[1], this.coords[0]), this.data.pk)
+    MarineVectorsLeaflet(this.map, this.missionId, this.data.label, L.latLng(this.coords[1], this.coords[0]), this.data.pk)
   }
 
-  createPopup(layer: L.Layer) {
-    const container = document.createElement('div')
-    const root = ReactDOM.createRoot(container)
-    root.render(
+  renderPopup() {
+    return (
       <POIPopup
         label={this.data.label}
         coords={this.coords}
         pk={this.data.pk}
-        missionId={this.parent.missionId}
+        missionId={this.missionId}
         onEdit={this.editCallback}
         onDelete={this.deleteCallback}
         onCreateSearch={this.createSearchCallback}
         onCalculateTDV={this.calculateTDVCallback}
       />
     )
-    layer.bindPopup(container)
-    layer.on('remove', () => root.unmount())
   }
 }
 
-class SMMPOIs extends SMMRealtime {
-  poiObjects: { [key: string]: SMMPOI }
-  constructor(map: L.Map, missionId: string | number, interval: number, color: string) {
-    super(map, missionId, interval, color)
-    this.poiObjects = {}
-    this.createPopup = this.createPopup.bind(this)
-  }
-
+class SMMPOIs extends SMMUserGeoCollection<SMMUserGeoPOIGeoJSON, SMMPOI> {
   getUrl() {
     return `/mission/${this.missionId}/data/pois/current/`
   }
 
-  getObject(pk: number, poi: SMMUserGeoPOIGeoJSON) {
-    if (!(pk in this.poiObjects)) {
-      const poiObject = new SMMPOI(this, poi)
-      this.poiObjects[pk] = poiObject
-    }
-    return this.poiObjects[pk]
-  }
-
-  createPopup(poi: SMMUserGeoPOIGeoJSON, layer: L.Layer) {
-    this.getObject(poi.properties.pk, poi).createPopup(layer)
+  createObject(poi: SMMUserGeoPOIGeoJSON) {
+    return new SMMPOI(this.map, this.missionId, poi)
   }
 }
 

--- a/frontend/usergeo/polygon.tsx
+++ b/frontend/usergeo/polygon.tsx
@@ -1,84 +1,57 @@
 import L from 'leaflet'
 import React from 'react'
-import * as ReactDOM from 'react-dom/client'
 
-import { smmDelete } from '../ajax'
-
-import { SMMRealtime } from '../smmmap'
-import { SMMUserGeoLabelData, SMMUserGeoPolygonGeoJSON } from './types'
+import { SMMUserGeoPolygonGeoJSON } from './types'
 import { PolygonPopup } from './PolygonPopup'
+import { SMMUserGeoLayer, SMMUserGeoCollection } from './base'
 
-class SMMPolygon {
-  parent: SMMPolygons
+class SMMPolygon extends SMMUserGeoLayer {
   coords: [number, number][][]
-  data: SMMUserGeoLabelData
-  constructor(parent: SMMPolygons, polygon: SMMUserGeoPolygonGeoJSON) {
-    this.parent = parent
-    this.data = polygon.properties
+
+  constructor(map: L.Map, missionId: number | string, polygon: SMMUserGeoPolygonGeoJSON) {
+    super(map, missionId, polygon.properties)
     this.coords = polygon.geometry.coordinates
-    this.editCallback = this.editCallback.bind(this)
-    this.deleteCallback = this.deleteCallback.bind(this)
-    this.createSearchCallback = this.createSearchCallback.bind(this)
   }
 
   editCallback() {
     L.PolygonAdder(
-      this.parent.map,
-      this.parent.missionId,
+      this.map,
+      this.missionId,
       this.coords[0].map((x) => L.latLng(x[1], x[0])),
       this.data.pk,
       this.data.label
     )
   }
 
-  deleteCallback() {
-    smmDelete(`/data/usergeo/${this.data.pk}/`)
-  }
-
   createSearchCallback() {
-    L.SearchAdder(this.parent.map, 'polygon', this.data.pk)
+    L.SearchAdder(this.map, 'polygon', this.data.pk)
   }
 
-  createPopup(layer: L.Layer) {
-    const container = document.createElement('div')
-    const root = ReactDOM.createRoot(container)
-    root.render(
+  getPopupOptions(): L.PopupOptions {
+    return { minWidth: 200 }
+  }
+
+  renderPopup() {
+    return (
       <PolygonPopup
         label={this.data.label}
         pk={this.data.pk}
-        missionId={this.parent.missionId}
+        missionId={this.missionId}
         onEdit={this.editCallback}
         onDelete={this.deleteCallback}
         onCreateSearch={this.createSearchCallback}
       />
     )
-    layer.bindPopup(container, { minWidth: 200 })
-    layer.on('remove', () => root.unmount())
   }
 }
 
-class SMMPolygons extends SMMRealtime {
-  polygonObjects: { [key: number]: SMMPolygon }
-  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
-    super(map, missionId, interval, color)
-    this.polygonObjects = {}
-    this.createPopup = this.createPopup.bind(this)
-  }
-
+class SMMPolygons extends SMMUserGeoCollection<SMMUserGeoPolygonGeoJSON, SMMPolygon> {
   getUrl() {
     return `/mission/${this.missionId}/data/userpolygons/current/`
   }
 
-  getObject(pk: number, polygon: SMMUserGeoPolygonGeoJSON) {
-    if (!(pk in this.polygonObjects)) {
-      const polygonObject = new SMMPolygon(this, polygon)
-      this.polygonObjects[pk] = polygonObject
-    }
-    return this.polygonObjects[pk]
-  }
-
-  createPopup(polygon: SMMUserGeoPolygonGeoJSON, layer: L.Layer) {
-    this.getObject(polygon.properties.pk, polygon).createPopup(layer)
+  createObject(polygon: SMMUserGeoPolygonGeoJSON) {
+    return new SMMPolygon(this.map, this.missionId, polygon)
   }
 }
 


### PR DESCRIPTION
## Description

- Remove duplicate deleteCallback, createPopup boilerplate from all three
- Remove direct parent reference; pass map/missionId to base constructor
- SMMUserGeoCollection.createObject() replaces per-class getObject duplication
- POI still has calculateTDVCallback (POI-specific); line/polygon add getPopupOptions()

## Summary by Sourcery

Refactor user geo POI, line, and polygon layers to share a common abstract base for popup rendering and lifecycle management.

Enhancements:
- Introduce shared SMMUserGeoLayer and SMMUserGeoCollection abstractions for POI, line, and polygon user geo layers.
- Update SMMPOI, SMMLine, and SMMPolygon to extend the new base layer, removing direct parent references and duplicated popup/delete logic.
- Standardize popup rendering via React components and map/missionId passed through the base class, with POI retaining its TDV-specific callback and line/polygon providing popup options.