### PR TITLE
Hide timeline Add Entry form when mission is closed

### DIFF
--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -226,7 +226,7 @@ export class MissionTimeLine extends React.Component<MissionTimeLineProps, Missi
     let timelineAdd = null
     if (this.state.missionData !== undefined) {
       missionData = <MissionHeader key="missionHeader" mission={this.state.missionData} />
-      if (this.state.missionClosed !== null) {
+      if (!this.state.missionClosed) {
         timelineAdd = <MissionTimeLineEntryAdd missionId={this.props.missionId} />
       }
     }


### PR DESCRIPTION
## Description

MissionTimeLine guarded the Add Entry form with
'this.state.missionClosed !== null', but missionClosed is initialised to false, so the expression was always true. The form rendered for every mission regardless of state. Switch the guard to '!this.state.missionClosed'.

## Summary by Sourcery

Bug Fixes:
- Fix the mission closed state check so the timeline add-entry form is hidden when the mission is closed.