### PR TITLE
Import the SearchPattern type into SearchDetailsPage

### DIFF
--- a/frontend/search/details.tsx
+++ b/frontend/search/details.tsx
@@ -11,7 +11,7 @@ import { smmGetJSON } from '../ajax'
 import { SMMObjectDetails } from '../SMMObjects/details'
 import { GeometryPoints } from '../geometry/details'
 import { GeoJsonMap } from '../geomap'
-import { ExpandingBoxSearch, SectorSearch } from '@canterbury-air-patrol/sar-search-patterns'
+import { ExpandingBoxSearch, SearchPattern, SectorSearch } from '@canterbury-air-patrol/sar-search-patterns'
 import { SearchRunner } from '@canterbury-air-patrol/sar-search-runner'
 import { SMMSearchObjectDetailsData } from './types'
 


### PR DESCRIPTION
## Description

SearchDetailsPage's state declared 'search?: SearchPattern' without importing the type. Only the lack of a tsc step in CI hid the error. Add the import from @canterbury-air-patrol/sar-search-patterns next to the existing SectorSearch/ExpandingBoxSearch imports.

## Summary by Sourcery

Bug Fixes:
- Resolve a TypeScript compile-time error in SearchDetailsPage by importing the SearchPattern type from the shared search patterns package.