### PR TITLE
Do not classify success-handler exceptions as request errors

### DIFF
--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -56,7 +56,11 @@ function request<T>(
       return parse(r)
     })
     .then((data) => {
-      success?.(data)
+      try {
+        success?.(data)
+      } catch (e) {
+        console.error('smm request success handler threw:', e)
+      }
       return data
     })
     .catch((err) => {


### PR DESCRIPTION
## Description

If a smm* request's success callback threw, the exception flowed into the surrounding .catch and error?.() ran as if the network request had failed. Callers then showed a 'request failed' state for a bug that actually lived inside their own handler. Wrap the success invocation in try/catch and log the exception so it stays visible without contaminating the error path.

## Summary by Sourcery

Bug Fixes:
- Prevent success callback exceptions from triggering the error handler and being misclassified as request failures.