### PR TITLE
Widen PopupDataList DataItem.value to ReactNode

### DIFF
--- a/frontend/popup.tsx
+++ b/frontend/popup.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from 'react'
+
 interface DataItem {
   label: string
-  value: string
+  value: ReactNode
 }
 
 interface ButtonItem {


### PR DESCRIPTION
## Description

DataItem.value was typed string. Callers that wanted to embed rich content (links, formatted text, multi-line strings) either had to pre-serialise or work around the type. Switch to React.ReactNode, which still accepts plain strings and numbers but additionally accepts elements and fragments. Backwards-compatible with every existing call site.

## Summary by Sourcery

Allow popup data items to render richer content by widening their value type.

New Features:
- Support non-string ReactNode values for popup data items.

Enhancements:
- Update DataItem typing to accept ReactNode values while preserving compatibility with existing string usage.