### PR TITLE
Type CustomMarineVectors against vendor module declaration

### DIFF
--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -4,7 +4,7 @@ import L from 'leaflet'
 
 import { MarineVectors, MarineVectorsDisplay } from '@canterbury-air-patrol/marine-total-drift-vector'
 import { Button, ButtonGroup } from 'react-bootstrap'
-import { smmGetJSON, smmPostBody } from '../ajax'
+import { smmGetJSON, smmPost } from '../ajax'
 
 interface CustomMarineVectorsProps {
   map: L.Map
@@ -14,6 +14,9 @@ interface CustomMarineVectorsProps {
   poiId: number
   dialog: L.Control.Dialog
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type VendorVector = any
 
 class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   onMap?: L.GeoJSON
@@ -34,7 +37,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   }
 
   getData() {
-    const data = {
+    const data: Record<string, string | number> = {
       from_lat: this.props.pos.lat,
       from_lng: this.props.pos.lng,
       poi_id: this.props.poiId,
@@ -44,7 +47,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
       wind_total: this.state.windVectors.length
     }
 
-    this.state.currentVectors.forEach((currVector, idx: number) => {
+    this.state.currentVectors.forEach((currVector: VendorVector, idx: number) => {
       data['curr_' + idx + '_from'] = this.formatTime(currVector.timeFrom)
       data['curr_' + idx + '_to'] = this.formatTime(currVector.timeTo)
       data['curr_' + idx + '_speed'] = currVector.getVectorSpeed()
@@ -52,7 +55,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
       data['curr_' + idx + '_distance'] = currVector.getVectorDistance()
     })
 
-    this.state.windVectors.forEach((windVector, idx: number) => {
+    this.state.windVectors.forEach((windVector: VendorVector, idx: number) => {
       data['wind_' + idx + '_from'] = this.formatTime(windVector.timeFrom)
       data['wind_' + idx + '_to'] = this.formatTime(windVector.timeTo)
       data['wind_' + idx + '_from_direction'] = windVector.direction
@@ -66,7 +69,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
 
   async add() {
     try {
-      await smmPostBody(`/mission/${this.props.missionId}/sar/marine/vectors/create/`, new URLSearchParams(this.getData()))
+      await smmPost(`/mission/${this.props.missionId}/sar/marine/vectors/create/`, this.getData())
       if (this.onMap) {
         this.props.map.removeLayer(this.onMap)
         this.onMap = undefined
@@ -84,7 +87,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
         this.props.map.removeLayer(this.onMap)
         this.onMap = undefined
       }
-      this.onMap = L.geoJSON(data, { color: 'yellow' })
+      this.onMap = L.geoJSON(data, { style: { color: 'yellow' } })
       this.onMap.addTo(this.props.map)
     } catch (e) {
       console.error('Failed to preview marine vector:', e)
@@ -130,7 +133,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   }
 }
 
-const MarineVectorsLeaflet = function (map: L.Map, missionId: number, posName, pos, poiId: number) {
+const MarineVectorsLeaflet = function (map: L.Map, missionId: number, posName: string, pos: L.LatLng, poiId: number) {
   const container = document.createElement('div')
   const dialog = L.control.dialog({ initOpen: true, size: [1000, 500] })
   ReactDOM.createRoot(container).render(<CustomMarineVectors map={map} missionId={missionId} posName={posName} pos={pos} poiId={Number(poiId)} dialog={dialog} />)

--- a/frontend/types/legacy-js.d.ts
+++ b/frontend/types/legacy-js.d.ts
@@ -7,6 +7,37 @@ declare module '*/SearchAdder/SearchAdder.js'
 declare module '*/ImageUploader/ImageUploader.js'
 declare module '*/Admin/admin.js'
 
-/* Vendor JS packages without bundled types. */
-declare module '@canterbury-air-patrol/marine-total-drift-vector'
+/* Untyped Canterbury Air Patrol vendor packages. The shapes below are
+ * permissive: the implementations are React class components whose
+ * state/methods we read but don't strictly type. Refine when a vendor
+ * publishes proper d.ts files. */
+declare module '@canterbury-air-patrol/marine-total-drift-vector' {
+  import * as React from 'react'
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  export class MarineVectors<P = unknown, S = any> extends React.Component<P, S> {
+    state: S & {
+      LKPLat: number
+      LKPLon: number
+      selectedLeeway: { multiplier: any; modifier: any }
+      currentVectors: any[]
+      windVectors: any[]
+    }
+    distance: any
+    bearing: any
+    recalculate: () => void
+    updateField: any
+    updateCurrentData: any
+    updateCurrentTimeFrom: any
+    updateCurrentTimeTo: any
+    updateLeewayData: any
+    updateWindData: any
+    updateWindTimeFrom: any
+    updateWindTimeTo: any
+    addCurrentVector: any
+    addWindVector: any
+  }
+  export const MarineVectorsDisplay: React.ComponentType<any>
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+}
+
 declare module '@canterbury-air-patrol/marine-search-area-coverage'


### PR DESCRIPTION
## Description

CustomMarineVectors extends the untyped MarineVectors React class. Until now tsc gave up entirely (this.props / this.state / methods all TS2339) and the class couldn't even be used as a JSX element. Enrich the @canterbury-air-patrol/marine-total-drift-vector ambient module so MarineVectors is declared as a React.Component subclass exposing the state and helper methods we touch. In leaflet.tsx, type getData()'s indexed write target with Record<string, string|number>, annotate the vendor vector iterator callbacks, and add the missing posName/pos parameter annotations on MarineVectorsLeaflet.

Also fixes two related typing issues:
- L.geoJSON's color option moves into a typed PathOptions style object.
- The vendor preview/create POST switches from smmPostBody (which expected FormData|URLSearchParams) to smmPost, which handles the Record<string,string|number> body shape directly.

Closes ~33 tsc errors in this file.

## Summary by Sourcery

Type the CustomMarineVectors integration against the vendor MarineVectors React class and align related marine leaflet utilities with stricter TypeScript and Leaflet typings.

New Features:
- Expose a typed MarineVectors React class and MarineVectorsDisplay component in the ambient @canterbury-air-patrol/marine-total-drift-vector module declaration.

Bug Fixes:
- Fix marine vector POST requests by using smmPost with a Record<string, string | number> body instead of URLSearchParams-based smmPostBody.
- Ensure L.geoJSON preview rendering uses a typed PathOptions-style configuration via the style option instead of a bare color property.

Enhancements:
- Type CustomMarineVectors.getData() and the vendor vector iterator callbacks to match the new vendor module declaration.
- Annotate MarineVectorsLeaflet positional arguments with concrete Leaflet and string types to eliminate implicit any usages.