### PR TITLE
Remove L namespace extensions; use named exports for adder functions

### DIFF
--- a/frontend/LineAdder/LineAdder.js
+++ b/frontend/LineAdder/LineAdder.js
@@ -4,13 +4,13 @@ import L from 'leaflet'
 import { VectorAdderDialog } from '../components/VectorAdderDialog'
 import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 
-L.LineAdder = function (map, missionId, currentPoints, replaces, label) {
+function LineAdder(map, missionId, currentPoints, replaces, label) {
   renderInLeafletDialog(map, (onClose) => (
     <VectorAdderDialog type="line" map={map} missionId={missionId} initialPoints={currentPoints} replaces={replaces} initialLabel={label} onClose={onClose} />
   ))
 }
 
-L.Control.LineAdder = L.Control.extend({
+const LineAdderControl = L.Control.extend({
   options: {
     position: 'topleft'
   },
@@ -20,7 +20,7 @@ L.Control.LineAdder = L.Control.extend({
   },
 
   onClick: function () {
-    L.LineAdder(this.map, this.options.missionId, [this.map.getCenter()], -1, '')
+    LineAdder(this.map, this.options.missionId, [this.map.getCenter()], -1, '')
   },
 
   onAdd: function (map) {
@@ -47,6 +47,8 @@ L.Control.LineAdder = L.Control.extend({
   onRemove: function () {}
 })
 
-L.control.lineadder = function (opts) {
-  return new L.Control.LineAdder(opts)
+function lineadder(opts) {
+  return new LineAdderControl(opts)
 }
+
+export { LineAdder, lineadder }

--- a/frontend/POIAdder/POIAdder.js
+++ b/frontend/POIAdder/POIAdder.js
@@ -5,13 +5,13 @@ import markerIcon from 'leaflet/dist/images/marker-icon.png'
 import { POIAdderDialog } from './POIAdderDialog'
 import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 
-L.POIAdder = function (map, missionId, pos, replaces, label) {
+function POIAdder(map, missionId, pos, replaces, label) {
   renderInLeafletDialog(map, (onClose) => <POIAdderDialog map={map} missionId={missionId} initialPos={pos} replaces={replaces} initialLabel={label} onClose={onClose} />, {
     initOpen: true
   })
 }
 
-L.Control.POIAdder = L.Control.extend({
+const POIAdderControl = L.Control.extend({
   options: {
     position: 'topleft'
   },
@@ -21,7 +21,7 @@ L.Control.POIAdder = L.Control.extend({
   },
 
   onClick: function () {
-    L.POIAdder(this.map, this.options.missionId, this.map.getCenter(), -1, '')
+    POIAdder(this.map, this.options.missionId, this.map.getCenter(), -1, '')
   },
 
   onAdd: function (map) {
@@ -48,6 +48,8 @@ L.Control.POIAdder = L.Control.extend({
   onRemove: function () {}
 })
 
-L.control.poiadder = function (opts) {
-  return new L.Control.POIAdder(opts)
+function poiadder(opts) {
+  return new POIAdderControl(opts)
 }
+
+export { POIAdder, poiadder }

--- a/frontend/PolygonAdder/PolygonAdder.js
+++ b/frontend/PolygonAdder/PolygonAdder.js
@@ -4,13 +4,13 @@ import L from 'leaflet'
 import { VectorAdderDialog } from '../components/VectorAdderDialog'
 import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 
-L.PolygonAdder = function (map, missionId, currentPoints, replaces, label) {
+function PolygonAdder(map, missionId, currentPoints, replaces, label) {
   renderInLeafletDialog(map, (onClose) => (
     <VectorAdderDialog type="polygon" map={map} missionId={missionId} initialPoints={currentPoints} replaces={replaces} initialLabel={label} onClose={onClose} />
   ))
 }
 
-L.Control.PolygonAdder = L.Control.extend({
+const PolygonAdderControl = L.Control.extend({
   options: {
     position: 'topleft'
   },
@@ -20,7 +20,7 @@ L.Control.PolygonAdder = L.Control.extend({
   },
 
   onClick: function () {
-    L.PolygonAdder(this.map, this.options.missionId, [this.map.getCenter()], -1, '')
+    PolygonAdder(this.map, this.options.missionId, [this.map.getCenter()], -1, '')
   },
 
   onAdd: function (map) {
@@ -47,6 +47,8 @@ L.Control.PolygonAdder = L.Control.extend({
   onRemove: function () {}
 })
 
-L.control.polygonadder = function (opts) {
-  return new L.Control.PolygonAdder(opts)
+function polygonadder(opts) {
+  return new PolygonAdderControl(opts)
 }
+
+export { PolygonAdder, polygonadder }

--- a/frontend/SearchAdder/SearchAdder.js
+++ b/frontend/SearchAdder/SearchAdder.js
@@ -1,9 +1,10 @@
 import React from 'react'
-import L from 'leaflet'
 
 import { SearchAdderDialog } from './SearchAdderDialog'
 import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 
-L.SearchAdder = function (map, objectType, objectID) {
+function SearchAdder(map, objectType, objectID) {
   renderInLeafletDialog(map, (onClose) => <SearchAdderDialog map={map} objectType={objectType} objectID={objectID} onClose={onClose} />)
 }
+
+export { SearchAdder }

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -18,11 +18,10 @@ import 'leaflet.locatecontrol/dist/L.Control.Locate.min.css'
 import { cookieJar } from './cookies'
 
 import './Admin/admin.js'
-import './POIAdder/POIAdder.js'
-import './PolygonAdder/PolygonAdder.js'
-import './LineAdder/LineAdder.js'
 import './ImageUploader/ImageUploader.js'
-import './SearchAdder/SearchAdder.js'
+import { poiadder } from './POIAdder/POIAdder.js'
+import { polygonadder } from './PolygonAdder/PolygonAdder.js'
+import { lineadder } from './LineAdder/LineAdder.js'
 
 import { SMMSearchesComplete, SMMSearchesInprogress, SMMSearchesNotStarted } from './search/map.js'
 import { SMMPOIs } from './usergeo/poi.js'
@@ -133,9 +132,9 @@ class SMMMap {
     this.map.locate({ setView: true, maxZoom: 16 })
 
     if (this.missionId !== 'current' && this.missionId !== 'all') {
-      L.control.poiadder({ missionId: this.missionId }).addTo(this.map)
-      L.control.polygonadder({ missionId: this.missionId }).addTo(this.map)
-      L.control.lineadder({ missionId: this.missionId }).addTo(this.map)
+      poiadder({ missionId: this.missionId }).addTo(this.map)
+      polygonadder({ missionId: this.missionId }).addTo(this.map)
+      lineadder({ missionId: this.missionId }).addTo(this.map)
       new LocateControl({
         setView: 'untilPan',
         keepCurrentZoomLevel: true,

--- a/frontend/usergeo/line.tsx
+++ b/frontend/usergeo/line.tsx
@@ -1,6 +1,8 @@
 import L from 'leaflet'
 import React from 'react'
 
+import { LineAdder } from '../LineAdder/LineAdder.js'
+import { SearchAdder } from '../SearchAdder/SearchAdder.js'
 import { SMMUserGeoLineGeoJSON } from './types'
 import { LinePopup } from './LinePopup'
 import { SMMUserGeoLayer, SMMUserGeoCollection } from './base'
@@ -14,7 +16,7 @@ class SMMLine extends SMMUserGeoLayer {
   }
 
   editCallback() {
-    L.LineAdder(
+    LineAdder(
       this.map,
       this.missionId,
       this.coords.map((x) => L.latLng(x[1], x[0])),
@@ -24,7 +26,7 @@ class SMMLine extends SMMUserGeoLayer {
   }
 
   createSearchCallback() {
-    L.SearchAdder(this.map, 'line', this.data.pk)
+    SearchAdder(this.map, 'line', this.data.pk)
   }
 
   getPopupOptions(): L.PopupOptions {

--- a/frontend/usergeo/poi.tsx
+++ b/frontend/usergeo/poi.tsx
@@ -1,8 +1,9 @@
 import L from 'leaflet'
-
 import React from 'react'
 
 import { MarineVectorsLeaflet } from '../marine/leaflet'
+import { POIAdder } from '../POIAdder/POIAdder.js'
+import { SearchAdder } from '../SearchAdder/SearchAdder.js'
 import { SMMUserGeoPOIGeoJSON } from './types'
 import { POIPopup } from './POIPopup'
 import { SMMUserGeoLayer, SMMUserGeoCollection } from './base'
@@ -17,11 +18,11 @@ class SMMPOI extends SMMUserGeoLayer {
   }
 
   editCallback() {
-    L.POIAdder(this.map, this.missionId, L.latLng(this.coords[1], this.coords[0]), this.data.pk, this.data.label)
+    POIAdder(this.map, this.missionId, L.latLng(this.coords[1], this.coords[0]), this.data.pk, this.data.label)
   }
 
   createSearchCallback() {
-    L.SearchAdder(this.map, 'point', this.data.pk)
+    SearchAdder(this.map, 'point', this.data.pk)
   }
 
   calculateTDVCallback() {

--- a/frontend/usergeo/polygon.tsx
+++ b/frontend/usergeo/polygon.tsx
@@ -1,6 +1,8 @@
 import L from 'leaflet'
 import React from 'react'
 
+import { PolygonAdder } from '../PolygonAdder/PolygonAdder.js'
+import { SearchAdder } from '../SearchAdder/SearchAdder.js'
 import { SMMUserGeoPolygonGeoJSON } from './types'
 import { PolygonPopup } from './PolygonPopup'
 import { SMMUserGeoLayer, SMMUserGeoCollection } from './base'
@@ -14,7 +16,7 @@ class SMMPolygon extends SMMUserGeoLayer {
   }
 
   editCallback() {
-    L.PolygonAdder(
+    PolygonAdder(
       this.map,
       this.missionId,
       this.coords[0].map((x) => L.latLng(x[1], x[0])),
@@ -24,7 +26,7 @@ class SMMPolygon extends SMMUserGeoLayer {
   }
 
   createSearchCallback() {
-    L.SearchAdder(this.map, 'polygon', this.data.pk)
+    SearchAdder(this.map, 'polygon', this.data.pk)
   }
 
   getPopupOptions(): L.PopupOptions {


### PR DESCRIPTION
## Description

- POIAdder, LineAdder, PolygonAdder, SearchAdder no longer mutate L
- Controls now use local const (POIAdderControl etc.) instead of L.Control.XXX
- Factory functions (poiadder, lineadder, polygonadder) exported directly
- map.tsx imports factories by name instead of using L.control.xxx
- usergeo files import POIAdder/LineAdder/PolygonAdder/SearchAdder directly instead of calling L.POIAdder, L.LineAdder, etc.

## Summary by Sourcery

Stop extending the Leaflet L namespace for adder functionality and switch to locally defined, named exports for adder functions and controls.

Enhancements:
- Define POI, line, polygon, and search adder functions and corresponding controls as local modules instead of attaching them to the global Leaflet L namespace.
- Export factory functions for POI, line, and polygon adders as named exports and update map initialization to use these factories directly.
- Update usergeo layers to import and call POIAdder, LineAdder, PolygonAdder, and SearchAdder as named imports instead of accessing them via L.XXX.