### PR TITLE
Make AssetCommandData.response optional and harmonise the checks

### DIFF
--- a/frontend/asset/types.ts
+++ b/frontend/asset/types.ts
@@ -43,7 +43,7 @@ interface AssetCommandData {
   reason?: string
   issued?: string
   issued_by?: string
-  response: {
+  response?: {
     set?: string
     by?: string
     type?: string

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -187,21 +187,22 @@ class AssetCommandView extends React.Component<AssetCommandViewProps, AssetComma
 
   render() {
     const responseData = []
-    if (this.props.lastCommand?.response !== undefined) {
-      if (this.props.lastCommand.response.set !== null) {
+    const response = this.props.lastCommand?.response
+    if (response) {
+      if (response.set) {
         responseData.push(
           <tr key="response">
             <td>
-              <i>{this.props.lastCommand.response.type}</i>
+              <i>{response.type}</i>
             </td>
-            <td>At: {this.props.lastCommand.response.set !== undefined ? new Date(this.props.lastCommand.response.set).toLocaleString() : ''}</td>
-            <td>By: {this.props.lastCommand.response.by}</td>
+            <td>At: {new Date(response.set).toLocaleString()}</td>
+            <td>By: {response.by}</td>
           </tr>
         )
         responseData.push(
           <tr key="message">
             <td>Message:</td>
-            <td colSpan={2}>{this.props.lastCommand.response.message}</td>
+            <td colSpan={2}>{response.message}</td>
           </tr>
         )
       } else {


### PR DESCRIPTION
## Description

AssetCommandData.response was declared required, but callers in asset/ui.tsx already used 'lastCommand?.response !== undefined' to guard for its absence. The same block then mixed '!== null' and '!== undefined' checks on response.set even though set is typed 'string | undefined'. Mark response optional in the type and replace the nested null/undefined gymnastics with destructuring + truthy checks. No behaviour change.

## Summary by Sourcery

Relax asset command response typing and simplify response rendering logic in the asset UI.

Enhancements:
- Make AssetCommandData.response optional to align the type with actual usage.
- Simplify AssetCommandView response rendering by reusing a local response reference and truthy checks instead of nested null/undefined guards.