### PR TITLE
Extract formatLocalDateTime helper and replace toLocaleString sites

### DIFF
--- a/frontend/SMMObjects/details.tsx
+++ b/frontend/SMMObjects/details.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../format'
 import { Table } from 'react-bootstrap'
 
 import React from 'react'
@@ -20,7 +21,7 @@ class SMMObjectDetails extends React.Component<SMMObjectDetailsProps, never> {
     tableRows.push(
       <tr key="created_at">
         <td>Created:</td>
-        <td>{new Date(data.created_at).toLocaleString()}</td>
+        <td>{formatLocalDateTime(data.created_at)}</td>
       </tr>
     )
     tableRows.push(
@@ -33,7 +34,7 @@ class SMMObjectDetails extends React.Component<SMMObjectDetailsProps, never> {
       tableRows.push(
         <tr key="deleted_at">
           <td>Deleted:</td>
-          <td>{new Date(data.deleted_at).toLocaleString()}</td>
+          <td>{formatLocalDateTime(data.deleted_at)}</td>
         </tr>
       )
       tableRows.push(
@@ -47,7 +48,7 @@ class SMMObjectDetails extends React.Component<SMMObjectDetailsProps, never> {
       tableRows.push(
         <tr key="replaced_at">
           <td>Replaced:</td>
-          <td>{new Date(data.replaced_at).toLocaleString()}</td>
+          <td>{formatLocalDateTime(data.replaced_at)}</td>
         </tr>
       )
       tableRows.push(

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../format'
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button } from 'react-bootstrap'
@@ -195,7 +196,7 @@ class AssetCommandView extends React.Component<AssetCommandViewProps, AssetComma
             <td>
               <i>{response.type}</i>
             </td>
-            <td>At: {new Date(response.set).toLocaleString()}</td>
+            <td>At: {formatLocalDateTime(response.set)}</td>
             <td>By: {response.by}</td>
           </tr>
         )
@@ -250,7 +251,7 @@ class AssetCommandView extends React.Component<AssetCommandViewProps, AssetComma
             <td>
               <b>{this.props.lastCommand?.action_txt}</b>
             </td>
-            <td>Issued: {this.props.lastCommand?.issued === undefined ? '' : new Date(this.props.lastCommand.issued).toLocaleString()}</td>
+            <td>Issued: {formatLocalDateTime(this.props.lastCommand?.issued)}</td>
             <td>By: {this.props.lastCommand?.issued_by}</td>
           </tr>
           {gotoRow}
@@ -466,7 +467,7 @@ class AssetStatus extends React.Component<AssetStatusProps, AssetStatusState> {
           <td>Status:</td>
           <td>{details.status.status}</td>
           <td>Since:</td>
-          <td>{details.status.since === undefined ? '' : new Date(details.status.since).toLocaleString()}</td>
+          <td>{formatLocalDateTime(details.status.since)}</td>
         </tr>
       )
       rows.push(

--- a/frontend/format.ts
+++ b/frontend/format.ts
@@ -1,0 +1,10 @@
+/**
+ * Format a backend ISO-8601 timestamp as a local-time string.
+ * Returns an empty string for null/undefined or unparseable input so the
+ * UI never shows "Invalid Date".
+ */
+export function formatLocalDateTime(value: string | null | undefined): string {
+  if (!value) return ''
+  const d = new Date(value)
+  return isNaN(d.getTime()) ? '' : d.toLocaleString()
+}

--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../../format'
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button } from 'react-bootstrap'
@@ -173,7 +174,7 @@ class MissionAssetStatus extends React.Component<MissionAssetStatusFormProps, Mi
               <td>{this.state.statusData?.status}</td>
               <td>{this.state.statusData?.status_description}</td>
               <td>{this.state.statusData?.notes}</td>
-              <td>{this.state.statusData?.since === undefined ? '' : new Date(this.state.statusData.since).toLocaleString()}</td>
+              <td>{formatLocalDateTime(this.state.statusData?.since)}</td>
             </tr>
             <MissionAssetStatusForm asset={this.props.asset} mission={this.props.mission} />
           </tbody>

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../format'
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
@@ -29,7 +30,7 @@ const MissionDetails: React.FC<MissionDetailsProps> = (props) => {
         </tr>
         <tr>
           <td>Started</td>
-          <td>{new Date(mission.started).toLocaleString()}</td>
+          <td>{formatLocalDateTime(mission.started)}</td>
         </tr>
         <tr>
           <td>Creator</td>
@@ -42,7 +43,7 @@ const MissionDetails: React.FC<MissionDetailsProps> = (props) => {
         {mission.closed && (
           <tr>
             <td>Closed</td>
-            <td>{new Date(mission.closed).toLocaleString()}</td>
+            <td>{formatLocalDateTime(mission.closed)}</td>
           </tr>
         )}
         {mission.closed_by && (
@@ -708,15 +709,15 @@ class MissionDetailsAssetRow extends React.Component<MissionDetailsAssetRowProps
         <>
           {missionAsset.status.name}
           <br />
-          <small>{new Date(missionAsset.status.since).toLocaleString()}</small>
+          <small>{formatLocalDateTime(missionAsset.status.since)}</small>
         </>
       )
     }
     if (missionAsset.added) {
-      added = new Date(missionAsset.added).toLocaleString()
+      added = formatLocalDateTime(missionAsset.added)
     }
     if (missionAsset.removed) {
-      removed = new Date(missionAsset.removed).toLocaleString()
+      removed = formatLocalDateTime(missionAsset.removed)
     } else {
       buttons.push(
         <Button key="btnRemove" variant="danger" onClick={this.remove}>

--- a/frontend/mission/list.tsx
+++ b/frontend/mission/list.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../format'
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
@@ -20,11 +21,11 @@ class MissionListRow extends React.Component<MissionListRowProps, never> {
     const { mission } = this.props
     const dataFields = []
     dataFields.push(<td key="name">{mission.name}</td>)
-    dataFields.push(<td key="opened">{new Date(mission.started).toLocaleString()}</td>)
+    dataFields.push(<td key="opened">{formatLocalDateTime(mission.started)}</td>)
     dataFields.push(<td key="creator">{mission.creator}</td>)
 
     if (this.props.showClosed) {
-      dataFields.push(<td key="closed">{mission.closed ? new Date(mission.closed).toLocaleString() : ''}</td>)
+      dataFields.push(<td key="closed">{formatLocalDateTime(mission.closed)}</td>)
       dataFields.push(<td key="closer">{mission.closed_by}</td>)
     }
 

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../format'
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button } from 'react-bootstrap'
@@ -143,7 +144,7 @@ class MissionTimelineEntry extends React.Component<MissionTimelineEntryProps, ne
     const entry = this.props.timelineEntry
     return (
       <tr>
-        <td>{new Date(entry.timestamp).toLocaleString()}</td>
+        <td>{formatLocalDateTime(entry.timestamp)}</td>
         <td>{entry.creator}</td>
         <td>{entry.event_type}</td>
         <td>{entry.message}</td>

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../format'
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
@@ -71,7 +72,7 @@ class OrganizationMemberRow extends React.Component<OrganizationMemberRowProps, 
     const organizationMember = this.props.organization_member
     const dataFields = []
     dataFields.push(<td key="name">{organizationMember.user}</td>)
-    dataFields.push(<td key="created">{new Date(organizationMember.added).toLocaleString()}</td>)
+    dataFields.push(<td key="created">{formatLocalDateTime(organizationMember.added)}</td>)
     dataFields.push(<td key="creator">{organizationMember.added_by}</td>)
 
     if (this.props.showButtons) {
@@ -120,7 +121,7 @@ class OrganizationAssetRow extends React.Component<OrganizationAssetRowProps, ne
     const dataFields = []
     dataFields.push(<td key="name">{organizationAsset.asset.name}</td>)
     dataFields.push(<td key="status">{organizationAsset.asset.status}</td>)
-    dataFields.push(<td key="created">{new Date(organizationAsset.added).toLocaleString()}</td>)
+    dataFields.push(<td key="created">{formatLocalDateTime(organizationAsset.added)}</td>)
     dataFields.push(<td key="creator">{organizationAsset.added_by}</td>)
 
     if (this.props.showButtons) {

--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../format'
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
@@ -19,7 +20,7 @@ class OrganizationListRow extends React.Component<OrganizationListRowProps, neve
     const { organization } = this.props
     const dataFields = []
     dataFields.push(<td key="name">{organization.name}</td>)
-    dataFields.push(<td key="created">{new Date(organization.created).toLocaleString()}</td>)
+    dataFields.push(<td key="created">{formatLocalDateTime(organization.created)}</td>)
     dataFields.push(<td key="creator">{organization.creator}</td>)
     dataFields.push(<td key="role">{organization.role}</td>)
 

--- a/frontend/search/SearchPopup.tsx
+++ b/frontend/search/SearchPopup.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../format'
 import React from 'react'
 import { SMMSearchObjectDetailsData } from './types'
 import { PopupButtonGroup, ButtonItem } from '../popup'
@@ -23,10 +24,10 @@ export function SearchPopup({ search, missionId, status, onDelete, onQueueDialog
     rows.push({ css: 'inprogress', label: 'Inprogress By', value: search.inprogress_by })
   }
   if (search.inprogress_at) {
-    rows.push({ css: 'inprogress', label: 'Search Started', value: new Date(search.inprogress_at).toLocaleString() })
+    rows.push({ css: 'inprogress', label: 'Search Started', value: formatLocalDateTime(search.inprogress_at) })
   }
   if (search.completed_at) {
-    rows.push({ css: 'completed', label: 'Search Completed', value: new Date(search.completed_at).toLocaleString() })
+    rows.push({ css: 'completed', label: 'Search Completed', value: formatLocalDateTime(search.completed_at) })
   }
 
   const buttons: ButtonItem[] = []

--- a/frontend/search/details.tsx
+++ b/frontend/search/details.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../format'
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 
@@ -44,7 +45,7 @@ class SearchDetails extends SMMObjectDetails {
       tableRows.push(
         <tr key="inprogress_at">
           <td>In Progress Since:</td>
-          <td>{new Date(data.inprogress_at).toLocaleString()}</td>
+          <td>{formatLocalDateTime(data.inprogress_at)}</td>
         </tr>
       )
       tableRows.push(
@@ -59,7 +60,7 @@ class SearchDetails extends SMMObjectDetails {
       tableRows.push(
         <tr key="queued_at">
           <td>Queued:</td>
-          <td>{new Date(data.queued_at).toLocaleString()}</td>
+          <td>{formatLocalDateTime(data.queued_at)}</td>
         </tr>
       )
       if (data.queued_for_asset !== null) {

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -1,3 +1,4 @@
+import { formatLocalDateTime } from '../format'
 import * as ReactDOM from 'react-dom/client'
 
 import L from 'leaflet'
@@ -105,7 +106,7 @@ class SMMSearchesNotStarted extends SMMSearches {
   searchStatus(search: SMMSearchObjectDetailsData) {
     let status = 'Unassigned'
     if (search.queued_at) {
-      const at = new Date(search.queued_at).toLocaleString()
+      const at = formatLocalDateTime(search.queued_at)
       if (search.queued_for_asset) {
         status = `Queued for ${search.queued_for_asset} at ${at}`
       } else {


### PR DESCRIPTION
## Description

23 call sites across 11 files used 'new Date(value).toLocaleString()', several of them guarded by ad-hoc '=== undefined ? "" : ...' expressions and most of them vulnerable to "Invalid Date" output if the backend ever returned a malformed timestamp. Introduce frontend/format.ts with a single formatLocalDateTime helper that:

- accepts string | null | undefined and returns '' for falsy input,
- returns '' rather than 'Invalid Date' when parsing fails,
- delegates the visible formatting to toLocaleString().

Update every call site (mission list/details/timeline, asset ui, asset status, organisation list/details, search popup/details/map, SMMObjects details) to use the helper, and collapse the redundant undefined guards now that the helper handles them.

## Summary by Sourcery

Centralize frontend date-time formatting via a reusable helper and update all existing UI call sites to use it, avoiding "Invalid Date" output and redundant undefined checks.

Enhancements:
- Introduce a formatLocalDateTime helper that safely parses backend timestamps and returns localized strings or empty output on invalid input.
- Replace scattered new Date(...).toLocaleString() usages across mission, asset, organization, search, and SMMObject UIs with the shared formatter, simplifying null/undefined handling.