### PR TITLE
Accept missionId as number or string in topbar and marine vectors

### DIFF
--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -8,7 +8,7 @@ import { smmGetJSON, smmPost } from '../ajax'
 
 interface CustomMarineVectorsProps {
   map: L.Map
-  missionId: number
+  missionId: number | string
   posName: string
   pos: L.LatLng
   poiId: number
@@ -133,7 +133,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   }
 }
 
-const MarineVectorsLeaflet = function (map: L.Map, missionId: number, posName: string, pos: L.LatLng, poiId: number) {
+const MarineVectorsLeaflet = function (map: L.Map, missionId: number | string, posName: string, pos: L.LatLng, poiId: number) {
   const container = document.createElement('div')
   const dialog = L.control.dialog({ initOpen: true, size: [1000, 500] })
   ReactDOM.createRoot(container).render(<CustomMarineVectors map={map} missionId={missionId} posName={posName} pos={pos} poiId={Number(poiId)} dialog={dialog} />)

--- a/frontend/menu/topbar.tsx
+++ b/frontend/menu/topbar.tsx
@@ -25,7 +25,7 @@ class SMMTopBar extends React.Component<object, never> {
 }
 
 interface SMMMissionTopBarProps {
-  missionId: number
+  missionId: number | string
 }
 
 class SMMMissionTopBar extends React.Component<SMMMissionTopBarProps, never> {


### PR DESCRIPTION
## Description

map.tsx reads the missionId hidden input as a string ("current", "all" or a numeric id rendered by the Django template). SMMMissionTopBar and MarineVectorsLeaflet declared missionId: number, so tsc rejected the call sites in map.tsx and usergeo/poi.tsx. The components only use missionId to template URLs - either form interpolates correctly - so widen the props to number | string. A proper discriminated MissionId union is captured in
todo/frontend/refactor-missionId-type-discriminated.md.

## Summary by Sourcery

Enhancements:
- Widen missionId prop types in MarineVectorsLeaflet and SMMMissionTopBar to accept both numeric and string mission identifiers.