### PR TITLE
Bind asset/user colour picker listener once per swatch DOM element

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -210,8 +210,11 @@ class SMMAssets extends SMMRealtime {
     const assetObject = this.assetObjects[assetId]
     const pickerDiv = document.getElementById(`assetNamePicker${assetId}`)
     if (pickerDiv) {
-      pickerDiv.addEventListener('click', assetObject.colorPicker)
       Object.assign(pickerDiv.style, { width: '15px', height: '15px', display: 'inline-block', backgroundColor: assetObject.color })
+      if (pickerDiv.dataset.smmListenerBound !== '1') {
+        pickerDiv.dataset.smmListenerBound = '1'
+        pickerDiv.addEventListener('click', assetObject.colorPicker)
+      }
     }
     return assetObject
   }

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -150,8 +150,11 @@ class SMMUserPositions extends SMMRealtime {
     const userObject = this.userObjects[userName]
     const pickerDiv = document.getElementById(`userNamePicker${userName}`)
     if (pickerDiv) {
-      pickerDiv.addEventListener('click', userObject.colorPicker)
       Object.assign(pickerDiv.style, { width: '15px', height: '15px', display: 'inline-block', backgroundColor: userObject.color })
+      if (pickerDiv.dataset.smmListenerBound !== '1') {
+        pickerDiv.dataset.smmListenerBound = '1'
+        pickerDiv.addEventListener('click', userObject.colorPicker)
+      }
     }
     return userObject
   }


### PR DESCRIPTION
## Description

createAsset/createUser re-added the click listener on every realtime tick (~3s), since both functions ran from the per-feature update path. After a few minutes a single click could open the colour picker dozens of times. Layer-control rebuilds also discard the previous swatch divs, so a sticky cache on the SMMAsset/SMMUserPosition would miss the new node. Use a dataset sentinel on the div itself so the listener is bound at most once per DOM element, while still reapplying style each tick so colour changes propagate to the swatch.

## Summary by Sourcery

Prevent duplicate colour picker activations for asset and user swatches by making the click listener bind only once per DOM element while keeping style updates on each realtime tick.

Bug Fixes:
- Fix repeated binding of colour picker click handlers for asset swatches on each realtime update.
- Fix repeated binding of colour picker click handlers for user swatches on each realtime update.