### PR TITLE
Correct AssetFullStatusData.name type to string

### DIFF
--- a/frontend/asset/types.ts
+++ b/frontend/asset/types.ts
@@ -17,7 +17,7 @@ interface AssetData {
 
 interface AssetFullStatusData {
   asset_id: number
-  name: number
+  name: string
   asset_type: string
   owner: string
   last_command?: AssetCommandData


### PR DESCRIPTION
## Description

The /assets/<id>/ endpoint returns the asset name as a string; the type declared it number, but the consumer in asset/ui.tsx rendered it straight into JSX as text. Switching to the right type lets future strict-mode checks catch any new misuse.

## Summary by Sourcery

Bug Fixes:
- Fix the AssetFullStatusData.name type from number to string to align with the /assets/<id>/ endpoint response.