### PR TITLE
Stop announcing popup link buttons as role="button"

### DIFF
--- a/frontend/popup.tsx
+++ b/frontend/popup.tsx
@@ -30,7 +30,7 @@ function PopupButtonGroup({ buttons }: { buttons: ButtonItem[] }) {
     <div className="btn-group-vertical">
       {buttons.map(({ label, btnClass, onclick, href }) =>
         href ? (
-          <a key={label} href={href} role="button" className={`btn ${btnClass}`}>
+          <a key={label} href={href} className={`btn ${btnClass}`}>
             {label}
           </a>
         ) : (


### PR DESCRIPTION
## Description

The href entries in PopupButtonGroup perform navigation, so labelling them role="button" misleads assistive tech (announced as button, but activation changes the page). Bootstrap's own pattern is just an anchor styled with the btn classes - drop the role override.

## Summary by Sourcery

Bug Fixes:
- Stop mislabelling popup navigation links as buttons for assistive technologies by removing the explicit button role from anchor elements.