### PR TITLE
Triage react-hooks/exhaustive-deps and enforce 0 warnings in CI

### DIFF
--- a/frontend/Admin/AssetCommandDialog.tsx
+++ b/frontend/Admin/AssetCommandDialog.tsx
@@ -34,7 +34,7 @@ export function AssetCommandDialog({ map, missionId, onClose }: Props) {
       if (data.assets.length > 0) setAssetId(String(data.assets[0].id))
       if (data.commands.length > 0) setCommand(data.commands[0].value)
     })
-  }, [])
+  }, [missionId])
 
   function handleSet() {
     if (!assetId) {

--- a/frontend/LatLngMarkerInput.tsx
+++ b/frontend/LatLngMarkerInput.tsx
@@ -15,6 +15,8 @@ export function LatLngMarkerInput({ map, initialPos, showLabels = true, onChange
   const markerRef = useRef<L.Marker | null>(null)
 
   useEffect(() => {
+    // Mount-only: the marker tracks user drags via setLatLng below, so we
+    // intentionally don't recreate it when initialPos/onChange change.
     const marker = L.marker(initialPos, { draggable: true, autoPan: true }).addTo(map)
     markerRef.current = marker
     marker.on('dragend', () => {
@@ -26,6 +28,7 @@ export function LatLngMarkerInput({ map, initialPos, showLabels = true, onChange
     return () => {
       marker.remove()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   function syncMarker(lat: string, lng: string) {

--- a/frontend/components/VectorAdderDialog.tsx
+++ b/frontend/components/VectorAdderDialog.tsx
@@ -26,12 +26,15 @@ export function VectorAdderDialog({ map, type, missionId, initialPoints, replace
   const shapeRef = useRef<L.Polyline | L.Polygon | null>(null)
 
   useEffect(() => {
+    // Mount-only: the shape is updated in place via setLatLngs below;
+    // changing type or map mid-dialog isn't supported.
     const shape = type === 'line' ? L.polyline(positionsRef.current, { color: 'yellow' }) : L.polygon(positionsRef.current, { color: 'yellow' })
     shape.addTo(map)
     shapeRef.current = shape
     return () => {
       shape.remove()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   function handlePositionChange(index: number, pos: L.LatLng) {

--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -21,7 +21,7 @@ export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: 
       setAssets(filtered)
       if (filtered.length > 0) setSelectedAssetId(String(filtered[0].id))
     })
-  }, [])
+  }, [missionId, createdFor])
 
   async function handleQueue() {
     const data: { asset?: string } = {}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "frontend/map.js",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "check": "tsc --noEmit && eslint frontend/ && prettier -c frontend/",
+    "check": "tsc --noEmit && eslint --max-warnings 0 frontend/ && prettier -c frontend/",
     "build-only": "esbuild $(esbuild-config) && mkdir -p dist/icons && cp frontend/icons/*.png dist/icons/",
     "build": "esbuild $(esbuild-config) && mkdir -p dist/icons && cp frontend/icons/*.png dist/icons/ && cp -dpR dist/* map/static/",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Description

Two dialogs (AssetCommandDialog, SearchQueueDialog) genuinely needed their missionId/createdFor dependencies in the effect array; the effect should refire if the parent changes them. Two Leaflet-mounting effects (LatLngMarkerInput, VectorAdderDialog) intentionally run only on mount - the underlying Leaflet object is then driven imperatively via refs - so suppress the lint with an explicit eslint-disable comment and a one-line note explaining the intent.

With all four warnings addressed, raise the lint gate by passing --max-warnings 0 to eslint inside npm run check, so any future unaddressed lint warning fails CI just like type errors do.

## Summary by Sourcery

Enforce zero-warning eslint checks in CI and adjust React hooks to satisfy exhaustive-deps linting while documenting intentional mount-only Leaflet effects.

Bug Fixes:
- Ensure AssetCommandDialog refetches data when missionId changes by including missionId in the effect dependency array.
- Ensure SearchQueueDialog refetches assets when missionId or createdFor changes by including these in the effect dependency array.

Enhancements:
- Document and explicitly disable react-hooks/exhaustive-deps for mount-only Leaflet marker and vector shape effects that are updated imperatively.
- Tighten the eslint gate in the npm check script by failing CI on any lint warning via --max-warnings 0.