### PR TITLE
Track the active popup React root on per-feature objects

### DIFF
--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -14,6 +14,7 @@ class SMMSearch {
   parent: SMMSearches
   search: SMMSearchObjectDetailsData
   QueueDialog?: L.Control.Dialog
+  popupRoot?: ReactDOM.Root
   constructor(parent: SMMSearches, search: SMMSearchObjectDetailsData) {
     this.parent = parent
     this.search = search
@@ -50,8 +51,10 @@ class SMMSearch {
   }
 
   createPopup(layer: L.Layer) {
+    this.popupRoot?.unmount()
     const container = document.createElement('div')
     const root = ReactDOM.createRoot(container)
+    this.popupRoot = root
     root.render(
       <SearchPopup
         search={this.search}
@@ -62,7 +65,12 @@ class SMMSearch {
       />
     )
     layer.bindPopup(container, { minWidth: 200 })
-    layer.on('remove', () => root.unmount())
+    layer.on('remove', () => {
+      root.unmount()
+      if (this.popupRoot === root) {
+        this.popupRoot = undefined
+      }
+    })
   }
 }
 

--- a/frontend/usergeo/base.tsx
+++ b/frontend/usergeo/base.tsx
@@ -14,6 +14,7 @@ abstract class SMMUserGeoLayer {
   map: L.Map
   missionId: number | string
   data: SMMUserGeoLabelData
+  popupRoot?: ReactDOM.Root
 
   constructor(map: L.Map, missionId: number | string, data: SMMUserGeoLabelData) {
     this.map = map
@@ -37,11 +38,18 @@ abstract class SMMUserGeoLayer {
   }
 
   createPopup(layer: L.Layer) {
+    this.popupRoot?.unmount()
     const container = document.createElement('div')
     const root = ReactDOM.createRoot(container)
+    this.popupRoot = root
     root.render(this.renderPopup())
     layer.bindPopup(container, this.getPopupOptions())
-    layer.on('remove', () => root.unmount())
+    layer.on('remove', () => {
+      root.unmount()
+      if (this.popupRoot === root) {
+        this.popupRoot = undefined
+      }
+    })
   }
 }
 


### PR DESCRIPTION
## Description

SMMSearch and SMMUserGeoLayer cached the per-feature instance but discarded the React root reference after binding it. If createPopup ever ran twice without the layer's 'remove' handler having fired (e.g. realtime recreates a feature mid-tick), the previous root was orphaned and never unmounted. Hold popupRoot on the instance, unmount any previous root before creating a new one, and only clear popupRoot on remove if the cleared root is the active one.

## Summary by Sourcery

Track and manage the active React popup root per feature to avoid orphaned roots when popups are recreated.

Bug Fixes:
- Ensure SMMSearch popups unmount any existing React root before creating a new one and clear the stored root only when the removed popup matches the active root.
- Ensure SMMUserGeoLayer popups unmount any existing React root before creating a new one and clear the stored root only when the removed popup matches the active root.