### PR TITLE
Reuse renderInLeafletDialog for the swatch colour picker

### DIFF
--- a/frontend/asset/ColorPickerDialog.tsx
+++ b/frontend/asset/ColorPickerDialog.tsx
@@ -1,4 +1,4 @@
-import { AssetColorPicker } from './map'
+import { CompactPicker, ColorResult } from 'react-color'
 
 interface Props {
   name: string
@@ -11,7 +11,7 @@ export function ColorPickerDialog({ name, color, onColorChange, onClose }: Props
   return (
     <div>
       <div>Color Picker for {name}</div>
-      <AssetColorPicker color={color} updateColor={onColorChange} />
+      <CompactPicker color={color} onChangeComplete={(c: ColorResult) => onColorChange(c.hex)} />
       <button className="btn btn-primary" onClick={onClose}>
         Done
       </button>

--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -3,42 +3,14 @@ import L from 'leaflet'
 
 import { SMMRealtime } from '../smmmap'
 import '@canterbury-air-patrol/leaflet-dialog'
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
-import { ColorResult, CompactPicker } from 'react-color'
 import { cookieJar } from '../cookies'
 import { MissionAssetData, AssetPointTime } from './types'
 
 import { smmGetJSON } from '../ajax'
 import { AssetPopup } from './AssetPopup'
 import { ColorPickerDialog } from './ColorPickerDialog'
-
-interface AssetColorPickerProps {
-  color: string
-  updateColor: (color: string) => void
-}
-
-interface AssetColorPickerState {
-  color: string
-}
-
-class AssetColorPicker extends React.Component<AssetColorPickerProps, AssetColorPickerState> {
-  constructor(props: AssetColorPickerProps) {
-    super(props)
-    this.state = {
-      color: this.props.color
-    }
-  }
-
-  updateColor = (color: ColorResult) => {
-    this.props.updateColor(color.hex)
-    this.setState({ color: color.hex })
-  }
-
-  render() {
-    return <CompactPicker color={this.state.color} onChangeComplete={this.updateColor} />
-  }
-}
+import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 
 class SMMAsset {
   map: L.Map
@@ -46,7 +18,6 @@ class SMMAsset {
   assetId: number
   assetName: string
   color: string
-  colorDialog?: L.Control.Dialog
   lastUpdate?: string
   path: Array<L.LatLng>
   updating: boolean
@@ -56,7 +27,6 @@ class SMMAsset {
     this.assetId = assetId
     this.assetName = assetName
     this.color = color
-    this.colorDialog = undefined
     this.lastUpdate = undefined
     this.path = []
     this.updating = false
@@ -64,7 +34,6 @@ class SMMAsset {
     this.polyline = L.polyline([], { color: this.color })
     this.updateColor = this.updateColor.bind(this)
     this.colorPicker = this.colorPicker.bind(this)
-    this.closeColorPicker = this.closeColorPicker.bind(this)
     this.updateNewRoute = this.updateNewRoute.bind(this)
     this.updateFailed = this.updateFailed.bind(this)
   }
@@ -81,30 +50,10 @@ class SMMAsset {
     })
   }
 
-  closeColorPicker() {
-    this.colorDialog?.destroy()
-    this.colorDialog = undefined
-  }
-
   colorPicker() {
-    if (!this.colorDialog) {
-      const container = document.createElement('div')
-      this.colorDialog = L.control.dialog({ initOpen: true }).setContent(container).addTo(this.map).hideClose()
-      const root = ReactDOM.createRoot(container)
-      root.render(
-        <ColorPickerDialog
-          name={this.assetName}
-          color={this.color}
-          onColorChange={this.updateColor}
-          onClose={() => {
-            root.unmount()
-            this.closeColorPicker()
-          }}
-        />
-      )
-    } else {
-      this.colorDialog.show()
-    }
+    renderInLeafletDialog(this.map, (onClose) => <ColorPickerDialog name={this.assetName} color={this.color} onColorChange={this.updateColor} onClose={onClose} />, {
+      initOpen: true
+    })
   }
 
   updateNewRoute(route: { features: Array<{ geometry: { coordinates: Array<number> }; properties: AssetPointTime }> }) {
@@ -306,4 +255,4 @@ class SMMAssets extends SMMRealtime {
   }
 }
 
-export { SMMAssets, AssetColorPicker }
+export { SMMAssets }

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -8,13 +8,13 @@ import { smmGetJSON } from '../ajax'
 import { SMMMissionUserPointTimeGeoJSON } from './types'
 import { UserPopup } from './UserPopup'
 import { ColorPickerDialog } from '../asset/ColorPickerDialog'
+import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 
 class SMMUserPosition {
   map: L.Map
   missionId: MissionId
   userName: string
   color: string
-  colorDialog?: L.Control.Dialog
   popupRoot?: ReactDOM.Root
   lastUpdate?: string
   path: L.LatLng[]
@@ -30,7 +30,6 @@ class SMMUserPosition {
     this.polyline = L.polyline([], { color: this.color })
     this.updateColor = this.updateColor.bind(this)
     this.colorPicker = this.colorPicker.bind(this)
-    this.closeColorPicker = this.closeColorPicker.bind(this)
     this.updateNewPosition = this.updateNewPosition.bind(this)
     this.updateError = this.updateError.bind(this)
   }
@@ -47,30 +46,10 @@ class SMMUserPosition {
     })
   }
 
-  closeColorPicker() {
-    this.colorDialog?.destroy()
-    this.colorDialog = undefined
-  }
-
   colorPicker() {
-    if (!this.colorDialog) {
-      const container = document.createElement('div')
-      this.colorDialog = L.control.dialog({ initOpen: true }).setContent(container).addTo(this.map).hideClose()
-      const root = ReactDOM.createRoot(container)
-      root.render(
-        <ColorPickerDialog
-          name={this.userName}
-          color={this.color}
-          onColorChange={this.updateColor}
-          onClose={() => {
-            root.unmount()
-            this.closeColorPicker()
-          }}
-        />
-      )
-    } else {
-      this.colorDialog.show()
-    }
+    renderInLeafletDialog(this.map, (onClose) => <ColorPickerDialog name={this.userName} color={this.color} onColorChange={this.updateColor} onClose={onClose} />, {
+      initOpen: true
+    })
   }
 
   updateNewPosition(route: { features: Array<SMMMissionUserPointTimeGeoJSON> }) {


### PR DESCRIPTION
## Description

SMMAsset and SMMUserPosition each carried a colorDialog field, a closeColorPicker helper, and a bespoke if/else that re-used or re-created an L.control.dialog wrapping ReactDOM.createRoot. Same pattern lives in components/renderInLeafletDialog.tsx, which adders already use. Route both colorPicker() implementations through the helper so the dialog/root lifecycle stays in one place.

Also drop the local AssetColorPicker wrapper class - it only forwarded CompactPicker behind unnecessary local state. Inline CompactPicker directly into ColorPickerDialog and rely on the parent's color prop as the source of truth. asset/map.tsx no longer needs to export the defunct wrapper.

## Summary by Sourcery

Refactor asset and user color picker dialogs to reuse the shared Leaflet dialog helper and simplify the color picker implementation.

Enhancements:
- Route SMMAsset and SMMUserPosition color pickers through the shared renderInLeafletDialog helper to centralize Leaflet dialog lifecycle management.
- Inline react-color’s CompactPicker directly into ColorPickerDialog and remove the AssetColorPicker wrapper and related exports for a simpler, single-source-of-truth color flow.