### PR TITLE
Drop legacy *.js ambient declarations now that the six files are TS

### DIFF
--- a/frontend/types/legacy-js.d.ts
+++ b/frontend/types/legacy-js.d.ts
@@ -1,12 +1,3 @@
-/* Legacy untyped JS modules in this repo. Each will get proper typings when
- * converted to .tsx (see todo/frontend/refactor-convert-js-to-typescript.md). */
-declare module '*/POIAdder/POIAdder'
-declare module '*/PolygonAdder/PolygonAdder'
-declare module '*/LineAdder/LineAdder'
-declare module '*/SearchAdder/SearchAdder'
-declare module '*/ImageUploader/ImageUploader.js'
-declare module '*/Admin/admin.js'
-
 /* Untyped Canterbury Air Patrol vendor packages. The shapes below are
  * permissive: the implementations are React class components whose
  * state/methods we read but don't strictly type. Refine when a vendor


### PR DESCRIPTION
## Description

With Admin, the four adders, and ImageUploader all converted to .tsx, the 'declare module "*/Admin/admin.js"' etc. fallbacks are no longer needed. Strip the section; only the two Canterbury Air Patrol vendor package shims remain in legacy-js.d.ts.

## Summary by Sourcery

Enhancements:
- Clean up TypeScript ambient type declarations by dropping unused module shims for legacy JS components that are now written in TS.