### PR TITLE
Centralise per-page Bootstrap imports in page-shell.ts

### DIFF
--- a/frontend/asset/list.tsx
+++ b/frontend/asset/list.tsx
@@ -1,5 +1,4 @@
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
+import '../page-shell'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/asset/type_list.tsx
+++ b/frontend/asset/type_list.tsx
@@ -1,5 +1,4 @@
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
+import '../page-shell'
 import { Table } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -1,6 +1,5 @@
+import '../page-shell'
 import { formatLocalDateTime } from '../format'
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/geomap.tsx
+++ b/frontend/geomap.tsx
@@ -1,5 +1,4 @@
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
+import './page-shell'
 import 'leaflet/dist/leaflet.css'
 import React from 'react'
 

--- a/frontend/icons/list.tsx
+++ b/frontend/icons/list.tsx
@@ -1,5 +1,4 @@
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
+import '../page-shell'
 import { Table } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -1,5 +1,4 @@
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
+import './page-shell'
 
 import * as ReactDOM from 'react-dom/client'
 

--- a/frontend/marinesac.tsx
+++ b/frontend/marinesac.tsx
@@ -1,5 +1,4 @@
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
+import './page-shell'
 import * as ReactDOM from 'react-dom/client'
 
 import { MarineSACTable } from '@canterbury-air-patrol/marine-search-area-coverage'

--- a/frontend/marinevectors.tsx
+++ b/frontend/marinevectors.tsx
@@ -1,5 +1,4 @@
-import 'bootstrap/dist/css/bootstrap.css'
-import 'bootstrap/dist/js/bootstrap.bundle'
+import './page-shell'
 
 import * as ReactDOM from 'react-dom/client'
 

--- a/frontend/menu/topbar.tsx
+++ b/frontend/menu/topbar.tsx
@@ -1,8 +1,6 @@
+import '../page-shell'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
-
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
 
 import { Nav, Navbar, NavbarBrand } from 'react-bootstrap'
 

--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -1,6 +1,5 @@
+import '../../page-shell'
 import { formatLocalDateTime } from '../../format'
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -1,6 +1,5 @@
+import '../page-shell'
 import { formatLocalDateTime } from '../format'
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/mission/list.tsx
+++ b/frontend/mission/list.tsx
@@ -1,6 +1,5 @@
+import '../page-shell'
 import { formatLocalDateTime } from '../format'
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -1,6 +1,5 @@
+import '../page-shell'
 import { formatLocalDateTime } from '../format'
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -1,6 +1,5 @@
+import '../page-shell'
 import { formatLocalDateTime } from '../format'
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -1,6 +1,5 @@
+import '../page-shell'
 import { formatLocalDateTime } from '../format'
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/organization/radio-operator.tsx
+++ b/frontend/organization/radio-operator.tsx
@@ -1,5 +1,4 @@
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
+import '../page-shell'
 import { Table } from 'react-bootstrap'
 
 import React from 'react'

--- a/frontend/page-shell.ts
+++ b/frontend/page-shell.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared side-effect imports every browser entrypoint pulls in. Keeps
+ * the same set of imports in lockstep across every page-shell bundle
+ * so new entries don't have to know which of bootstrap, bootstrap CSS
+ * etc. they need to load.
+ */
+import 'bootstrap/dist/js/bootstrap.bundle'
+import 'bootstrap/dist/css/bootstrap.css'

--- a/frontend/pretty.tsx
+++ b/frontend/pretty.tsx
@@ -1,2 +1,0 @@
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'

--- a/frontend/search/details.tsx
+++ b/frontend/search/details.tsx
@@ -1,6 +1,5 @@
+import '../page-shell'
 import { formatLocalDateTime } from '../format'
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
 
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'

--- a/frontend/usergeo/details.tsx
+++ b/frontend/usergeo/details.tsx
@@ -1,5 +1,4 @@
-import 'bootstrap'
-import 'bootstrap/dist/css/bootstrap.css'
+import '../page-shell'
 
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'


### PR DESCRIPTION
## Description

19 entrypoints repeated 'import "bootstrap"' + 'import "bootstrap/dist/css/bootstrap.css"' verbatim, and marinevectors additionally pulled in the bundle for Popper-backed UI. Introduce frontend/page-shell.ts that pulls in bootstrap.bundle (Popper included) and the Bootstrap CSS once, and switch every entrypoint to a single 'import "./page-shell"' (paths adjusted for depth).

## Summary by Sourcery

Centralize Bootstrap initialization into a shared frontend page shell and update all React entrypoints to use it.

Enhancements:
- Introduce a shared frontend/page-shell module that imports the Bootstrap bundle and CSS once for all pages.
- Simplify React entrypoints by replacing per-file Bootstrap imports with a single page-shell import to ensure consistent UI initialization.