### PR TITLE
Fix smmPatch and flattenPoints types (sourcery PR#944, PR#949)

### DIFF
--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -95,7 +95,7 @@ function smmPostBody(url: string, body: FormData | URLSearchParams, success?: (d
   )
 }
 
-function smmPatch(url: string, data: Record<string, unknown>, success?: (data: unknown) => void, error?: (data?: unknown) => void) {
+function smmPatch(url: string, data: Record<string, unknown>, success?: (data: string) => void, error?: (data?: unknown) => void) {
   return request(
     url,
     {

--- a/frontend/components/flattenPoints.ts
+++ b/frontend/components/flattenPoints.ts
@@ -1,7 +1,7 @@
 import L from 'leaflet'
 
-export function flattenPoints(points: L.LatLng[]): Record<string, string | number> {
-  const data: Record<string, string | number> = { points: points.length }
+export function flattenPoints(points: L.LatLng[]): Record<string, number> {
+  const data: Record<string, number> = { points: points.length }
   points.forEach((p, i) => {
     data[`point${i}_lat`] = p.lat
     data[`point${i}_lng`] = p.lng


### PR DESCRIPTION
## Description

- smmPatch success callback: unknown -> string (implementation calls r.text())
- flattenPoints return type: Record<string, string|number> -> Record<string, number>
  (all values are numeric: point count, lat, lng)

## Summary by Sourcery

Align type definitions for point flattening and PATCH request callbacks with their actual runtime behavior.

Bug Fixes:
- Correct the smmPatch success callback type to use string instead of unknown.
- Narrow the flattenPoints return type to a numeric Record<string, number> reflecting actual point data values.