### PR TITLE
Render popup link buttons as anchors instead of nesting

### DIFF
--- a/frontend/popup.tsx
+++ b/frontend/popup.tsx
@@ -30,8 +30,8 @@ function PopupButtonGroup({ buttons }: { buttons: ButtonItem[] }) {
     <div className="btn-group-vertical">
       {buttons.map(({ label, btnClass, onclick, href }) =>
         href ? (
-          <a key={label} href={href}>
-            <button className={`btn ${btnClass}`}>{label}</button>
+          <a key={label} href={href} role="button" className={`btn ${btnClass}`}>
+            {label}
           </a>
         ) : (
           <button key={label} className={`btn ${btnClass}`} onClick={onclick}>


### PR DESCRIPTION
## Description

PopupButtonGroup wrapped a <button> inside an <a> for href entries. The markup is invalid HTML (interactive content inside an anchor), trips assistive tech, and produces two focus stops. Render the link as a single <a role="button"> styled with the Bootstrap button classes, matching how react-bootstrap and Bootstrap itself handle the pattern.

## Summary by Sourcery

Enhancements:
- Align popup link button markup with Bootstrap/react-bootstrap patterns by using anchor elements with button styling and roles for link-based actions.