### PR TITLE
Add minimal ambient types for leaflet-realtime

### DIFF
--- a/frontend/types/leaflet-realtime.d.ts
+++ b/frontend/types/leaflet-realtime.d.ts
@@ -1,0 +1,37 @@
+/* Minimal typings for leaflet-realtime. The plugin attaches L.realtime as
+ * a module side-effect; this declaration augments the leaflet namespace
+ * so tsc can resolve the calls. Feature payloads vary per call site and
+ * are intentionally typed as `any` in the callbacks - call sites declare
+ * their own feature shapes locally. */
+import 'leaflet'
+
+declare module 'leaflet' {
+  interface RealtimeSource {
+    url: string
+    type?: string
+  }
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  interface RealtimeOptions {
+    interval?: number
+    color?: string
+    onEachFeature?: (feature: any, layer: any) => any
+    updateFeature?: (feature: any, oldLayer?: any) => any
+    getFeatureId?: (feature: any) => number | string
+    pointToLayer?: (feature: any, latlng: LatLng) => any
+    style?: PathOptions | ((feature: any) => PathOptions)
+    cache?: boolean
+    start?: boolean
+    removeMissing?: boolean
+  }
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  interface Realtime extends GeoJSON {
+    start(): this
+    stop(): this
+    update(featureCollection?: unknown): this
+    remove(featureId?: number | string): this
+  }
+
+  function realtime(source: RealtimeSource | string, options?: RealtimeOptions): Realtime
+}


### PR DESCRIPTION
## Description

leaflet-realtime is a side-effect import; until this commit tsc had no typing for L.realtime, so every realtime call site emitted TS2339. Augment the leaflet module with a permissive shape: the callback signatures use any/Layer so each call site can keep its bespoke feature-property annotations without struct-compat errors. Closes the 4 TS2339 realtime errors across smmmap/asset/image/user.

## Summary by Sourcery

New Features:
- Introduce a Realtime API interface, options, and factory function typing augmentation for the Leaflet module to cover leaflet-realtime usage.