### PR TITLE
Auto-select first option when default-select state is undefined

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -425,7 +425,7 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
     const data = await smmGetJSON<{ values: AssetStatusValueData[] }>('/assets/status/values/', {})
     this.setState((oldState) => ({
       statusValues: data.values,
-      ...(oldState.selectedValueId === null && data.values.length > 0 ? { selectedValueId: data.values[0].id } : {})
+      ...(oldState.selectedValueId === undefined && data.values.length > 0 ? { selectedValueId: data.values[0].id } : {})
     }))
   }
 

--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -63,7 +63,7 @@ class MissionAssetStatusForm extends React.Component<MissionAssetStatusFormProps
     const data = await smmGetJSON<{ values: MissionAssetStatusValue[] }>('/mission/asset/status/values/', {})
     this.setState((oldState) => ({
       statusValues: data.values,
-      ...(oldState.selectedValueId === null && data.values.length > 0 ? { selectedValueId: data.values[0].id } : {})
+      ...(oldState.selectedValueId === undefined && data.values.length > 0 ? { selectedValueId: data.values[0].id } : {})
     }))
   }
 

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -209,7 +209,7 @@ class OrganizationMemberAdd extends React.Component<OrganizationMemberAddProps, 
     const data = await smmGetJSON<{ users: { id: number; username: string }[] }>(`/organization/${this.props.organizationId}/users/notmember/`, {})
     this.setState((oldState) => ({
       userList: data.users,
-      ...(oldState.userId === null && data.users.length > 0 ? { userId: data.users[0].id } : {})
+      ...(oldState.userId === undefined && data.users.length > 0 ? { userId: data.users[0].id } : {})
     }))
   }
 
@@ -325,7 +325,7 @@ class OrganizationAssetAdd extends React.Component<OrganizationAssetAddProps, Or
     const data = await smmGetJSON<{ assets: AssetData[] }>('/assets/', {})
     this.setState((oldState) => ({
       assetList: data.assets,
-      ...(oldState.assetId === null && data.assets.length > 0 ? { assetId: data.assets[0].id } : {})
+      ...(oldState.assetId === undefined && data.assets.length > 0 ? { assetId: data.assets[0].id } : {})
     }))
   }
 


### PR DESCRIPTION
## Description

Four updateData callbacks (AssetStatus, MissionAssetStatus, OrganizationMemberAdd, OrganizationAssetAdd) seeded a default selection only when 'oldState.<id> === null'. The fields are initialised to undefined, so 'undefined === null' was always false and the default branch never fired. The select visually rendered the first option but state stayed undefined, so clicking Add/Save before manually changing the dropdown sent no value. Compare against undefined instead.

## Summary by Sourcery

Bug Fixes:
- Fix default selection logic in asset status, mission asset status, organization member add, and organization asset add forms by treating undefined state as uninitialized instead of null.