### PR TITLE
Use object instead of never for parentless page components

### DIFF
--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -84,8 +84,8 @@ interface OrganizationAddState {
   organizationName: string
 }
 
-class OrganizationAdd extends React.Component<never, OrganizationAddState> {
-  constructor(props: never) {
+class OrganizationAdd extends React.Component<object, OrganizationAddState> {
+  constructor(props: object) {
     super(props)
 
     this.state = {
@@ -139,9 +139,9 @@ interface OrganizationListPageState {
   knownOrganizations: OrganizationData[]
 }
 
-class OrganizationListPage extends React.Component<never, OrganizationListPageState> {
+class OrganizationListPage extends React.Component<object, OrganizationListPageState> {
   timer?: number
-  constructor(props: never) {
+  constructor(props: object) {
     super(props)
 
     this.state = {


### PR DESCRIPTION
## Description

OrganizationAdd and OrganizationListPage declared React.Component <never, State>. The render side then instantiated them as <X />, which TypeScript treats as supplying an empty object - not assignable to never. The runtime contract is "this component takes no props"; the correct expression of that on a class component is object (or {}). Switch both classes to React.Component<object, ...>.

## Summary by Sourcery

Enhancements:
- Align OrganizationAdd and OrganizationListPage props typing with React best practices by replacing never with object for class component props.