### PR TITLE
Route asset and user track updates through smmGetJSON

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -127,15 +127,13 @@ class SMMAsset {
     }
     this.updating = true
 
-    let assetUrl = `/mission/${this.missionId}/data/assets/${this.assetId}/position/history/?oldest=last`
+    const assetUrl = `/mission/${this.missionId}/data/assets/${this.assetId}/position/history/`
+    const params: Record<string, string | undefined> = { oldest: 'last' }
     if (this.lastUpdate) {
-      assetUrl = `${assetUrl}&from=${this.lastUpdate}`
+      params.from = this.lastUpdate
     }
 
-    fetch(assetUrl)
-      .then((r) => r.json())
-      .then(this.updateNewRoute)
-      .catch(this.updateFailed)
+    smmGetJSON<{ features: Array<{ geometry: { coordinates: Array<number> }; properties: AssetPointTime }> }>(assetUrl, params).then(this.updateNewRoute).catch(this.updateFailed)
   }
 }
 

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -4,6 +4,7 @@ import { SMMRealtime } from '../smmmap'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { cookieJar } from '../cookies'
+import { smmGetJSON } from '../ajax'
 import { SMMMissionUserPointTimeGeoJSON } from './types'
 import { UserPopup } from './UserPopup'
 import { ColorPickerDialog } from '../asset/ColorPickerDialog'
@@ -93,15 +94,13 @@ class SMMUserPosition {
     }
     this.updating = true
 
-    let userUrl = `/mission/${this.missionId}/data/user/${this.userName}/position/history/?oldest=last`
+    const userUrl = `/mission/${this.missionId}/data/user/${this.userName}/position/history/`
+    const params: Record<string, string | undefined> = { oldest: 'last' }
     if (this.lastUpdate != null) {
-      userUrl = `${userUrl}&from=${this.lastUpdate}`
+      params.from = this.lastUpdate
     }
 
-    fetch(userUrl)
-      .then((r) => r.json())
-      .then(this.updateNewPosition)
-      .catch(this.updateError)
+    smmGetJSON<{ features: Array<SMMMissionUserPointTimeGeoJSON> }>(userUrl, params).then(this.updateNewPosition).catch(this.updateError)
   }
 }
 


### PR DESCRIPTION
## Description

SMMAsset.update and SMMUserPosition.update used raw fetch, so they did not benefit from the central HTTP status check, Accept header, or the new 30s timeout (with abort). They also hand-built query strings, which skipped URLSearchParams encoding for the 'from' timestamp. Use smmGetJSON with a params object instead.

## Summary by Sourcery

Route asset and user position history updates through the shared smmGetJSON helper instead of raw fetch.

Enhancements:
- Leverage centralized JSON request helper for asset route history updates, including shared status handling and timeouts.
- Leverage centralized JSON request helper for user position history updates, including shared status handling and timeouts.
- Use structured params objects for query construction to ensure proper encoding of timestamps and other parameters.