### PR TITLE
Guard AssetTrackAs against missing geolocation and stale watch IDs

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -25,7 +25,7 @@ interface AssetTrackAsState {
 }
 
 class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState> {
-  watchID: number
+  watchID?: number
 
   constructor(props: AssetTrackAsProps) {
     super(props)
@@ -37,8 +37,6 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
       tracking: false,
       errorMsg: ''
     }
-
-    this.watchID = 0
 
     this.enableTracking = this.enableTracking.bind(this)
     this.disableTracking = this.disableTracking.bind(this)
@@ -88,28 +86,24 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
   }
 
   enableTracking() {
-    if (navigator.geolocation) {
-      const options = {
-        timeout: 60000,
-        enableHighAccuracy: true
-      }
-      this.watchID = navigator.geolocation.watchPosition(this.positionUpdate, this.positionErrorHandler, options)
+    if (!navigator.geolocation) {
+      this.setState({ errorMsg: 'Geolocation is not supported by this browser' })
+      return
     }
-
-    this.setState(function () {
-      return {
-        tracking: true
-      }
-    })
+    const options = {
+      timeout: 60000,
+      enableHighAccuracy: true
+    }
+    this.watchID = navigator.geolocation.watchPosition(this.positionUpdate, this.positionErrorHandler, options)
+    this.setState({ tracking: true })
   }
 
   disableTracking() {
-    navigator.geolocation.clearWatch(this.watchID)
-    this.setState(function () {
-      return {
-        tracking: false
-      }
-    })
+    if (this.watchID !== undefined) {
+      navigator.geolocation.clearWatch(this.watchID)
+      this.watchID = undefined
+    }
+    this.setState({ tracking: false })
   }
 
   render() {


### PR DESCRIPTION
## Description

watchID was initialised to 0 (a valid watchPosition return value on some browsers) so an unconditional clearWatch(0) could abort an unrelated watcher. enableTracking also flipped tracking to true even when navigator.geolocation was absent, leaving the button reading 'Disable Tracking' with nothing actually running. Make watchID optional, only clearWatch when it has a real id, and short-circuit enableTracking with an error message when geolocation is unavailable.

## Summary by Sourcery

Guard asset tracking against missing geolocation support and stale position watch IDs.

Bug Fixes:
- Prevent enableTracking from toggling tracking on when navigator.geolocation is unavailable, instead surfacing a user-visible error message.
- Ensure geolocation clearWatch is only called when a valid watch ID exists, avoiding interference with unrelated watchers.