### PR TITLE
Augment leaflet namespace for the smmadmin and imageuploader controls

### DIFF
--- a/frontend/types/leaflet-smm-controls.d.ts
+++ b/frontend/types/leaflet-smm-controls.d.ts
@@ -1,0 +1,19 @@
+/* Ambient types for the bespoke Leaflet controls registered in
+ * frontend/Admin/admin.js and frontend/ImageUploader/ImageUploader.js.
+ * Both will get real typings when those files are converted to TS
+ * (see todo/frontend/refactor-convert-js-to-typescript.md). */
+import 'leaflet'
+
+declare module 'leaflet' {
+  interface SMMAdminOptions extends ControlOptions {
+    missionId: number | string
+  }
+  interface ImageUploaderOptions extends ControlOptions {
+    missionId: number | string
+  }
+
+  namespace control {
+    function smmadmin(opts: SMMAdminOptions): Control
+    function imageuploader(opts: ImageUploaderOptions): Control
+  }
+}


### PR DESCRIPTION
## Description

frontend/Admin/admin.js and frontend/ImageUploader/ImageUploader.js register L.control.smmadmin and L.control.imageuploader as side-effect-only mutations of the leaflet namespace. Until those files get proper TypeScript conversions, declare the constructor signatures inline so map.tsx's call sites typecheck.

## Summary by Sourcery

New Features:
- Add Leaflet module augmentations for smmadmin and imageuploader controls including their options interfaces and control factory functions.