### PR TITLE
Introduce MissionId discriminated union with type guard

### DIFF
--- a/frontend/Admin/AssetCommandDialog.tsx
+++ b/frontend/Admin/AssetCommandDialog.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import { useEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 
@@ -13,7 +14,7 @@ interface CommandFormData {
 
 interface Props {
   map: L.Map
-  missionId: number | string
+  missionId: MissionId
   onClose: () => void
 }
 

--- a/frontend/Admin/admin.tsx
+++ b/frontend/Admin/admin.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 import * as ReactDOM from 'react-dom/client'
 
@@ -5,10 +6,10 @@ import { AdminMenuDialog } from './AdminMenuDialog'
 import { AssetCommandDialog } from './AssetCommandDialog'
 
 interface SMMAdminOptions extends L.ControlOptions {
-  missionId: number | string
+  missionId: MissionId
 }
 
-function openAssetCommand(map: L.Map, missionId: number | string) {
+function openAssetCommand(map: L.Map, missionId: MissionId) {
   const container = document.createElement('div')
   const dialog = L.control.dialog({ initOpen: true }).setContent(container).addTo(map).hideClose()
   const root = ReactDOM.createRoot(container)

--- a/frontend/ImageUploader/ImageUploader.tsx
+++ b/frontend/ImageUploader/ImageUploader.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import * as ReactDOM from 'react-dom/client'
 import L from 'leaflet'
 
@@ -5,10 +6,10 @@ import { ImageUploaderDialog } from './ImageUploaderDialog'
 import { createIconControl } from '../components/iconControl'
 
 interface ImageUploaderControlOptions {
-  missionId: number | string
+  missionId: MissionId
 }
 
-function openUploader(map: L.Map, missionId: number | string) {
+function openUploader(map: L.Map, missionId: MissionId) {
   const container = document.createElement('div')
   const dialog = L.control.dialog({ initOpen: true }).setContent(container).addTo(map).hideClose()
   const root = ReactDOM.createRoot(container)

--- a/frontend/ImageUploader/ImageUploaderDialog.tsx
+++ b/frontend/ImageUploader/ImageUploaderDialog.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import { useRef } from 'react'
 import L from 'leaflet'
 
@@ -6,7 +7,7 @@ import { smmPostBody } from '../ajax'
 
 interface Props {
   map: L.Map
-  missionId: number | string
+  missionId: MissionId
   onClose: () => void
 }
 

--- a/frontend/LineAdder/LineAdder.tsx
+++ b/frontend/LineAdder/LineAdder.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 
 import { VectorAdderDialog } from '../components/VectorAdderDialog'
@@ -5,10 +6,10 @@ import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 import { createIconControl } from '../components/iconControl'
 
 interface LineAdderControlOptions {
-  missionId: number | string
+  missionId: MissionId
 }
 
-function LineAdder(map: L.Map, missionId: number | string, currentPoints: L.LatLng[], replaces: number, label: string) {
+function LineAdder(map: L.Map, missionId: MissionId, currentPoints: L.LatLng[], replaces: number, label: string) {
   renderInLeafletDialog(map, (onClose) => (
     <VectorAdderDialog type="line" map={map} missionId={missionId} initialPoints={currentPoints} replaces={replaces} initialLabel={label} onClose={onClose} />
   ))

--- a/frontend/POIAdder/POIAdder.tsx
+++ b/frontend/POIAdder/POIAdder.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 import markerIcon from 'leaflet/dist/images/marker-icon.png'
 
@@ -6,10 +7,10 @@ import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 import { createIconControl } from '../components/iconControl'
 
 interface POIAdderControlOptions {
-  missionId: number | string
+  missionId: MissionId
 }
 
-function POIAdder(map: L.Map, missionId: number | string, pos: L.LatLng, replaces: number, label: string) {
+function POIAdder(map: L.Map, missionId: MissionId, pos: L.LatLng, replaces: number, label: string) {
   renderInLeafletDialog(map, (onClose) => <POIAdderDialog map={map} missionId={missionId} initialPos={pos} replaces={replaces} initialLabel={label} onClose={onClose} />, {
     initOpen: true
   })

--- a/frontend/POIAdder/POIAdderDialog.tsx
+++ b/frontend/POIAdder/POIAdderDialog.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import { useRef, useState } from 'react'
 import L from 'leaflet'
 
@@ -8,7 +9,7 @@ import { DialogActions } from '../components/DialogActions'
 
 interface Props {
   map: L.Map
-  missionId: number | string
+  missionId: MissionId
   initialPos: L.LatLng
   replaces: number
   initialLabel: string

--- a/frontend/PolygonAdder/PolygonAdder.tsx
+++ b/frontend/PolygonAdder/PolygonAdder.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 
 import { VectorAdderDialog } from '../components/VectorAdderDialog'
@@ -5,10 +6,10 @@ import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 import { createIconControl } from '../components/iconControl'
 
 interface PolygonAdderControlOptions {
-  missionId: number | string
+  missionId: MissionId
 }
 
-function PolygonAdder(map: L.Map, missionId: number | string, currentPoints: L.LatLng[], replaces: number, label: string) {
+function PolygonAdder(map: L.Map, missionId: MissionId, currentPoints: L.LatLng[], replaces: number, label: string) {
   renderInLeafletDialog(map, (onClose) => (
     <VectorAdderDialog type="polygon" map={map} missionId={missionId} initialPoints={currentPoints} replaces={replaces} initialLabel={label} onClose={onClose} />
   ))

--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 
 import { SMMRealtime } from '../smmmap'
@@ -41,7 +42,7 @@ class AssetColorPicker extends React.Component<AssetColorPickerProps, AssetColor
 
 class SMMAsset {
   map: L.Map
-  missionId: number | string
+  missionId: MissionId
   assetId: number
   assetName: string
   color: string
@@ -50,7 +51,7 @@ class SMMAsset {
   path: Array<L.LatLng>
   updating: boolean
   polyline: L.Polyline
-  constructor(map: L.Map, missionId: number | string, assetId: number, assetName: string, color: string) {
+  constructor(map: L.Map, missionId: MissionId, assetId: number, assetName: string, color: string) {
     this.missionId = missionId
     this.assetId = assetId
     this.assetName = assetName
@@ -144,7 +145,7 @@ class SMMAssets extends SMMRealtime {
   assetIconMap: { [key: number]: string }
   assetStatusMap: { [key: number]: { status: string; notes: string } }
   popupRoots: { [key: number]: ReactDOM.Root }
-  constructor(map: L.Map, missionId: number | string, interval: number, color: string, overlayAdd: (name: string, overlay: L.Layer) => void) {
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string, overlayAdd: (name: string, overlay: L.Layer) => void) {
     super(map, missionId, interval, color)
     this.overlayAdd = overlayAdd
     this.assetObjects = {}

--- a/frontend/components/VectorAdderDialog.tsx
+++ b/frontend/components/VectorAdderDialog.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import { useEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 
@@ -12,7 +13,7 @@ const resourceMap = { line: 'userlines', polygon: 'userpolygons' } as const
 interface Props {
   map: L.Map
   type: 'line' | 'polygon'
-  missionId: number | string
+  missionId: MissionId
   initialPoints: L.LatLng[]
   replaces: number
   initialLabel: string

--- a/frontend/image/ImagePopup.tsx
+++ b/frontend/image/ImagePopup.tsx
@@ -1,3 +1,4 @@
+import { MissionId, isSpecificMission } from '../mission/MissionId'
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { PopupDataList, PopupButtonGroup } from '../popup'
 
@@ -6,7 +7,7 @@ interface Props {
   pk: number
   coords: [number, number]
   priority: boolean
-  missionId: number | string
+  missionId: MissionId
   onPrioritize: () => void
   onDeprioritize: () => void
 }
@@ -17,10 +18,9 @@ export function ImagePopup({ description, pk, coords, priority, missionId, onPri
     { label: 'Lat', value: degreesToDM(coords[1], 'lat') },
     { label: 'Long', value: degreesToDM(coords[0], 'lon') }
   ]
-  const buttons =
-    missionId !== 'current' && missionId !== 'all'
-      ? [priority ? { label: 'Deprioritize', btnClass: 'btn-light', onclick: onDeprioritize } : { label: 'Prioritize', btnClass: 'btn-light', onclick: onPrioritize }]
-      : []
+  const buttons = isSpecificMission(missionId)
+    ? [priority ? { label: 'Deprioritize', btnClass: 'btn-light', onclick: onDeprioritize } : { label: 'Prioritize', btnClass: 'btn-light', onclick: onPrioritize }]
+    : []
   return (
     <div>
       <PopupDataList items={items} dlClass="row" />

--- a/frontend/image/map.tsx
+++ b/frontend/image/map.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 import * as ReactDOM from 'react-dom/client'
 
@@ -7,7 +8,7 @@ import { smmPatch } from '../ajax'
 import { ImagePopup } from './ImagePopup'
 
 abstract class SMMImage extends SMMRealtime {
-  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string) {
     super(map, missionId, interval, color)
 
     this.createPopup = this.createPopup.bind(this)
@@ -59,7 +60,7 @@ abstract class SMMImage extends SMMRealtime {
 }
 
 class SMMImageAll extends SMMImage {
-  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string) {
     super(map, missionId, interval, color)
     this.getUrl = this.getUrl.bind(this)
   }
@@ -70,7 +71,7 @@ class SMMImageAll extends SMMImage {
 }
 
 class SMMImageImportant extends SMMImage {
-  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string) {
     super(map, missionId, interval, color)
     this.getUrl = this.getUrl.bind(this)
   }

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -1,3 +1,4 @@
+import { MissionId, isSpecificMission } from './mission/MissionId'
 import './page-shell'
 
 import * as ReactDOM from 'react-dom/client'
@@ -36,7 +37,7 @@ class SMMMap {
   layerControlMaps: L.Control.Layers
   layerControlAssets: L.Control.Layers
   layerControlUsers: L.Control.Layers
-  missionId: number | string
+  missionId: MissionId
   assets?: SMMAssets
   users?: SMMUserPositions
   POIs?: SMMPOIs
@@ -49,7 +50,7 @@ class SMMMap {
   importantImages?: SMMImageImportant
   marineVectors?: SMMMarineVector
 
-  constructor(mapElem: string | HTMLElement, missionId: number | string) {
+  constructor(mapElem: string | HTMLElement, missionId: MissionId) {
     this.map = L.map(mapElem)
     this.layerControl = L.control.layers({}, {})
     this.layerControlMaps = L.control.layers({}, {})
@@ -118,7 +119,7 @@ class SMMMap {
 
     this.map.locate({ setView: true, maxZoom: 16 })
 
-    if (this.missionId !== 'current' && this.missionId !== 'all') {
+    if (isSpecificMission(this.missionId)) {
       poiadder({ missionId: this.missionId }).addTo(this.map)
       polygonadder({ missionId: this.missionId }).addTo(this.map)
       lineadder({ missionId: this.missionId }).addTo(this.map)
@@ -188,14 +189,21 @@ class SMMMap {
   }
 }
 
+function parseMissionId(raw: string): MissionId {
+  if (raw === 'current' || raw === 'all') return raw
+  const n = Number(raw)
+  if (Number.isFinite(n)) return n
+  throw new Error(`Invalid missionId: ${raw}`)
+}
+
 function mapInit() {
   const wrapperEl = document.createElement('div')
   wrapperEl.className = 'd-flex flex-column w-100 h-100'
   document.body.appendChild(wrapperEl)
 
-  const missionId = encodeURIComponent((document.getElementById('missionId') as HTMLInputElement).value)
+  const missionId = parseMissionId((document.getElementById('missionId') as HTMLInputElement).value)
 
-  if (missionId !== 'all' && missionId !== 'current') {
+  if (isSpecificMission(missionId)) {
     const menuEl = document.createElement('div')
     menuEl.className = 'flex-grow-0 flex-shrink-1'
     wrapperEl.appendChild(menuEl)

--- a/frontend/marine/MarineVectorPopup.tsx
+++ b/frontend/marine/MarineVectorPopup.tsx
@@ -1,15 +1,16 @@
+import { MissionId, isSpecificMission } from '../mission/MissionId'
 import { PopupDataList, PopupButtonGroup, ButtonItem } from '../popup'
 
 interface Props {
   pk: number
-  missionId: number | string
+  missionId: MissionId
   onDelete: () => void
 }
 
 export function MarineVectorPopup({ pk, missionId, onDelete }: Props) {
   const items = [{ label: 'Total Drift Vector', value: String(pk) }]
   const buttons: ButtonItem[] = []
-  if (missionId !== 'current' && missionId !== 'all') {
+  if (isSpecificMission(missionId)) {
     buttons.push({ label: 'Delete', btnClass: 'btn-danger', onclick: onDelete })
   }
   return (

--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import * as ReactDOM from 'react-dom/client'
 import L from 'leaflet'
 
@@ -7,7 +8,7 @@ import { smmGetJSON, smmPost } from '../ajax'
 
 interface CustomMarineVectorsProps {
   map: L.Map
-  missionId: number | string
+  missionId: MissionId
   posName: string
   pos: L.LatLng
   poiId: number
@@ -132,7 +133,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   }
 }
 
-const MarineVectorsLeaflet = function (map: L.Map, missionId: number | string, posName: string, pos: L.LatLng, poiId: number) {
+const MarineVectorsLeaflet = function (map: L.Map, missionId: MissionId, posName: string, pos: L.LatLng, poiId: number) {
   const container = document.createElement('div')
   const dialog = L.control.dialog({ initOpen: true, size: [1000, 500] })
   ReactDOM.createRoot(container).render(<CustomMarineVectors map={map} missionId={missionId} posName={posName} pos={pos} poiId={Number(poiId)} dialog={dialog} />)

--- a/frontend/marine/vectors.tsx
+++ b/frontend/marine/vectors.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 import * as ReactDOM from 'react-dom/client'
 
@@ -7,7 +8,7 @@ import { smmDelete } from '../ajax'
 import { MarineVectorPopup } from './MarineVectorPopup'
 
 class SMMMarineVector extends SMMRealtime {
-  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string) {
     super(map, missionId, interval, color)
 
     this.createPopup = this.createPopup.bind(this)

--- a/frontend/menu/topbar.tsx
+++ b/frontend/menu/topbar.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import '../page-shell'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
@@ -23,7 +24,7 @@ class SMMTopBar extends React.Component<object, never> {
 }
 
 interface SMMMissionTopBarProps {
-  missionId: number | string
+  missionId: MissionId
 }
 
 class SMMMissionTopBar extends React.Component<SMMMissionTopBarProps, never> {

--- a/frontend/mission/MissionId.ts
+++ b/frontend/mission/MissionId.ts
@@ -1,0 +1,16 @@
+/**
+ * Mission identifier as it flows through the frontend. Either a numeric
+ * mission id from the backend or one of two sentinel strings the map
+ * entrypoint exposes for the cross-mission views.
+ */
+export type MissionId = number | 'current' | 'all'
+
+/**
+ * Narrow MissionId to a real numeric id. Useful in guards around
+ * features that require a specific mission (search creation, image
+ * upload, marine vectors, etc.) - they should not run when the user is
+ * looking at the aggregate "current" / "all" views.
+ */
+export function isSpecificMission(id: MissionId): id is number {
+  return typeof id === 'number'
+}

--- a/frontend/search/SearchPopup.tsx
+++ b/frontend/search/SearchPopup.tsx
@@ -1,3 +1,4 @@
+import { MissionId, isSpecificMission } from '../mission/MissionId'
 import { formatLocalDateTime } from '../format'
 import React from 'react'
 import { SMMSearchObjectDetailsData } from './types'
@@ -5,7 +6,7 @@ import { PopupButtonGroup, ButtonItem } from '../popup'
 
 interface Props {
   search: SMMSearchObjectDetailsData
-  missionId: number | string
+  missionId: MissionId
   status: string
   onDelete: () => void
   onQueueDialog: () => void
@@ -31,7 +32,7 @@ export function SearchPopup({ search, missionId, status, onDelete, onQueueDialog
   }
 
   const buttons: ButtonItem[] = []
-  if (missionId !== 'current' && missionId !== 'all') {
+  if (isSpecificMission(missionId)) {
     if (!search.inprogress_at) {
       buttons.push({ label: 'Delete', btnClass: 'btn-danger', onclick: onDelete })
     }

--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import { useEffect, useState } from 'react'
 
 import { MissionAssetData } from '../asset/types'
@@ -6,7 +7,7 @@ import { FormInputGroup } from '../components/FormInputGroup'
 
 interface Props {
   searchPk: number
-  missionId: number | string
+  missionId: MissionId
   createdFor: string
   onClose: () => void
 }

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import { formatLocalDateTime } from '../format'
 import * as ReactDOM from 'react-dom/client'
 
@@ -76,7 +77,7 @@ class SMMSearch {
 
 abstract class SMMSearches extends SMMRealtime {
   searchObjects: { [key: number]: SMMSearch }
-  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string) {
     super(map, missionId, interval, color)
 
     this.searchObjects = {}

--- a/frontend/smmmap.tsx
+++ b/frontend/smmmap.tsx
@@ -1,13 +1,14 @@
+import { MissionId } from './mission/MissionId'
 import L from 'leaflet'
 import 'leaflet-realtime'
 
 abstract class SMMRealtime {
   map: L.Map
-  missionId: number | string
+  missionId: MissionId
   interval: number
   color: string
 
-  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string) {
     this.map = map
     this.missionId = missionId
     this.interval = interval

--- a/frontend/types/leaflet-smm-controls.d.ts
+++ b/frontend/types/leaflet-smm-controls.d.ts
@@ -1,15 +1,14 @@
 /* Ambient types for the bespoke Leaflet controls registered in
- * frontend/Admin/admin.js and frontend/ImageUploader/ImageUploader.js.
- * Both will get real typings when those files are converted to TS
- * (see todo/frontend/refactor-convert-js-to-typescript.md). */
+ * frontend/Admin/admin.tsx and frontend/ImageUploader/ImageUploader.tsx. */
 import 'leaflet'
+import type { MissionId } from '../mission/MissionId'
 
 declare module 'leaflet' {
   interface SMMAdminOptions extends ControlOptions {
-    missionId: number | string
+    missionId: MissionId
   }
   interface ImageUploaderOptions extends ControlOptions {
-    missionId: number | string
+    missionId: MissionId
   }
 
   namespace control {

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 
 import { SMMRealtime } from '../smmmap'
@@ -10,7 +11,7 @@ import { ColorPickerDialog } from '../asset/ColorPickerDialog'
 
 class SMMUserPosition {
   map: L.Map
-  missionId: number | string
+  missionId: MissionId
   userName: string
   color: string
   colorDialog?: L.Control.Dialog
@@ -19,7 +20,7 @@ class SMMUserPosition {
   path: L.LatLng[]
   updating: boolean
   polyline: L.Polyline
-  constructor(map: L.Map, missionId: number | string, userName: string, color: string) {
+  constructor(map: L.Map, missionId: MissionId, userName: string, color: string) {
     this.missionId = missionId
     this.userName = userName
     this.color = color
@@ -106,7 +107,7 @@ class SMMUserPosition {
 class SMMUserPositions extends SMMRealtime {
   userObjects: { [key: string]: SMMUserPosition }
   overlayAdd: (name: string, overlay: L.Layer) => void
-  constructor(map: L.Map, missionId: number | string, interval: number, color: string, overlayAdd: (name: string, overlay: L.Layer) => void) {
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string, overlayAdd: (name: string, overlay: L.Layer) => void) {
     super(map, missionId, interval, color)
     this.overlayAdd = overlayAdd
     this.userObjects = {}

--- a/frontend/usergeo/LinePopup.tsx
+++ b/frontend/usergeo/LinePopup.tsx
@@ -1,9 +1,10 @@
+import { MissionId, isSpecificMission } from '../mission/MissionId'
 import { PopupDataList, PopupButtonGroup, ButtonItem } from '../popup'
 
 interface Props {
   label: string
   pk: number
-  missionId: number | string
+  missionId: MissionId
   onEdit: () => void
   onDelete: () => void
   onCreateSearch: () => void
@@ -11,15 +12,14 @@ interface Props {
 
 export function LinePopup({ label, pk, missionId, onEdit, onDelete, onCreateSearch }: Props) {
   const items = [{ label: 'Line', value: label }]
-  const buttons: ButtonItem[] =
-    missionId !== 'current' && missionId !== 'all'
-      ? [
-          { label: 'Edit', btnClass: 'btn-light', onclick: onEdit },
-          { label: 'Delete', btnClass: 'btn-danger', onclick: onDelete },
-          { label: 'Create Search', btnClass: 'btn-light', onclick: onCreateSearch },
-          { label: 'Details', btnClass: 'btn-light', href: `/data/usergeo/${pk}/` }
-        ]
-      : []
+  const buttons: ButtonItem[] = isSpecificMission(missionId)
+    ? [
+        { label: 'Edit', btnClass: 'btn-light', onclick: onEdit },
+        { label: 'Delete', btnClass: 'btn-danger', onclick: onDelete },
+        { label: 'Create Search', btnClass: 'btn-light', onclick: onCreateSearch },
+        { label: 'Details', btnClass: 'btn-light', href: `/data/usergeo/${pk}/` }
+      ]
+    : []
   return (
     <div>
       <PopupDataList items={items} dlClass="line row" />

--- a/frontend/usergeo/POIPopup.tsx
+++ b/frontend/usergeo/POIPopup.tsx
@@ -1,3 +1,4 @@
+import { MissionId, isSpecificMission } from '../mission/MissionId'
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import { PopupDataList, PopupButtonGroup, ButtonItem } from '../popup'
 
@@ -5,7 +6,7 @@ interface Props {
   label: string
   coords: [number, number]
   pk: number
-  missionId: number | string
+  missionId: MissionId
   onEdit: () => void
   onDelete: () => void
   onCreateSearch: () => void
@@ -18,16 +19,15 @@ export function POIPopup({ label, coords, pk, missionId, onEdit, onDelete, onCre
     { label: 'Lat', value: degreesToDM(coords[1], 'lat') },
     { label: 'Long', value: degreesToDM(coords[0], 'lon') }
   ]
-  const buttons: ButtonItem[] =
-    missionId !== 'current' && missionId !== 'all'
-      ? [
-          { label: 'Move', btnClass: 'btn-light', onclick: onEdit },
-          { label: 'Delete', btnClass: 'btn-danger', onclick: onDelete },
-          { label: 'Create Search', btnClass: 'btn-light', onclick: onCreateSearch },
-          { label: 'Calculate TDV', btnClass: 'btn-light', onclick: onCalculateTDV },
-          { label: 'Details', btnClass: 'btn-light', href: `/data/usergeo/${pk}/` }
-        ]
-      : []
+  const buttons: ButtonItem[] = isSpecificMission(missionId)
+    ? [
+        { label: 'Move', btnClass: 'btn-light', onclick: onEdit },
+        { label: 'Delete', btnClass: 'btn-danger', onclick: onDelete },
+        { label: 'Create Search', btnClass: 'btn-light', onclick: onCreateSearch },
+        { label: 'Calculate TDV', btnClass: 'btn-light', onclick: onCalculateTDV },
+        { label: 'Details', btnClass: 'btn-light', href: `/data/usergeo/${pk}/` }
+      ]
+    : []
   return (
     <div>
       <PopupDataList items={items} dlClass="poi row" />

--- a/frontend/usergeo/PolygonPopup.tsx
+++ b/frontend/usergeo/PolygonPopup.tsx
@@ -1,9 +1,10 @@
+import { MissionId, isSpecificMission } from '../mission/MissionId'
 import { PopupDataList, PopupButtonGroup, ButtonItem } from '../popup'
 
 interface Props {
   label: string
   pk: number
-  missionId: number | string
+  missionId: MissionId
   onEdit: () => void
   onDelete: () => void
   onCreateSearch: () => void
@@ -11,15 +12,14 @@ interface Props {
 
 export function PolygonPopup({ label, pk, missionId, onEdit, onDelete, onCreateSearch }: Props) {
   const items = [{ label: 'Polygon', value: label }]
-  const buttons: ButtonItem[] =
-    missionId !== 'current' && missionId !== 'all'
-      ? [
-          { label: 'Edit', btnClass: 'btn-light', onclick: onEdit },
-          { label: 'Delete', btnClass: 'btn-danger', onclick: onDelete },
-          { label: 'Create Search', btnClass: 'btn-light', onclick: onCreateSearch },
-          { label: 'Details', btnClass: 'btn-light', href: `/data/usergeo/${pk}/` }
-        ]
-      : []
+  const buttons: ButtonItem[] = isSpecificMission(missionId)
+    ? [
+        { label: 'Edit', btnClass: 'btn-light', onclick: onEdit },
+        { label: 'Delete', btnClass: 'btn-danger', onclick: onDelete },
+        { label: 'Create Search', btnClass: 'btn-light', onclick: onCreateSearch },
+        { label: 'Details', btnClass: 'btn-light', href: `/data/usergeo/${pk}/` }
+      ]
+    : []
   return (
     <div>
       <PopupDataList items={items} dlClass="polygon row" />

--- a/frontend/usergeo/base.tsx
+++ b/frontend/usergeo/base.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 import React from 'react'
 import * as ReactDOM from 'react-dom/client'
@@ -12,11 +13,11 @@ import { SMMUserGeoLabelData } from './types'
  */
 abstract class SMMUserGeoLayer {
   map: L.Map
-  missionId: number | string
+  missionId: MissionId
   data: SMMUserGeoLabelData
   popupRoot?: ReactDOM.Root
 
-  constructor(map: L.Map, missionId: number | string, data: SMMUserGeoLabelData) {
+  constructor(map: L.Map, missionId: MissionId, data: SMMUserGeoLabelData) {
     this.map = map
     this.missionId = missionId
     this.data = data
@@ -60,7 +61,7 @@ abstract class SMMUserGeoLayer {
 abstract class SMMUserGeoCollection<TGeoJSON extends { properties: SMMUserGeoLabelData }, TLayer extends SMMUserGeoLayer> extends SMMRealtime {
   objects: { [key: number]: TLayer }
 
-  constructor(map: L.Map, missionId: number | string, interval: number, color: string) {
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string) {
     super(map, missionId, interval, color)
     this.objects = {}
     this.createPopup = this.createPopup.bind(this)

--- a/frontend/usergeo/line.tsx
+++ b/frontend/usergeo/line.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 
 import { LineAdder } from '../LineAdder/LineAdder'
@@ -9,7 +10,7 @@ import { SMMUserGeoLayer, SMMUserGeoCollection } from './base'
 class SMMLine extends SMMUserGeoLayer {
   coords: [number, number][]
 
-  constructor(map: L.Map, missionId: number | string, line: SMMUserGeoLineGeoJSON) {
+  constructor(map: L.Map, missionId: MissionId, line: SMMUserGeoLineGeoJSON) {
     super(map, missionId, line.properties)
     this.coords = line.geometry.coordinates
   }

--- a/frontend/usergeo/poi.tsx
+++ b/frontend/usergeo/poi.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 
 import { MarineVectorsLeaflet } from '../marine/leaflet'
@@ -10,7 +11,7 @@ import { SMMUserGeoLayer, SMMUserGeoCollection } from './base'
 class SMMPOI extends SMMUserGeoLayer {
   coords: [number, number]
 
-  constructor(map: L.Map, missionId: number | string, poi: SMMUserGeoPOIGeoJSON) {
+  constructor(map: L.Map, missionId: MissionId, poi: SMMUserGeoPOIGeoJSON) {
     super(map, missionId, poi.properties)
     this.coords = poi.geometry.coordinates
     this.calculateTDVCallback = this.calculateTDVCallback.bind(this)

--- a/frontend/usergeo/polygon.tsx
+++ b/frontend/usergeo/polygon.tsx
@@ -1,3 +1,4 @@
+import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 
 import { PolygonAdder } from '../PolygonAdder/PolygonAdder'
@@ -9,7 +10,7 @@ import { SMMUserGeoLayer, SMMUserGeoCollection } from './base'
 class SMMPolygon extends SMMUserGeoLayer {
   coords: [number, number][][]
 
-  constructor(map: L.Map, missionId: number | string, polygon: SMMUserGeoPolygonGeoJSON) {
+  constructor(map: L.Map, missionId: MissionId, polygon: SMMUserGeoPolygonGeoJSON) {
     super(map, missionId, polygon.properties)
     this.coords = polygon.geometry.coordinates
   }


### PR DESCRIPTION
## Description

Replace the ad-hoc 'missionId: number | string' that flowed through 29 files with 'type MissionId = number | "current" | "all"'. Add an isSpecificMission(id): id is number type guard so the popup/control checks that previously wrote out the two sentinel strings inline ('missionId !== "current" && missionId !== "all"') now narrow through the guard. map.tsx parses the hidden input value via parseMissionId which converts numeric strings to numbers at the boundary; an unrecognised value throws so the failure is loud.

Updates leaflet-smm-controls.d.ts to consume MissionId for SMMAdminOptions / ImageUploaderOptions.

## Summary by Sourcery

Introduce a strongly-typed MissionId discriminated union and type guard and apply it across map-related front-end components.

Enhancements:
- Replace ad-hoc number|string missionId usage with a MissionId union type shared across front-end map, popup, and realtime classes.
- Add isSpecificMission type guard and use it to gate mission-specific controls and actions instead of inline string comparisons.
- Parse missionId inputs at the map entrypoint via a dedicated parser that normalizes numeric strings and rejects invalid values.
- Update Leaflet control typings and various dialog/control props to consume MissionId for improved type safety.