### PR TITLE
Centralize Leaflet default marker icons in leaflet-setup.ts

### DIFF
--- a/frontend/geomap.tsx
+++ b/frontend/geomap.tsx
@@ -1,12 +1,9 @@
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
-import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import React from 'react'
 
-import markerIcon from 'leaflet/dist/images/marker-icon.png'
-import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
-import markerIconShadow from 'leaflet/dist/images/marker-shadow.png'
+import './leaflet-setup'
 import { MapContainer, Polyline, Polygon, Marker, TileLayer } from 'react-leaflet'
 
 import { mapCoordinates, coordinateToLatLng } from './geometry/details'
@@ -21,14 +18,6 @@ interface GeoJsonMapProps {
 }
 
 class GeoJsonMap extends React.Component<GeoJsonMapProps, never> {
-  constructor(props: GeoJsonMapProps) {
-    super(props)
-
-    L.Icon.Default.prototype.options.iconUrl = markerIcon
-    L.Icon.Default.prototype.options.iconRetinaUrl = markerIcon2x
-    L.Icon.Default.prototype.options.shadowUrl = markerIconShadow
-  }
-
   render() {
     const geometry = this.props.geometry
     let firstPoint = { lat: 0, lng: 0 }

--- a/frontend/leaflet-setup.ts
+++ b/frontend/leaflet-setup.ts
@@ -1,0 +1,13 @@
+/**
+ * Side-effect module that wires Leaflet's default marker icons to the
+ * assets bundled by esbuild. Import once at the top of any entrypoint
+ * that uses Leaflet markers (map.tsx, geomap.tsx, ...).
+ */
+import L from 'leaflet'
+import markerIcon from 'leaflet/dist/images/marker-icon.png'
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
+import markerIconShadow from 'leaflet/dist/images/marker-shadow.png'
+
+L.Icon.Default.prototype.options.iconUrl = markerIcon
+L.Icon.Default.prototype.options.iconRetinaUrl = markerIcon2x
+L.Icon.Default.prototype.options.shadowUrl = markerIconShadow

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -5,9 +5,7 @@ import * as ReactDOM from 'react-dom/client'
 
 import L, { LatLng } from 'leaflet'
 import 'leaflet/dist/leaflet.css'
-import markerIcon from 'leaflet/dist/images/marker-icon.png'
-import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
-import markerIconShadow from 'leaflet/dist/images/marker-shadow.png'
+import './leaflet-setup'
 
 import 'leaflet-realtime'
 import '@canterbury-air-patrol/leaflet-dialog'
@@ -107,10 +105,6 @@ class SMMMap {
   }
 
   setupMap() {
-    L.Icon.Default.prototype.options.iconUrl = markerIcon
-    L.Icon.Default.prototype.options.iconRetinaUrl = markerIcon2x
-    L.Icon.Default.prototype.options.shadowUrl = markerIconShadow
-
     smmGetJSON<Parameters<typeof this.mapLayersCallback>[0]>('/map/tile/layers/', {}).then(this.mapLayersCallback)
 
     this.layerControl.addTo(this.map)


### PR DESCRIPTION
## Description

Both map.tsx and geomap.tsx separately imported the three marker PNGs and mutated L.Icon.Default.prototype.options to point at them. geomap even did the mutation from a class constructor, so every new <GeoJsonMap> instance rewrote the global prototype.

Extract a side-effect module frontend/leaflet-setup.ts that runs the icon-default wiring exactly once on first import, and replace both sites with a single 'import "./leaflet-setup"'. New Leaflet entrypoints now opt in with one import instead of copy-pasting six lines.

## Summary by Sourcery

Centralize Leaflet default marker icon configuration into a shared setup module and update map components to rely on it instead of configuring icons per-instance.

Enhancements:
- Introduce a dedicated leaflet-setup side-effect module to initialize Leaflet default marker icons once at import time.
- Remove per-component Leaflet marker icon configuration from geomap and map implementations to avoid repeated global prototype mutations.