### PR TITLE
Enforce tsc --noEmit in npm run check

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,14 +1,14 @@
-name: ESLint
+name: Frontend Check
 
 on:
   pull_request
 
 jobs:
-  eslint:
+  check:
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v6
      - name: Install modules
        run: npm ci
-     - name: Run ESLint
+     - name: Run frontend check (tsc + eslint + prettier)
        run: npm run check

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "frontend/map.js",
   "scripts": {
-    "check": "eslint frontend/ && prettier -c frontend/",
+    "typecheck": "tsc --noEmit",
+    "check": "tsc --noEmit && eslint frontend/ && prettier -c frontend/",
     "build-only": "esbuild $(esbuild-config) && mkdir -p dist/icons && cp frontend/icons/*.png dist/icons/",
     "build": "esbuild $(esbuild-config) && mkdir -p dist/icons && cp frontend/icons/*.png dist/icons/ && cp -dpR dist/* map/static/",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Description

With 0 remaining tsc errors after the preceding cleanup, wire 'tsc --noEmit' as the first step in npm run check (and expose a standalone 'typecheck' script for local use). The existing GitHub Actions workflow already runs npm run check on every PR, so any future TypeScript regression now fails CI. Rename the workflow's display name from 'ESLint' to 'Frontend Check' to reflect the broader scope.

## Summary by Sourcery

Enforce TypeScript type-checking in the frontend CI check and align npm scripts and workflow naming with the broader frontend validation.

New Features:
- Add a standalone npm script to run TypeScript type-checking without emitting output.

Enhancements:
- Update the existing frontend check script to run TypeScript type-checking before ESLint and Prettier.
- Rename the GitHub Actions ESLint workflow and job to reflect the wider frontend checks now being performed.