### PR TITLE
Close the remaining tsc tail

### DIFF
--- a/frontend/SearchAdder/SearchAdderDialog.tsx
+++ b/frontend/SearchAdder/SearchAdderDialog.tsx
@@ -78,7 +78,7 @@ export function SearchAdderDialog({ map, objectType, objectID, onClose }: Props)
   async function handlePreview() {
     const data = await smmGetJSON<GeoJSON.GeoJsonObject>(getUrl(searchType, objectType), getData())
     previewRef.current?.remove()
-    previewRef.current = L.geoJSON(data, { color: 'yellow' }).addTo(map)
+    previewRef.current = L.geoJSON(data, { style: { color: 'yellow' } }).addTo(map)
   }
 
   function handleCreate() {

--- a/frontend/marinevectors.tsx
+++ b/frontend/marinevectors.tsx
@@ -6,5 +6,5 @@ import * as ReactDOM from 'react-dom/client'
 
 import { MarineVectors } from '@canterbury-air-patrol/marine-total-drift-vector'
 
-const root = ReactDOM.createRoot(document.getElementById('root'))
+const root = ReactDOM.createRoot(document.getElementById('root')!)
 root.render(<MarineVectors />)

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -60,10 +60,10 @@ interface MissionDetailsExternalReferencesRowProps {
   ExternalReference: MissionExternalReferenceData
 }
 
+type ExtRefField = 'name' | 'code' | 'url' | 'notes'
+
 interface MissionDetailsExternalReferencesRowState {
-  editFields: {
-    [name: string]: boolean
-  }
+  editFields: Partial<Record<ExtRefField, boolean>>
   values: {
     name: string
     code?: string
@@ -94,13 +94,13 @@ class MissionDetailsExternalReferencesRow extends React.Component<MissionDetails
     this.delete = this.delete.bind(this)
   }
 
-  toggleEdit(field: string) {
+  toggleEdit(field: ExtRefField) {
     this.setState((prevState) => ({
       editFields: { ...prevState.editFields, [field]: true }
     }))
   }
 
-  handleChange(field: string, event: React.ChangeEvent<HTMLInputElement>) {
+  handleChange(field: ExtRefField, event: React.ChangeEvent<HTMLInputElement>) {
     const { value } = event.target
     this.setState((prevState) => ({
       values: { ...prevState.values, [field]: value }
@@ -130,7 +130,7 @@ class MissionDetailsExternalReferencesRow extends React.Component<MissionDetails
     smmDelete(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`)
   }
 
-  renderField(field: string, displayValue?: string) {
+  renderField(field: ExtRefField, displayValue?: string) {
     return this.state.editFields[field] ? (
       <input type="text" value={this.state.values[field] ?? ''} onChange={(e) => this.handleChange(field, e)} />
     ) : (

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -29,7 +29,7 @@ class SMMSearch {
   }
 
   searchQueueDestroy() {
-    this.QueueDialog.destroy()
+    this.QueueDialog?.destroy()
     this.QueueDialog = undefined
   }
 

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -48,7 +48,7 @@ class SMMUserPosition {
   }
 
   closeColorPicker() {
-    this.colorDialog.destroy()
+    this.colorDialog?.destroy()
     this.colorDialog = undefined
   }
 


### PR DESCRIPTION
## Description

Five small fixes:
- SearchAdderDialog preview moves L.geoJSON's color into a typed PathOptions style object (the top-level 'color' is not a GeoJSONOptions field).
- marinevectors.tsx entry asserts document.getElementById('root') is non-null when handing it to ReactDOM.createRoot.
- mission/details.tsx MissionDetailsExternalReferencesRow narrows the field parameter on renderField/toggleEdit/handleChange to an ExtRefField union, replacing the generic string indexing.
- search/map.tsx and user/map.tsx route the optional QueueDialog and colorDialog destroy calls through optional chaining.

tsc --noEmit reports 0 errors after this commit.

## Summary by Sourcery

Address remaining TypeScript type issues to achieve a clean tsc --noEmit run.

Bug Fixes:
- Fix GeoJSON preview styling by using a typed PathOptions style object instead of a top-level color option.
- Guard optional QueueDialog and colorDialog destruction with optional chaining to avoid runtime errors when dialogs are unset.

Enhancements:
- Tighten MissionDetailsExternalReferencesRow field typing with a dedicated ExtRefField union and a typed editFields map.
- Assert non-null root DOM element when creating the MarineVectors React root.