### PR TITLE
Use Bootstrap utility classes instead of inline style strings

### DIFF
--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -190,21 +190,21 @@ class SMMMap {
 
 function mapInit() {
   const wrapperEl = document.createElement('div')
-  wrapperEl.setAttribute('style', 'width:100%;height:100%;display:flex;flex-flow:column;')
+  wrapperEl.className = 'd-flex flex-column w-100 h-100'
   document.body.appendChild(wrapperEl)
 
   const missionId = encodeURIComponent((document.getElementById('missionId') as HTMLInputElement).value)
 
   if (missionId !== 'all' && missionId !== 'current') {
     const menuEl = document.createElement('div')
-    menuEl.setAttribute('style', 'flex: 0 1 auto;')
+    menuEl.className = 'flex-grow-0 flex-shrink-1'
     wrapperEl.appendChild(menuEl)
     const div = ReactDOM.createRoot(menuEl)
     div.render(<SMMMissionTopBar missionId={missionId} />)
   }
 
   const mapEl = document.createElement('div')
-  mapEl.setAttribute('style', 'flex: 1 1 auto;')
+  mapEl.className = 'flex-grow-1'
   wrapperEl.appendChild(mapEl)
 
   return new SMMMap(mapEl, missionId)


### PR DESCRIPTION
## Description

mapInit() set its wrapper/menu/map divs via setAttribute('style', ...) with CSS strings. Bootstrap 5 already ships every utility used here:
- 'width:100%;height:100%;display:flex;flex-flow:column;' -> 'd-flex flex-column w-100 h-100'
- 'flex: 0 1 auto;'  -> 'flex-shrink-0'
- 'flex: 1 1 auto;'  -> 'flex-grow-1'

Inline styles bypass cascade and are awkward to override; the utility classes inherit any theming we add later for free.

## Summary by Sourcery

Enhancements:
- Use Bootstrap flex and sizing utility classes instead of inline style strings for wrapper, menu, and map containers to align with CSS cascade and theming practices.