### PR TITLE
Preserve marine vector preview when the next request fails

### DIFF
--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -78,12 +78,12 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   }
 
   async preview() {
-    if (this.onMap) {
-      this.props.map.removeLayer(this.onMap)
-      this.onMap = undefined
-    }
     try {
       const data = await smmGetJSON<GeoJSON.GeoJsonObject>(`/mission/${this.props.missionId}/sar/marine/vectors/create/`, this.getData())
+      if (this.onMap) {
+        this.props.map.removeLayer(this.onMap)
+        this.onMap = undefined
+      }
       this.onMap = L.geoJSON(data, { color: 'yellow' })
       this.onMap.addTo(this.props.map)
     } catch (e) {


### PR DESCRIPTION
## Description

CustomMarineVectors.preview removed the existing preview layer before the new vectors fetch, so a failed request left the user with no preview rendered at all. Wait until the fetch succeeds before swapping the layer; on error the previous preview stays on the map.

## Summary by Sourcery

Bug Fixes:
- Keep the existing marine vector preview on the map when a new preview request fails instead of clearing the layer before the fetch completes.