### PR TITLE
Format search popup timestamps as local datetimes

### DIFF
--- a/frontend/search/SearchPopup.tsx
+++ b/frontend/search/SearchPopup.tsx
@@ -23,10 +23,10 @@ export function SearchPopup({ search, missionId, status, onDelete, onQueueDialog
     rows.push({ css: 'inprogress', label: 'Inprogress By', value: search.inprogress_by })
   }
   if (search.inprogress_at) {
-    rows.push({ css: 'inprogress', label: 'Search Started', value: search.inprogress_at })
+    rows.push({ css: 'inprogress', label: 'Search Started', value: new Date(search.inprogress_at).toLocaleString() })
   }
   if (search.completed_at) {
-    rows.push({ css: 'completed', label: 'Search Completed', value: search.completed_at })
+    rows.push({ css: 'completed', label: 'Search Completed', value: new Date(search.completed_at).toLocaleString() })
   }
 
   const buttons: ButtonItem[] = []

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -106,10 +106,11 @@ class SMMSearchesNotStarted extends SMMSearches {
   searchStatus(search: SMMSearchObjectDetailsData) {
     let status = 'Unassigned'
     if (search.queued_at) {
+      const at = new Date(search.queued_at).toLocaleString()
       if (search.queued_for_asset) {
-        status = `Queued for ${search.queued_for_asset} at ${search.queued_at}`
+        status = `Queued for ${search.queued_for_asset} at ${at}`
       } else {
-        status = `Queued for ${search.created_for} at ${search.queued_at}`
+        status = `Queued for ${search.created_for} at ${at}`
       }
     }
 


### PR DESCRIPTION
## Description

queued_at, inprogress_at and completed_at were rendered as raw ISO-8601 strings ("2026-05-29T12:00:00.000Z"). Pass them through new Date(...).toLocaleString() like the rest of the codebase so the popup shows a human-readable, locale-aware datetime.

## Summary by Sourcery

Format search-related timestamps as human-readable, locale-aware datetimes in the search map status and popup.

Enhancements:
- Render queued_at timestamps in the search map status using localized datetime strings instead of raw ISO-8601 values.
- Render inprogress_at and completed_at timestamps in the search popup using localized datetime strings instead of raw ISO-8601 values.