### PR TITLE
Bump tsconfig target to ES2020 with explicit lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     "jsx": "react",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
## Description

target was es2016, which made tsc reject our existing use of Object.entries (ES2017) and Promise.finally (ES2018). esbuild handles the actual transpilation, so the target setting only affects which lib types are visible to tsc. Bump to es2020 and add an explicit DOM/DOM.Iterable lib so iteration utilities such as for...of over NodeLists also resolve. Leaves jsx and module settings alone for separate follow-ups (cleanup-react-fragment-imports etc.).