### PR TITLE
Add minimal ambient types for @canterbury-air-patrol/leaflet-dialog

### DIFF
--- a/frontend/types/leaflet-dialog.d.ts
+++ b/frontend/types/leaflet-dialog.d.ts
@@ -1,0 +1,37 @@
+/* Minimal typings for @canterbury-air-patrol/leaflet-dialog. The plugin
+ * attaches L.control.dialog as a module side-effect and the corresponding
+ * Control.Dialog subclass on L.Control. Refine the option/method surface
+ * as more of the plugin is exercised. */
+import 'leaflet'
+
+declare module 'leaflet' {
+  namespace Control {
+    interface DialogOptions extends ControlOptions {
+      initOpen?: boolean
+      size?: [number, number]
+      maxSize?: [number, number]
+      minSize?: [number, number]
+      anchor?: [number, number]
+    }
+
+    interface Dialog extends Control {
+      setContent(content: HTMLElement | string): this
+      setLocation(location: [number, number]): this
+      setSize(size: [number, number]): this
+      hideClose(): this
+      showClose(): this
+      open(): this
+      close(): this
+      show(): this
+      destroy(): this
+      lock(): this
+      unlock(): this
+      freeze(): this
+      unfreeze(): this
+    }
+  }
+
+  namespace control {
+    function dialog(options?: Control.DialogOptions): Control.Dialog
+  }
+}


### PR DESCRIPTION
## Description

leaflet-dialog augments L with Control.Dialog and L.control.dialog as side-effect imports; before this commit tsc rejected every dialog call site (10 errors across asset/user/marine/search/components). Declare a DialogOptions / Dialog / control.dialog surface large enough to cover the methods we actually call (setContent, addTo, hideClose, show, destroy, remove). Future call sites can extend as needed.

## Summary by Sourcery

Add minimal TypeScript ambient declarations for the @canterbury-air-patrol/leaflet-dialog plugin to integrate its dialog control into the Leaflet typings.

New Features:
- Introduce DialogOptions and Dialog interfaces under Leaflet's Control namespace to describe the dialog control API used by the app.
- Expose a control.dialog factory function typing that returns a typed Control.Dialog instance.