### PR TITLE
Add usePolling hook

### DIFF
--- a/frontend/hooks/usePolling.ts
+++ b/frontend/hooks/usePolling.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Run `fn` once on mount and then every `intervalMs` until the
+ * component unmounts.
+ *
+ * The callback is captured in a ref so the effect only re-installs the
+ * interval when `intervalMs` changes - callers don't need to wrap `fn`
+ * in useCallback. Polling also pauses while the tab is hidden so a
+ * minimised browser doesn't keep hitting the server.
+ */
+export function usePolling(fn: () => void | Promise<void>, intervalMs: number) {
+  const fnRef = useRef(fn)
+
+  useEffect(() => {
+    fnRef.current = fn
+  }, [fn])
+
+  useEffect(() => {
+    let cancelled = false
+
+    const tick = () => {
+      if (!cancelled) fnRef.current()
+    }
+
+    tick()
+
+    let id = document.visibilityState === 'visible' ? window.setInterval(tick, intervalMs) : 0
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && id === 0) {
+        tick()
+        id = window.setInterval(tick, intervalMs)
+      } else if (document.visibilityState !== 'visible' && id !== 0) {
+        window.clearInterval(id)
+        id = 0
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    return () => {
+      cancelled = true
+      if (id !== 0) window.clearInterval(id)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [intervalMs])
+}


### PR DESCRIPTION
## Description

A dozen page-level class components hand-roll the same triple: componentDidMount setInterval + componentWillUnmount clearInterval + 'timer?: number'. The hook captures that pattern, plus two improvements:

- the polling pauses while the document is hidden, so a minimised browser stops thrashing the server,
- the callback is held in a ref and re-read on each tick, so callers don't need useCallback for stable references.

## Summary by Sourcery

New Features:
- Add a usePolling hook to run a callback immediately and at a fixed interval, pausing when the document is hidden.