### PR TITLE
Render AssetTrackAs geolocation errors via state

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -21,11 +21,11 @@ interface AssetTrackAsState {
   longitude: number
   altitude: number | null
   tracking: boolean
+  errorMsg: string
 }
 
 class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState> {
   watchID: number
-  errorMsg: string
 
   constructor(props: AssetTrackAsProps) {
     super(props)
@@ -34,11 +34,11 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
       latitude: 0,
       longitude: 0,
       altitude: 0,
-      tracking: false
+      tracking: false,
+      errorMsg: ''
     }
 
     this.watchID = 0
-    this.errorMsg = ''
 
     this.enableTracking = this.enableTracking.bind(this)
     this.disableTracking = this.disableTracking.bind(this)
@@ -69,20 +69,22 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
   }
 
   positionErrorHandler(error: GeolocationPositionError) {
+    let errorMsg
     switch (error.code) {
       case error.PERMISSION_DENIED:
-        this.errorMsg = 'No permision given to access location'
+        errorMsg = 'No permission given to access location'
         break
       case error.POSITION_UNAVAILABLE:
-        this.errorMsg = 'Unable to get the current position'
+        errorMsg = 'Unable to get the current position'
         break
       case error.TIMEOUT:
-        this.errorMsg = 'Timed out getting position'
+        errorMsg = 'Timed out getting position'
         break
       default:
-        this.errorMsg = `Unknown error: ${error.code}`
+        errorMsg = `Unknown error: ${error.code}`
         break
     }
+    this.setState({ errorMsg })
   }
 
   enableTracking() {
@@ -132,7 +134,7 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
             </td>
           </tr>
           <tr>
-            <td colSpan={3}>{this.errorMsg}</td>
+            <td colSpan={3}>{this.state.errorMsg}</td>
           </tr>
         </tbody>
       </Table>


### PR DESCRIPTION
## Description

errorMsg was an instance field, so positionErrorHandler's assignment never triggered a re-render and the localised 'No permission' / 'Unable to get the current position' / 'Timed out' messages were invisible to the user. Move errorMsg into state, set it through setState, and read it from state in render. Also fix the 'permision' typo while editing the same lines.

## Summary by Sourcery

Render geolocation permission and position errors via React state in AssetTrackAs so they appear in the UI.

Bug Fixes:
- Fix geolocation error messages not triggering a re-render by storing the message in component state.
- Correct the typo in the geolocation permission error message text.