### PR TITLE
Await smmDelete in OrganizationMemberRow and OrganizationAssetRow

### DIFF
--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -30,9 +30,9 @@ class OrganizationMemberRow extends React.Component<OrganizationMemberRowProps, 
     this.saveChanges = this.saveChanges.bind(this)
   }
 
-  delete() {
+  async delete() {
     const organizationMember = this.props.organization_member
-    smmDelete(`/organization/${this.props.organizationId}/user/${organizationMember.user}/`)
+    await smmDelete(`/organization/${this.props.organizationId}/user/${organizationMember.user}/`)
   }
 
   updateSelectedRole(event: React.ChangeEvent<HTMLSelectElement>) {
@@ -109,9 +109,9 @@ class OrganizationAssetRow extends React.Component<OrganizationAssetRowProps, ne
     this.delete = this.delete.bind(this)
   }
 
-  delete() {
+  async delete() {
     const { organization_asset } = this.props
-    smmDelete(`/organization/${this.props.organizationId}/assets/${organization_asset.asset.id}/`)
+    await smmDelete(`/organization/${this.props.organizationId}/assets/${organization_asset.asset.id}/`)
   }
 
   render() {


### PR DESCRIPTION
## Description

Previously the delete promise was fire-and-forget; an unhandled rejection would be silently swallowed. Making delete() async propagates failures to React's event system.

## Summary by Sourcery

Propagate failures from organization member and asset deletion actions by awaiting the delete requests instead of firing them asynchronously without handling rejections.

Bug Fixes:
- Ensure organization member deletion errors surface through React by awaiting the delete request.
- Ensure organization asset deletion errors surface through React by awaiting the delete request.