### PR TITLE
Switch to the automatic JSX runtime

### DIFF
--- a/esbuild.config.json
+++ b/esbuild.config.json
@@ -22,6 +22,7 @@
     "bundle": true,
     "minify": true,
     "outdir": "dist",
+    "jsx": "automatic",
     "loader": {
         ".js": "jsx",
         ".png": "file",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     /* Language and Environment */
     "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "lib": ["ES2020", "DOM", "DOM.Iterable"],            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "jsx": "react",                                /* Specify what JSX code is generated. */
+    "jsx": "react-jsx",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */


### PR DESCRIPTION
## Description

tsc and esbuild both used classic JSX, which required every TSX file to keep an unused 'import React from "react"' just to satisfy React.createElement. Switch tsconfig jsx to react-jsx and esbuild's jsx setting to automatic so the bundler emits jsx() calls and pulls react/jsx-runtime itself. The default React import is no longer needed - that mechanical cleanup comes in the next commit.

## Summary by Sourcery

Switch the TypeScript and esbuild configurations to use React's automatic JSX runtime instead of the classic JSX transform.

Build:
- Update tsconfig to emit JSX using the react-jsx runtime.
- Configure esbuild to use the automatic JSX runtime for JSX transformation.