### PR TITLE
Gate AssetTrackAs position POSTs on watchID instead of stale state

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -45,15 +45,12 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
   }
 
   positionUpdate(position: GeolocationPosition) {
+    if (this.watchID === undefined) {
+      return
+    }
+
     const { latitude, longitude, altitude } = position.coords
     const newHeading = position.coords.heading
-
-    const data = {
-      lat: latitude,
-      lon: longitude,
-      alt: altitude,
-      heading: newHeading
-    }
 
     this.setState({
       latitude,
@@ -61,9 +58,12 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
       altitude
     })
 
-    if (this.state.tracking) {
-      smmGet(`/data/assets/${this.props.asset}/position/add/`, data)
-    }
+    smmGet(`/data/assets/${this.props.asset}/position/add/`, {
+      lat: latitude,
+      lon: longitude,
+      alt: altitude,
+      heading: newHeading
+    })
   }
 
   positionErrorHandler(error: GeolocationPositionError) {


### PR DESCRIPTION
## Description

positionUpdate previously POSTed when this.state.tracking was true, but setState is asynchronous and the geolocation callback can fire after disableTracking has run. The result was an occasional stray position POST after the user disabled tracking. Use the synchronously cleared this.watchID as the authoritative gate instead, and short-circuit the callback when it is undefined.

## Summary by Sourcery

Bug Fixes:
- Prevent stray position updates from being POSTed after tracking has been disabled by short-circuiting the geolocation callback when no watch ID is active.