### PR TITLE
Clear AssetTrackAs errorMsg on enable and hide empty error row

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -96,7 +96,7 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
       enableHighAccuracy: true
     }
     this.watchID = navigator.geolocation.watchPosition(this.positionUpdate, this.positionErrorHandler, options)
-    this.setState({ tracking: true })
+    this.setState({ tracking: true, errorMsg: '' })
   }
 
   disableTracking() {
@@ -128,9 +128,11 @@ class AssetTrackAs extends React.Component<AssetTrackAsProps, AssetTrackAsState>
               <Button onClick={this.state.tracking ? this.disableTracking : this.enableTracking}>{this.state.tracking ? 'Disable Tracking' : 'Enable Tracking'}</Button>
             </td>
           </tr>
-          <tr>
-            <td colSpan={3}>{this.state.errorMsg}</td>
-          </tr>
+          {this.state.errorMsg && (
+            <tr>
+              <td colSpan={3}>{this.state.errorMsg}</td>
+            </tr>
+          )}
         </tbody>
       </Table>
     )


### PR DESCRIPTION
## Description

errorMsg persisted in state after a transient failure, so re-enabling tracking after granting permission left a stale 'No permission' line on the page while tracking was actually working. Clear errorMsg as part of the same setState that flips tracking to true. Also wrap the errorMsg <tr> in a conditional so an empty string no longer renders as a blank table row.

## Summary by Sourcery

Clear stale geolocation tracking error messages when tracking is re-enabled and avoid rendering an empty error row in the asset tracking table.

Bug Fixes:
- Reset the AssetTrackAs error message when tracking is re-enabled so stale permission errors are not displayed while tracking is active.
- Hide the error message table row entirely when there is no error text to prevent an empty row from being shown.