### PR TITLE
Tighten geolocation watch options for field use

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -91,7 +91,8 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
       return
     }
     const options = {
-      timeout: 60000,
+      timeout: 15000,
+      maximumAge: 1000,
       enableHighAccuracy: true
     }
     this.watchID = navigator.geolocation.watchPosition(this.positionUpdate, this.positionErrorHandler, options)


### PR DESCRIPTION
## Description

watchPosition was configured with a 60s timeout and no maximumAge, so a stuck fix kept the user waiting a full minute before the error path fired, and every callback forced a fresh fix at full battery cost. Drop timeout to 15s for faster feedback and allow up to 1s of cache between fixes to ease battery drain on mobile field devices.

## Summary by Sourcery

Adjust geolocation tracking configuration to improve responsiveness and reduce battery usage in the asset tracking UI.

Bug Fixes:
- Reduce geolocation watch timeout to minimize delays before reporting tracking errors when position updates are stuck.

Enhancements:
- Allow a short cache window for geolocation fixes to lower battery consumption on mobile field devices.