### PR TITLE
Default external-reference edit inputs to empty string

### DIFF
--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -132,7 +132,7 @@ class MissionDetailsExternalReferencesRow extends React.Component<MissionDetails
 
   renderField(field: string, displayValue?: string) {
     return this.state.editFields[field] ? (
-      <input type="text" value={this.state.values[field]} onChange={(e) => this.handleChange(field, e)} />
+      <input type="text" value={this.state.values[field] ?? ''} onChange={(e) => this.handleChange(field, e)} />
     ) : (
       <span onClick={() => this.toggleEdit(field)}>{displayValue}</span>
     )


### PR DESCRIPTION
## Description

MissionDetailsExternalReferencesRow.renderField passed this.state.values[field] directly to the <input value> prop. For code/url/notes the backing field is optional, so the input rendered as uncontrolled (value={undefined}) on the first edit, then flipped to controlled when the user typed. React warned about the transition and the first keystroke was occasionally dropped. Coerce undefined values to '' so the input is controlled from the start.

## Summary by Sourcery

Bug Fixes:
- Default empty mission external reference fields to an empty string to avoid uncontrolled-to-controlled input warnings and dropped keystrokes.