### PR TITLE
Drop Bootstrap 4 input-group-prepend wrappers

### DIFF
--- a/frontend/Admin/AssetCommandDialog.tsx
+++ b/frontend/Admin/AssetCommandDialog.tsx
@@ -2,13 +2,14 @@ import { useEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 
 import { smmGetJSON, smmPost } from '../ajax'
+import { LatLngMarkerInput } from '../LatLngMarkerInput'
+import { FormInputGroup } from '../components/FormInputGroup'
 
 interface CommandFormData {
   assets: { id: number; name: string }[]
   commands: { value: string; label: string }[]
   requires_position: string[]
 }
-import { LatLngMarkerInput } from '../LatLngMarkerInput'
 
 interface Props {
   map: L.Map
@@ -68,10 +69,7 @@ export function AssetCommandDialog({ map, missionId, onClose }: Props) {
 
   return (
     <div>
-      <div className="input-group input-group-sm mb-3">
-        <div className="input-group-prepend">
-          <span className="input-group-text">Asset</span>
-        </div>
+      <FormInputGroup label="Asset">
         <select className="form-control" value={assetId} onChange={(e) => setAssetId(e.target.value)}>
           {assets.map((a) => (
             <option key={a.id} value={a.id}>
@@ -79,11 +77,8 @@ export function AssetCommandDialog({ map, missionId, onClose }: Props) {
             </option>
           ))}
         </select>
-      </div>
-      <div className="input-group input-group-sm mb-3">
-        <div className="input-group-prepend">
-          <span className="input-group-text">Command</span>
-        </div>
+      </FormInputGroup>
+      <FormInputGroup label="Command">
         <select className="form-control" value={command} onChange={(e) => setCommand(e.target.value)}>
           {commands.map((c) => (
             <option key={c.value} value={c.value}>
@@ -91,13 +86,10 @@ export function AssetCommandDialog({ map, missionId, onClose }: Props) {
             </option>
           ))}
         </select>
-      </div>
-      <div className="input-group input-group-sm mb-3">
-        <div className="input-group-prepend">
-          <span className="input-group-text">Reason</span>
-        </div>
+      </FormInputGroup>
+      <FormInputGroup label="Reason">
         <input type="text" className="form-control" value={reason} onChange={(e) => setReason(e.target.value)} />
-      </div>
+      </FormInputGroup>
       {requiresPosition.includes(command) && (
         <LatLngMarkerInput
           map={map}

--- a/frontend/components/FormInputGroup.tsx
+++ b/frontend/components/FormInputGroup.tsx
@@ -8,9 +8,7 @@ interface Props {
 export function FormInputGroup({ label, children }: Props) {
   return (
     <div className="input-group input-group-sm mb-3">
-      <div className="input-group-prepend">
-        <span className="input-group-text">{label}</span>
-      </div>
+      <span className="input-group-text">{label}</span>
       {children}
     </div>
   )

--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { MissionAssetData } from '../asset/types'
 import { smmGetJSON, smmPost } from '../ajax'
+import { FormInputGroup } from '../components/FormInputGroup'
 
 interface Props {
   searchPk: number
@@ -32,20 +33,14 @@ export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: 
 
   return (
     <div>
-      <div className="input-group input-group-sm mb-3">
-        <div className="input-group-prepend">
-          <span className="input-group-text">Queue for</span>
-        </div>
+      <FormInputGroup label="Queue for">
         <select className="form-control" value={selectType} onChange={(e) => setSelectType(e.target.value as 'type' | 'asset')}>
           <option value="type">Asset Type</option>
           <option value="asset">Specific Asset</option>
         </select>
-      </div>
+      </FormInputGroup>
       {selectType === 'asset' && (
-        <div className="input-group input-group-sm mb-3">
-          <div className="input-group-prepend">
-            <span className="input-group-text">Asset</span>
-          </div>
+        <FormInputGroup label="Asset">
           <select className="form-control" value={selectedAssetId} onChange={(e) => setSelectedAssetId(e.target.value)}>
             {assets.map((a) => (
               <option key={a.id} value={a.id}>
@@ -53,7 +48,7 @@ export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: 
               </option>
             ))}
           </select>
-        </div>
+        </FormInputGroup>
       )}
       <div className="btn-group">
         <button className="btn btn-light" onClick={handleQueue}>


### PR DESCRIPTION
## Description

Bootstrap 5 removed the input-group-prepend/append wrapper divs; input-group-text now sits directly inside input-group. Six occurrences remained:

- frontend/components/FormInputGroup unwraps to a plain span.
- frontend/Admin/AssetCommandDialog (three call sites) and frontend/search/SearchQueueDialog (two call sites) replace inline input-group HTML with the existing FormInputGroup component, matching the rest of the codebase.

## Summary by Sourcery

Replace remaining Bootstrap 4-style input group markup with the shared FormInputGroup component and align it with Bootstrap 5 structure.

Bug Fixes:
- Align input group markup with Bootstrap 5 by removing deprecated input-group-prepend wrappers.

Enhancements:
- Refactor asset command dialog fields to use the shared FormInputGroup component instead of inline input group markup.
- Refactor search queue dialog fields to use the shared FormInputGroup component for consistent styling and structure.
- Simplify FormInputGroup to render the label span directly inside the input-group container.