### PR TITLE
Use a discriminated GeometryJSON union across geomap/search/usergeo

### DIFF
--- a/frontend/geomap.tsx
+++ b/frontend/geomap.tsx
@@ -5,43 +5,36 @@ import React from 'react'
 import './leaflet-setup'
 import { MapContainer, Polyline, Polygon, Marker, TileLayer } from 'react-leaflet'
 
-import { mapCoordinates, coordinateToLatLng } from './geometry/details'
+import { mapCoordinates, coordinateToLatLng, GeometryJSON } from './geometry/details'
 
 import './geomap.css'
 
 interface GeoJsonMapProps {
-  geometry: {
-    type: string
-    coordinates: [number, number] | [number, number][] | [number, number][][]
-  }
+  geometry: GeometryJSON
 }
 
 class GeoJsonMap extends React.Component<GeoJsonMapProps, never> {
   render() {
-    const geometry = this.props.geometry
+    const { geometry } = this.props
     let firstPoint = { lat: 0, lng: 0 }
     const objects = []
 
     switch (geometry.type) {
-      case 'LineString':
-        {
-          const coordinates = mapCoordinates(geometry.coordinates as [number, number][])
-          firstPoint = coordinates[0]
-          objects.push(<Polyline key="linestring" positions={coordinates} />)
-        }
+      case 'LineString': {
+        const coordinates = mapCoordinates(geometry.coordinates)
+        firstPoint = coordinates[0]
+        objects.push(<Polyline key="linestring" positions={coordinates} />)
         break
-      case 'Polygon':
-        {
-          const coordinates = mapCoordinates((geometry.coordinates as [number, number][][])[0])
-          firstPoint = coordinates[0]
-          objects.push(<Polygon key="polygon" positions={coordinates} />)
-        }
+      }
+      case 'Polygon': {
+        const coordinates = mapCoordinates(geometry.coordinates[0])
+        firstPoint = coordinates[0]
+        objects.push(<Polygon key="polygon" positions={coordinates} />)
         break
+      }
       case 'Point':
-        firstPoint = coordinateToLatLng(geometry.coordinates as [number, number])
+        firstPoint = coordinateToLatLng(geometry.coordinates)
         objects.push(<Marker key="point" position={firstPoint} />)
-        break
-      default:
         break
     }
 

--- a/frontend/geometry/details.tsx
+++ b/frontend/geometry/details.tsx
@@ -10,6 +10,13 @@ interface Point {
   alt?: number
 }
 
+/** A GeoJSON-style geometry tagged by its `type` field. Lets TypeScript
+ *  narrow `coordinates` automatically instead of probing array depth. */
+export type GeometryJSON =
+  | { type: 'Point'; coordinates: [number, number] }
+  | { type: 'LineString'; coordinates: [number, number][] }
+  | { type: 'Polygon'; coordinates: [number, number][][] }
+
 function coordinateToLatLng(point: number[]): Point {
   return {
     lat: point[1],
@@ -22,22 +29,24 @@ function mapCoordinates(points: number[][]): Point[] {
 }
 
 interface GeometryPointsProps {
-  points: [number, number] | [number, number][] | [number, number][][]
+  geometry: GeometryJSON
 }
 
 class GeometryPoints extends React.Component<GeometryPointsProps, never> {
-  pointsFromProps() {
-    if (!Array.isArray(this.props.points[0])) {
-      return [coordinateToLatLng(this.props.points as [number, number])]
-    } else if (Array.isArray(this.props.points[0][0])) {
-      return mapCoordinates((this.props.points as [number, number][][])[0])
-    } else {
-      return mapCoordinates(this.props.points as [number, number][])
+  pointsFromGeometry(): Point[] {
+    const { geometry } = this.props
+    switch (geometry.type) {
+      case 'Point':
+        return [coordinateToLatLng(geometry.coordinates)]
+      case 'LineString':
+        return mapCoordinates(geometry.coordinates)
+      case 'Polygon':
+        return mapCoordinates(geometry.coordinates[0])
     }
   }
 
   render() {
-    const points = this.pointsFromProps()
+    const points = this.pointsFromGeometry()
 
     const tableRows = points.map((point, index) => (
       <tr key={index}>

--- a/frontend/search/details.tsx
+++ b/frontend/search/details.tsx
@@ -9,7 +9,7 @@ import { Button } from 'react-bootstrap'
 import { smmGetJSON } from '../ajax'
 
 import { SMMObjectDetails } from '../SMMObjects/details'
-import { GeometryPoints } from '../geometry/details'
+import { GeometryPoints, GeometryJSON } from '../geometry/details'
 import { GeoJsonMap } from '../geomap'
 import { ExpandingBoxSearch, SearchPattern, SectorSearch } from '@canterbury-air-patrol/sar-search-patterns'
 import { SearchRunner } from '@canterbury-air-patrol/sar-search-runner'
@@ -127,10 +127,7 @@ interface SearchDetailsPageProps {
 interface SearchDetailsPageState {
   data?: SMMSearchObjectDetailsData
   search?: SearchPattern
-  geometry?: {
-    type: string
-    coordinates: [number, number] | [number, number][] | [number, number][][]
-  }
+  geometry?: GeometryJSON
 }
 
 class SearchDetailsPage extends React.Component<SearchDetailsPageProps, SearchDetailsPageState> {
@@ -159,10 +156,7 @@ class SearchDetailsPage extends React.Component<SearchDetailsPageProps, SearchDe
   updateDataResponse(data: {
     features: {
       properties: SMMSearchObjectDetailsData
-      geometry: {
-        type: string
-        coordinates: [number, number] | [number, number][] | [number, number][][]
-      }
+      geometry: GeometryJSON
     }[]
   }) {
     const search = createSearch(data.features['0'].properties)
@@ -189,10 +183,10 @@ class SearchDetailsPage extends React.Component<SearchDetailsPageProps, SearchDe
         </Collapsible>
       )
     }
-    if (this.state.geometry && this.state.geometry.coordinates) {
+    if (this.state.geometry) {
       parts.push(
         <Collapsible key="points" trigger="Coordinates">
-          <GeometryPoints points={this.state.geometry.coordinates} />
+          <GeometryPoints geometry={this.state.geometry} />
         </Collapsible>
       )
       parts.push(<GeoJsonMap key="map" geometry={this.state.geometry} />)

--- a/frontend/usergeo/details.tsx
+++ b/frontend/usergeo/details.tsx
@@ -6,7 +6,7 @@ import * as ReactDOM from 'react-dom/client'
 import { smmGetJSON } from '../ajax'
 
 import { SMMObjectDetails } from '../SMMObjects/details'
-import { GeometryPoints } from '../geometry/details'
+import { GeometryPoints, GeometryJSON } from '../geometry/details'
 import { GeoJsonMap } from '../geomap'
 
 interface SMMUserGeoObjectData {
@@ -32,10 +32,7 @@ interface UserGeoDetailsPageProps {
 
 interface UserGeoDetailsPageState {
   data?: SMMUserGeoObjectData
-  geometry?: {
-    type: string
-    coordinates: [number, number] | [number, number][] | [number, number][][]
-  }
+  geometry?: GeometryJSON
 }
 
 class UserGeoDetailsPage extends React.Component<UserGeoDetailsPageProps, UserGeoDetailsPageState> {
@@ -63,7 +60,7 @@ class UserGeoDetailsPage extends React.Component<UserGeoDetailsPageProps, UserGe
     type GeoResponse = {
       features: {
         properties: SMMUserGeoObjectData
-        geometry: { type: string; coordinates: [number, number] | [number, number][] | [number, number][][] }
+        geometry: GeometryJSON
       }[]
     }
     const data = await smmGetJSON<GeoResponse>(`/data/usergeo/${this.props.userGeoId}/`, {})
@@ -78,8 +75,8 @@ class UserGeoDetailsPage extends React.Component<UserGeoDetailsPageProps, UserGe
     if (this.state.data) {
       parts.push(<UserGeoDetails key="details" data={this.state.data} />)
     }
-    if (this.state.geometry && this.state.geometry.coordinates) {
-      parts.push(<GeometryPoints key="points" points={this.state.geometry.coordinates} />)
+    if (this.state.geometry) {
+      parts.push(<GeometryPoints key="points" geometry={this.state.geometry} />)
       parts.push(<GeoJsonMap key="map" geometry={this.state.geometry} />)
     }
     return <div>{parts}</div>


### PR DESCRIPTION
## Description

Three places (geomap.tsx, search/details.tsx, usergeo/details.tsx) declared the same loose shape:
  { type: string; coordinates: [n,n] | [n,n][] | [n,n][][] }
and then probed array depth to pick which branch to render. Replace with a single shared union:
  type GeometryJSON =
    | { type: 'Point';      coordinates: [n,n] }
    | { type: 'LineString'; coordinates: [n,n][] }
    | { type: 'Polygon';    coordinates: [n,n][][] }

TypeScript narrows the coordinate shape in each switch arm, so the 'as [number, number]' / 'as [number, number][][]' casts in geomap and the array-depth probing in GeometryPoints disappear. GeometryPoints takes the whole geometry now instead of just the coordinates, so the caller doesn't have to forward an already-typed value through an untyped slot.

## Summary by Sourcery

Unify geometry handling across the frontend by introducing a shared discriminated GeometryJSON type and wiring it through geomap, search details, and usergeo details views.

New Features:
- Introduce a shared GeometryJSON discriminated union type for Point, LineString, and Polygon geometries.

Enhancements:
- Refactor GeoJsonMap and GeometryPoints to consume GeometryJSON directly, removing manual coordinate shape probing and casts.
- Update search and usergeo details pages to store and pass GeometryJSON objects consistently to geometry-related components.