### PR TITLE
Remove dead Delete button from organisation list rows

### DIFF
--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -15,14 +15,6 @@ interface OrganizationListRowProps {
 }
 
 class OrganizationListRow extends React.Component<OrganizationListRowProps, never> {
-  constructor(props: OrganizationListRowProps) {
-    super(props)
-
-    this.delete_organization = this.delete_organization.bind(this)
-  }
-
-  delete_organization() {}
-
   render() {
     const { organization } = this.props
     const dataFields = []
@@ -42,13 +34,6 @@ class OrganizationListRow extends React.Component<OrganizationListRowProps, neve
         buttons.push(
           <Button key="radio-operator" href={`/organization/${organization.id}/radio/operator/`}>
             Radio Operator
-          </Button>
-        )
-      }
-      if (organization.role === 'Admin') {
-        buttons.push(
-          <Button key="delete" className="btn-danger" onClick={this.delete_organization}>
-            Delete
           </Button>
         )
       }


### PR DESCRIPTION
## Description

The Admin-only Delete button on OrganizationListRow was wired to an empty delete_organization() handler. The backend exposes no endpoint to delete an organisation either (only its members or assets). Drop the button and its no-op handler so the UI does not advertise an action that never worked.

## Summary by Sourcery

Bug Fixes:
- Remove a non-functional Delete button from organization list rows that was wired to a no-op handler.