### PR TITLE
Use layer.once for popup root cleanup across all feature kinds

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -228,7 +228,7 @@ class SMMAssets extends SMMRealtime {
     this.popupRoots[assetId] = root
     root.render(<AssetPopup assetName={String(assetId)} coords={asset.geometry.coordinates} />)
     layer.bindPopup(container, { minWidth: 200 })
-    layer.on('remove', () => {
+    layer.once('remove', () => {
       root.unmount()
       delete this.popupRoots[assetId]
     })

--- a/frontend/image/map.tsx
+++ b/frontend/image/map.tsx
@@ -55,7 +55,7 @@ abstract class SMMImage extends SMMRealtime {
       />
     )
     layer.bindPopup(container)
-    layer.on('remove', () => root.unmount())
+    layer.once('remove', () => root.unmount())
   }
 }
 

--- a/frontend/marine/vectors.tsx
+++ b/frontend/marine/vectors.tsx
@@ -25,7 +25,7 @@ class SMMMarineVector extends SMMRealtime {
     const root = ReactDOM.createRoot(container)
     root.render(<MarineVectorPopup pk={tdvID} missionId={this.missionId} onDelete={() => smmDelete(`/sar/marine/vectors/${tdvID}/`)} />)
     layer.bindPopup(container)
-    layer.on('remove', () => root.unmount())
+    layer.once('remove', () => root.unmount())
   }
 }
 

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -65,7 +65,7 @@ class SMMSearch {
       />
     )
     layer.bindPopup(container, { minWidth: 200 })
-    layer.on('remove', () => {
+    layer.once('remove', () => {
       root.unmount()
       if (this.popupRoot === root) {
         this.popupRoot = undefined

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -166,7 +166,7 @@ class SMMUserPositions extends SMMRealtime {
     userObject.popupRoot = root
     root.render(<UserPopup userName={userName} />)
     layer.bindPopup(container, { minWidth: 200 })
-    layer.on('remove', () => {
+    layer.once('remove', () => {
       root.unmount()
       userObject.popupRoot = undefined
     })

--- a/frontend/usergeo/base.tsx
+++ b/frontend/usergeo/base.tsx
@@ -44,7 +44,7 @@ abstract class SMMUserGeoLayer {
     this.popupRoot = root
     root.render(this.renderPopup())
     layer.bindPopup(container, this.getPopupOptions())
-    layer.on('remove', () => {
+    layer.once('remove', () => {
       root.unmount()
       if (this.popupRoot === root) {
         this.popupRoot = undefined


### PR DESCRIPTION
## Description

createPopup attached the cleanup handler via layer.on('remove', ...). If createPopup ever ran twice on the same layer (paired with the defensive popupRoot tracking added recently), multiple identical remove handlers would stack on the layer. Switch every popup creator to layer.once so the handler is bound and fired at most once.

## Summary by Sourcery

Enhancements:
- Switch popup removal handlers from layer.on to layer.once for assets, images, marine vectors, search results, user positions, and user geo layers to avoid stacking identical cleanup callbacks.