### PR TITLE
Drop unused default React imports after jsx-runtime switch

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ export default [
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
+  pluginReact.configs.flat["jsx-runtime"],
   {
     settings: {
       react: {

--- a/frontend/Admin/AdminMenuDialog.tsx
+++ b/frontend/Admin/AdminMenuDialog.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 interface Props {
   onCommand: () => void
   onClose: () => void

--- a/frontend/Admin/AssetCommandDialog.tsx
+++ b/frontend/Admin/AssetCommandDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 
 import { smmGetJSON, smmPost } from '../ajax'

--- a/frontend/Admin/admin.js
+++ b/frontend/Admin/admin.js
@@ -1,5 +1,4 @@
 import L from 'leaflet'
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import { AdminMenuDialog } from './AdminMenuDialog'

--- a/frontend/ImageUploader/ImageUploader.js
+++ b/frontend/ImageUploader/ImageUploader.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import L from 'leaflet'
 

--- a/frontend/ImageUploader/ImageUploaderDialog.tsx
+++ b/frontend/ImageUploader/ImageUploaderDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import { useRef } from 'react'
 import L from 'leaflet'
 
 import { LatLngMarkerInput } from '../LatLngMarkerInput'

--- a/frontend/LatLngMarkerInput.tsx
+++ b/frontend/LatLngMarkerInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 import { degreesToDM, DMToDegrees } from '@canterbury-air-patrol/deg-converter'
 

--- a/frontend/LineAdder/LineAdder.js
+++ b/frontend/LineAdder/LineAdder.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import L from 'leaflet'
 
 import { VectorAdderDialog } from '../components/VectorAdderDialog'

--- a/frontend/POIAdder/POIAdder.js
+++ b/frontend/POIAdder/POIAdder.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import L from 'leaflet'
 import markerIcon from 'leaflet/dist/images/marker-icon.png'
 

--- a/frontend/POIAdder/POIAdderDialog.tsx
+++ b/frontend/POIAdder/POIAdderDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import L from 'leaflet'
 
 import { LatLngMarkerInput } from '../LatLngMarkerInput'

--- a/frontend/PolygonAdder/PolygonAdder.js
+++ b/frontend/PolygonAdder/PolygonAdder.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import L from 'leaflet'
 
 import { VectorAdderDialog } from '../components/VectorAdderDialog'

--- a/frontend/SearchAdder/SearchAdder.js
+++ b/frontend/SearchAdder/SearchAdder.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { SearchAdderDialog } from './SearchAdderDialog'
 import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 

--- a/frontend/SearchAdder/SearchAdderDialog.tsx
+++ b/frontend/SearchAdder/SearchAdderDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 
 import { smmGetJSON, smmPost } from '../ajax'

--- a/frontend/asset/AssetPopup.tsx
+++ b/frontend/asset/AssetPopup.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { PopupDataList } from '../popup'
 

--- a/frontend/asset/ColorPickerDialog.tsx
+++ b/frontend/asset/ColorPickerDialog.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { AssetColorPicker } from './map'
 
 interface Props {

--- a/frontend/components/VectorAdderDialog.tsx
+++ b/frontend/components/VectorAdderDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 
 import { LatLngMarkerInput } from '../LatLngMarkerInput'

--- a/frontend/image/ImagePopup.tsx
+++ b/frontend/image/ImagePopup.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { PopupDataList, PopupButtonGroup } from '../popup'
 

--- a/frontend/image/map.tsx
+++ b/frontend/image/map.tsx
@@ -1,5 +1,4 @@
 import L from 'leaflet'
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import { SMMRealtime } from '../smmmap'

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -1,7 +1,6 @@
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import L, { LatLng } from 'leaflet'

--- a/frontend/marine/MarineVectorPopup.tsx
+++ b/frontend/marine/MarineVectorPopup.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { PopupDataList, PopupButtonGroup, ButtonItem } from '../popup'
 
 interface Props {

--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import L from 'leaflet'
 

--- a/frontend/marine/vectors.tsx
+++ b/frontend/marine/vectors.tsx
@@ -1,5 +1,4 @@
 import L from 'leaflet'
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import { SMMRealtime } from '../smmmap'

--- a/frontend/marinesac.tsx
+++ b/frontend/marinesac.tsx
@@ -1,6 +1,5 @@
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import { MarineSACTable } from '@canterbury-air-patrol/marine-search-area-coverage'

--- a/frontend/marinevectors.tsx
+++ b/frontend/marinevectors.tsx
@@ -1,7 +1,6 @@
 import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap/dist/js/bootstrap.bundle'
 
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import { MarineVectors } from '@canterbury-air-patrol/marine-total-drift-vector'

--- a/frontend/popup.tsx
+++ b/frontend/popup.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 interface DataItem {
   label: string
   value: string

--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { MissionAssetData } from '../asset/types'
 import { smmGetJSON, smmPost } from '../ajax'

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import L from 'leaflet'

--- a/frontend/user/UserPopup.tsx
+++ b/frontend/user/UserPopup.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { PopupDataList } from '../popup'
 

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -1,7 +1,6 @@
 import L from 'leaflet'
 
 import { SMMRealtime } from '../smmmap'
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { cookieJar } from '../cookies'
 import { smmGetJSON } from '../ajax'

--- a/frontend/usergeo/LinePopup.tsx
+++ b/frontend/usergeo/LinePopup.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { PopupDataList, PopupButtonGroup, ButtonItem } from '../popup'
 
 interface Props {

--- a/frontend/usergeo/POIPopup.tsx
+++ b/frontend/usergeo/POIPopup.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { PopupDataList, PopupButtonGroup, ButtonItem } from '../popup'
 

--- a/frontend/usergeo/PolygonPopup.tsx
+++ b/frontend/usergeo/PolygonPopup.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { PopupDataList, PopupButtonGroup, ButtonItem } from '../popup'
 
 interface Props {

--- a/frontend/usergeo/line.tsx
+++ b/frontend/usergeo/line.tsx
@@ -1,5 +1,4 @@
 import L from 'leaflet'
-import React from 'react'
 
 import { LineAdder } from '../LineAdder/LineAdder.js'
 import { SearchAdder } from '../SearchAdder/SearchAdder.js'

--- a/frontend/usergeo/poi.tsx
+++ b/frontend/usergeo/poi.tsx
@@ -1,5 +1,4 @@
 import L from 'leaflet'
-import React from 'react'
 
 import { MarineVectorsLeaflet } from '../marine/leaflet'
 import { POIAdder } from '../POIAdder/POIAdder.js'

--- a/frontend/usergeo/polygon.tsx
+++ b/frontend/usergeo/polygon.tsx
@@ -1,5 +1,4 @@
 import L from 'leaflet'
-import React from 'react'
 
 import { PolygonAdder } from '../PolygonAdder/PolygonAdder.js'
 import { SearchAdder } from '../SearchAdder/SearchAdder.js'


### PR DESCRIPTION
## Description

With the automatic JSX runtime in place, 'import React from "react"' is no longer needed in files that never reference the React namespace directly. Strip the default import from 34 files (28 .tsx + 6 .js) and convert 'import React, { useEffect, ... } from "react"' to 'import { useEffect, ... } from "react"' where applicable. Files that use React.Component / React.ChangeEvent / React.JSX still keep the default import.

ESLint config swaps in pluginReact.configs.flat['jsx-runtime'] so the recommended react/react-in-jsx-scope and react/jsx-uses-react rules no longer fire for the now-removed import.

## Summary by Sourcery

Remove unused default React imports now that the automatic JSX runtime is enabled and align linting with the jsx-runtime configuration.

Enhancements:
- Drop unnecessary default React imports from React components that no longer reference the React namespace directly.

Build:
- Update ESLint flat config to include the React jsx-runtime preset so legacy JSX-scope rules are disabled under the new runtime.