### PR TITLE
Replace Leaflet private API access with public equivalents

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -81,7 +81,7 @@ class SMMAsset {
   }
 
   closeColorPicker() {
-    this.colorDialog.destroy()
+    this.colorDialog?.destroy()
     this.colorDialog = undefined
   }
 
@@ -240,23 +240,18 @@ class SMMAssets extends SMMRealtime {
 
   assetLayer(asset: { properties: { asset: number } }, latlng: L.LatLng) {
     const iconUrl = this.getAssetIcon(asset.properties.asset)
+    const title = this.assetNameMap[asset.properties.asset]
     if (iconUrl) {
       return L.marker(latlng, {
-        icon: L.icon(
-          {
-            iconUrl,
-            iconSize: [50, 50],
-            iconAnchor: [25, 50]
-          },
-          {
-            title: this.assetNameMap[asset.properties.asset]
-          }
-        )
+        title,
+        icon: L.icon({
+          iconUrl,
+          iconSize: [50, 50],
+          iconAnchor: [25, 50]
+        })
       })
     }
-    return L.marker(latlng, {
-      title: this.assetNameMap[asset.properties.asset]
-    })
+    return L.marker(latlng, { title })
   }
 
   assetUpdate(asset: { properties: { asset: number; alt?: number; heading?: number; fix?: string }; geometry: { type: string; coordinates: Array<number> } }, oldLayer: L.Marker) {
@@ -283,9 +278,13 @@ class SMMAssets extends SMMRealtime {
     if (asset.geometry.type === 'Point') {
       const c = asset.geometry.coordinates
       oldLayer.setLatLng([c[1], c[0]])
-      if (oldLayer._icon && oldLayer._icon.title !== this.assetNameMap[assetId]) {
-        oldLayer._icon.title = this.assetNameMap[assetId]
+
+      const newTitle = this.assetNameMap[assetId]
+      const iconEl = oldLayer.getElement()
+      if (iconEl && iconEl.title !== newTitle) {
+        iconEl.title = newTitle
       }
+      oldLayer.options.title = newTitle
 
       const currentIcon = oldLayer.getIcon()
       if (assetId in this.assetIconMap) {
@@ -295,8 +294,7 @@ class SMMAssets extends SMMRealtime {
             L.icon({
               iconUrl,
               iconSize: [50, 50],
-              iconAnchor: [25, 50],
-              title: this.assetNameMap[assetId]
+              iconAnchor: [25, 50]
             })
           )
         }

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -4,7 +4,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
-import L, { LatLng, Util } from 'leaflet'
+import L, { LatLng } from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import markerIcon from 'leaflet/dist/images/marker-icon.png'
 import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
@@ -72,9 +72,8 @@ class SMMMap {
     return name.replace(/[^a-zA-Z0-9]/g, '_')
   }
 
-  layerStateChanged(e: L.LayerEvent) {
-    const layer = this.layerControlMaps._getLayer(Util.stamp(e.target))
-    cookieJar.set(`layer_${this.convertCookieName(layer.name)}_on_map`, e.type === 'add')
+  layerStateChanged(e: L.LayersControlEvent) {
+    cookieJar.set(`layer_${this.convertCookieName(e.name)}_on_map`, e.type === 'overlayadd')
   }
 
   mapLayersCallback(data: {
@@ -82,13 +81,7 @@ class SMMMap {
   }) {
     let baseSelected = false
     for (const layer of data.layers) {
-      const options: {
-        attribution: string
-        minZoom: number
-        maxZoom: number
-        subdomains?: string
-        referrerPolicy?: string
-      } = {
+      const options: L.TileLayerOptions = {
         attribution: layer.attribution,
         minZoom: layer.minZoom,
         maxZoom: layer.maxZoom,
@@ -110,7 +103,6 @@ class SMMMap {
         if (layerEnabled === true) {
           tileLayer.addTo(this.map)
         }
-        tileLayer.on('add remove', this.layerStateChanged)
       }
     }
   }
@@ -126,6 +118,9 @@ class SMMMap {
     this.layerControlMaps.addTo(this.map)
     this.layerControlAssets.addTo(this.map)
     this.layerControlUsers.addTo(this.map)
+
+    this.map.on('overlayadd', this.layerStateChanged)
+    this.map.on('overlayremove', this.layerStateChanged)
 
     this.map.setView(new LatLng(0, 0), 16)
 


### PR DESCRIPTION
## Description

Three uses of private internals fell out into proper typings:

- map.tsx layerStateChanged switched from listening on each tilelayer's add/remove event (and looking the name up via layerControlMaps._getLayer(Util.stamp(...))) to listening on the map's overlayadd/overlayremove events, which fire only on user-initiated toggles and carry the layer name in the event payload. Also drops the now-unused Util import and bumps the tile options to the real TileLayerOptions type so referrerPolicy typechecks.

- asset/map.tsx assetUpdate replaced oldLayer._icon with the public Marker.getElement(), and moved 'title' off L.icon (where it isn't a valid IconOption) and onto the marker via setIcon + options.title. The L.icon(...) two-argument call in assetLayer became a single IconOptions object plus the title on L.marker.

- asset/map.tsx closeColorPicker uses optional chaining on the possibly-undefined colorDialog.

Closes 11 tsc errors and removes two undocumented internals that would break on any leaflet upgrade.

## Summary by Sourcery

Replace Leaflet private API usage with public event and marker APIs while tightening typings for map layers and tile options.

Enhancements:
- Track overlay layer visibility using Leaflet overlayadd/overlayremove map events and L.LayersControlEvent payloads instead of private layer control internals.
- Use L.TileLayerOptions for tile layer configuration to align with Leaflet’s public typings and support referrerPolicy.
- Configure marker titles via marker options and getElement() instead of accessing private marker _icon properties.
- Guard color dialog destruction with optional chaining to avoid calling destroy on undefined.