### PR TITLE
Fix marine vector popup crash from undefined createButtonGroup

### DIFF
--- a/frontend/marine/MarineVectorPopup.tsx
+++ b/frontend/marine/MarineVectorPopup.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { PopupDataList, PopupButtonGroup, ButtonItem } from '../popup'
+
+interface Props {
+  pk: number
+  missionId: number | string
+  onDelete: () => void
+}
+
+export function MarineVectorPopup({ pk, missionId, onDelete }: Props) {
+  const items = [{ label: 'Total Drift Vector', value: String(pk) }]
+  const buttons: ButtonItem[] = []
+  if (missionId !== 'current' && missionId !== 'all') {
+    buttons.push({ label: 'Delete', btnClass: 'btn-danger', onclick: onDelete })
+  }
+  return (
+    <div>
+      <PopupDataList items={items} dlClass="row" />
+      {buttons.length > 0 && <PopupButtonGroup buttons={buttons} />}
+    </div>
+  )
+}

--- a/frontend/marine/vectors.tsx
+++ b/frontend/marine/vectors.tsx
@@ -1,6 +1,11 @@
+import L from 'leaflet'
+import React from 'react'
+import * as ReactDOM from 'react-dom/client'
+
 import { SMMRealtime } from '../smmmap'
 import { TotalDriftVectorData } from './types'
 import { smmDelete } from '../ajax'
+import { MarineVectorPopup } from './MarineVectorPopup'
 
 class SMMMarineVector extends SMMRealtime {
   constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
@@ -16,36 +21,11 @@ class SMMMarineVector extends SMMRealtime {
   createPopup(tdv: { properties: TotalDriftVectorData }, layer: L.Layer) {
     const tdvID = tdv.properties.pk
 
-    const popupContent = document.createElement('div')
-    const dl = document.createElement('dl')
-    dl.className = 'row'
-    popupContent.appendChild(dl)
-
-    const dt = document.createElement('dt')
-    dt.className = 'image-label col-sm-2'
-    dt.textContent = 'Total Drift Vector'
-    dl.appendChild(dt)
-
-    const dd = document.createElement('dd')
-    dd.className = 'image-name col-sm-10'
-    dd.textContent = tdvID.toString()
-    dl.appendChild(dd)
-
-    if (this.missionId !== 'current' && this.missionId !== 'all') {
-      popupContent.appendChild(
-        this.createButtonGroup([
-          {
-            label: 'Delete',
-            onclick: function () {
-              smmDelete(`/sar/marine/vectors/${tdvID}/`)
-            },
-            btnClass: 'btn-danger'
-          }
-        ])
-      )
-    }
-
-    layer.bindPopup(popupContent)
+    const container = document.createElement('div')
+    const root = ReactDOM.createRoot(container)
+    root.render(<MarineVectorPopup pk={tdvID} missionId={this.missionId} onDelete={() => smmDelete(`/sar/marine/vectors/${tdvID}/`)} />)
+    layer.bindPopup(container)
+    layer.on('remove', () => root.unmount())
   }
 }
 


### PR DESCRIPTION
## Description

SMMMarineVector.createPopup called this.createButtonGroup, which was never defined on the class or its base. Opening a TDV popup on a regular mission threw at runtime. Replace the raw-DOM popup body with a small MarineVectorPopup React component reusing PopupDataList/PopupButtonGroup, matching the pattern used by SearchPopup and POIPopup.

## Summary by Sourcery

Replace the marine vector Leaflet popup with a React-based popup component to prevent runtime crashes when opening TDV popups.

Bug Fixes:
- Fix runtime crash caused by calling an undefined createButtonGroup when opening marine vector popups.

Enhancements:
- Introduce a MarineVectorPopup React component that reuses shared popup list and button components for displaying drift vector details and delete actions.