### PR TITLE
Guard against undefined userId in addOrganizationMember

### DIFF
--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -221,7 +221,8 @@ class OrganizationMemberAdd extends React.Component<OrganizationMemberAddProps, 
 
   async addOrganizationMember() {
     const user = this.state.userList.find((user) => user.id === this.state.userId)
-    await smmPost(`/organization/${this.props.organizationId}/user/${user?.username}/`, {})
+    if (!user) return
+    await smmPost(`/organization/${this.props.organizationId}/user/${user.username}/`, {})
     this.setState({ userId: undefined })
   }
 


### PR DESCRIPTION
## Description

If userId is undefined (no user selected or list empty), find() returns undefined and the POST URL would contain the literal string 'undefined'. Early-return if no user is found; also removes the optional-chain on user.username since user is now guaranteed to exist.

## Summary by Sourcery

Bug Fixes:
- Prevent sending organization member POST requests with an undefined user by ensuring a selected user exists before constructing the request URL.