### PR TITLE
Add ambient type declarations for esbuild-handled imports

### DIFF
--- a/frontend/types/assets.d.ts
+++ b/frontend/types/assets.d.ts
@@ -1,0 +1,8 @@
+declare module '*.css'
+declare module '*.png'
+declare module '*.ttf'
+declare module '*.woff2'
+declare module '*.svg'
+declare module '*.jpg'
+declare module '*.jpeg'
+declare module '*.gif'

--- a/frontend/types/legacy-js.d.ts
+++ b/frontend/types/legacy-js.d.ts
@@ -1,0 +1,12 @@
+/* Legacy untyped JS modules in this repo. Each will get proper typings when
+ * converted to .tsx (see todo/frontend/refactor-convert-js-to-typescript.md). */
+declare module '*/POIAdder/POIAdder.js'
+declare module '*/PolygonAdder/PolygonAdder.js'
+declare module '*/LineAdder/LineAdder.js'
+declare module '*/SearchAdder/SearchAdder.js'
+declare module '*/ImageUploader/ImageUploader.js'
+declare module '*/Admin/admin.js'
+
+/* Vendor JS packages without bundled types. */
+declare module '@canterbury-air-patrol/marine-total-drift-vector'
+declare module '@canterbury-air-patrol/marine-search-area-coverage'


### PR DESCRIPTION
## Description

esbuild bundles imports of *.css, *.png, *.ttf, *.woff2, six legacy JS controls (POIAdder, PolygonAdder, LineAdder, SearchAdder, ImageUploader, admin), and two untyped vendor packages (@canterbury-air-patrol/marine-total-drift-vector and @canterbury-air-patrol/marine-search-area-coverage). All of these lack TypeScript declarations, which made tsc report 43 spurious errors. Add minimal ambient module declarations under frontend/types/ so tsc can resolve them while we work towards real typings (the legacy JS files have proper conversion captured in todo/frontend/refactor-convert-js-to-typescript.md).

## Summary by Sourcery

Add ambient TypeScript module declarations for asset imports and legacy JavaScript modules so esbuild-bundled resources type-check cleanly.

Enhancements:
- Introduce ambient declarations for legacy in-repo JavaScript controls to unblock TypeScript compilation.
- Add ambient declarations for common asset file types and untyped vendor packages used by the frontend.