### PR TITLE
Fix 'defintion' typo in @ts-expect-error comments

### DIFF
--- a/frontend/marinesac.tsx
+++ b/frontend/marinesac.tsx
@@ -17,5 +17,5 @@ export function createMarineSACTable(elementId: string, missionId: number) {
   )
 }
 
-// @ts-expect-error: globalThis has no defintion
+// @ts-expect-error: globalThis has no definition
 globalThis.createMarineSACTable = createMarineSACTable

--- a/frontend/usergeo/details.tsx
+++ b/frontend/usergeo/details.tsx
@@ -93,5 +93,5 @@ function createUserGeoDetailsPage(elementId: string, missionId: number, userGeoI
 }
 export { UserGeoDetailsPage, createUserGeoDetailsPage }
 
-// @ts-expect-error: globalThis has no defintion
+// @ts-expect-error: globalThis has no definition
 globalThis.createUserGeoDetailsPage = createUserGeoDetailsPage


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix spelling of 'definition' in @ts-expect-error comments in frontend entrypoints.