### PR TITLE
Declare global Window create* functions instead of @ts-expect-error

### DIFF
--- a/frontend/asset/list.tsx
+++ b/frontend/asset/list.tsx
@@ -119,5 +119,4 @@ function createAssetList(elementId: string) {
   )
 }
 
-// @ts-expect-error: globalThis doesn't have a define
-globalThis.createAssetList = createAssetList
+window.createAssetList = createAssetList

--- a/frontend/asset/type_list.tsx
+++ b/frontend/asset/type_list.tsx
@@ -99,5 +99,4 @@ function createAssetTypeList(elementId: string) {
   )
 }
 
-// @ts-expect-error: globalThis doesn't have a define
-globalThis.createAssetTypeList = createAssetTypeList
+window.createAssetTypeList = createAssetTypeList

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -595,7 +595,6 @@ function createAssetUI(elementId: string, assetId: number) {
   )
 }
 
-// @ts-expect-error: globalThis doesn't have a define
-globalThis.createAssetUI = createAssetUI
+window.createAssetUI = createAssetUI
 
 export { AssetCommandView, AssetMissionDetails, AssetUI }

--- a/frontend/icons/list.tsx
+++ b/frontend/icons/list.tsx
@@ -120,5 +120,4 @@ function createIconList(elementId: string) {
   )
 }
 
-// @ts-expect-error: globalTime has no definition
-globalThis.createIconList = createIconList
+window.createIconList = createIconList

--- a/frontend/marinesac.tsx
+++ b/frontend/marinesac.tsx
@@ -16,5 +16,4 @@ export function createMarineSACTable(elementId: string, missionId: number) {
   )
 }
 
-// @ts-expect-error: globalThis has no definition
-globalThis.createMarineSACTable = createMarineSACTable
+window.createMarineSACTable = createMarineSACTable

--- a/frontend/menu/topbar.tsx
+++ b/frontend/menu/topbar.tsx
@@ -49,8 +49,7 @@ function createSMMMissionTopBar(elementId: string, missionId: number) {
   div.render(<SMMMissionTopBar missionId={missionId} />)
 }
 
-// @ts-expect-error: globalThis doesn't have a define
-globalThis.createSMMMissionTopBar = createSMMMissionTopBar
+window.createSMMMissionTopBar = createSMMMissionTopBar
 
 interface SMMOrganizationTopBarProps {
   organizationId: number
@@ -91,7 +90,6 @@ function createSMMOrganizationTopBar(elementId: string, organizationId: number, 
   div.render(<SMMOrganizationTopBar organizationId={organizationId} showRadioOperator={showRadioOperator} />)
 }
 
-// @ts-expect-error: globalThis doesn't have a define
-globalThis.createSMMOrganizationTopBar = createSMMOrganizationTopBar
+window.createSMMOrganizationTopBar = createSMMOrganizationTopBar
 
 export { SMMTopBar, SMMMissionTopBar, SMMOrganizationTopBar }

--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -196,5 +196,4 @@ function createMissionAssetStatus(elementId: string, asset: number, mission: num
 
 export { MissionAssetStatus }
 
-// @ts-expect-error: globalThis doesn't have a define
-globalThis.createMissionAssetStatus = createMissionAssetStatus
+window.createMissionAssetStatus = createMissionAssetStatus

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -942,5 +942,4 @@ function createMissionDetails(elementId: string, missionId: number) {
 
 export { MissionDetailPage }
 
-// @ts-expect-error: globalThis has no definition
-globalThis.createMissionDetails = createMissionDetails
+window.createMissionDetails = createMissionDetails

--- a/frontend/mission/list.tsx
+++ b/frontend/mission/list.tsx
@@ -193,5 +193,4 @@ function createMissionList(elementId: string) {
 
 export { MissionListRow, MissionListPage }
 
-// @ts-expect-error: globalThis doesn't have a definition
-globalThis.createMissionList = createMissionList
+window.createMissionList = createMissionList

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -268,5 +268,4 @@ export function createMissionTimeline(elementId: string, missionId: number) {
   )
 }
 
-// @ts-expect-error: globalThis has no definition
-globalThis.createMissionTimeline = createMissionTimeline
+window.createMissionTimeline = createMissionTimeline

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -488,5 +488,4 @@ function createOrganizationDetails(elementId: string, organizationId: number) {
   div.render(<OrganizationPage organizationId={organizationId} />)
 }
 
-// @ts-expect-error: globalThis has not definition
-globalThis.createOrganizationDetails = createOrganizationDetails
+window.createOrganizationDetails = createOrganizationDetails

--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -191,5 +191,4 @@ function createOrganizationList(elementId: string) {
 
 export { OrganizationListRow }
 
-// @ts-expect-error: globalThis is not defined
-globalThis.createOrganizationList = createOrganizationList
+window.createOrganizationList = createOrganizationList

--- a/frontend/organization/radio-operator.tsx
+++ b/frontend/organization/radio-operator.tsx
@@ -93,5 +93,4 @@ function createRadioOperator(elementId: string, organizationId: number) {
   )
 }
 
-// @ts-expect-error: globalThis has no definition
-globalThis.createRadioOperator = createRadioOperator
+window.createRadioOperator = createRadioOperator

--- a/frontend/search/details.tsx
+++ b/frontend/search/details.tsx
@@ -207,5 +207,4 @@ function createSearchDetailsPage(elementId: string, missionId: number, searchId:
 }
 export { SearchDetails, createSearchDetailsPage }
 
-// @ts-expect-error: globalThis has no definition
-globalThis.createSearchDetailsPage = createSearchDetailsPage
+window.createSearchDetailsPage = createSearchDetailsPage

--- a/frontend/types/window-create.d.ts
+++ b/frontend/types/window-create.d.ts
@@ -1,0 +1,27 @@
+/* Window augmentation for the create* mount functions each entrypoint
+ * exposes for the Django templates to call. Keeping this in one place
+ * lets us drop the per-file '// @ts-expect-error: globalThis...'
+ * comments and surface typos at compile time. */
+
+declare global {
+  interface Window {
+    createAssetList: (elementId: string) => void
+    createAssetTypeList: (elementId: string) => void
+    createAssetUI: (elementId: string, assetId: number) => void
+    createIconList: (elementId: string) => void
+    createMarineSACTable: (elementId: string, missionId: number) => void
+    createMissionAssetStatus: (elementId: string, asset: number, mission: number) => void
+    createMissionDetails: (elementId: string, missionId: number) => void
+    createMissionList: (elementId: string) => void
+    createMissionTimeline: (elementId: string, missionId: number) => void
+    createOrganizationDetails: (elementId: string, organizationId: number) => void
+    createOrganizationList: (elementId: string) => void
+    createRadioOperator: (elementId: string, organizationId: number) => void
+    createSearchDetailsPage: (elementId: string, missionId: number, searchId: number) => void
+    createSMMMissionTopBar: (elementId: string, missionId: number) => void
+    createSMMOrganizationTopBar: (elementId: string, organizationId: number, showRadioOperator: boolean) => void
+    createUserGeoDetailsPage: (elementId: string, missionId: number, userGeoId: number) => void
+  }
+}
+
+export {}

--- a/frontend/usergeo/details.tsx
+++ b/frontend/usergeo/details.tsx
@@ -93,5 +93,4 @@ function createUserGeoDetailsPage(elementId: string, missionId: number, userGeoI
 }
 export { UserGeoDetailsPage, createUserGeoDetailsPage }
 
-// @ts-expect-error: globalThis has no definition
-globalThis.createUserGeoDetailsPage = createUserGeoDetailsPage
+window.createUserGeoDetailsPage = createUserGeoDetailsPage


### PR DESCRIPTION
## Description

Each entrypoint exposes a window-level create<Page> function the Django template invokes after page load. Until now every site repeated '// @ts-expect-error: globalThis...' (with four different misspellings) followed by 'globalThis.createX = createX'. @ts-expect-error only needs *some* error on the next line to be satisfied, so a typo in the function name would silently pass the type check.

Add a single frontend/types/window-create.d.ts that augments 'interface Window' with the 16 create* signatures, then drop every expect-error comment and switch the assignment to 'window.createX = createX'. Future typos now fail tsc.

## Summary by Sourcery

Declare and use strongly-typed window-level create* entrypoint functions instead of relying on per-file TypeScript expect-error comments for global assignments.

Enhancements:
- Add a central Window interface augmentation defining all create* entrypoint functions used by Django templates.
- Replace globalThis assignments and @ts-expect-error comments with window.create* assignments across all frontend entrypoints to surface typos at compile time.