### PR TITLE
Convert asset list / asset type list / icon list pages to FCs

### DIFF
--- a/frontend/asset/list.tsx
+++ b/frontend/asset/list.tsx
@@ -1,13 +1,11 @@
 import '../page-shell'
+import { useState } from 'react'
+import * as ReactDOM from 'react-dom/client'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
 
-import React from 'react'
-import * as ReactDOM from 'react-dom/client'
-
 import { smmGetJSON } from '../ajax'
-
 import { SMMTopBar } from '../menu/topbar'
-
+import { usePolling } from '../hooks/usePolling'
 import { AssetData } from './types'
 
 interface AssetListRowProps {
@@ -15,97 +13,61 @@ interface AssetListRowProps {
   showButtons: boolean
 }
 
-class AssetListRow extends React.Component<AssetListRowProps, never> {
-  render() {
-    const { asset } = this.props
-    const dataFields = []
-    dataFields.push(<td key="name">{asset.name}</td>)
-    dataFields.push(<td key="type">{asset.type_name}</td>)
-    dataFields.push(<td key="owner">{asset.owner}</td>)
-    dataFields.push(<td key="status">{asset.status}</td>)
-
-    if (this.props.showButtons) {
-      const buttons = [
-        <Button key="interface" href={`/assets/${asset.id}/`}>
-          Interface
-        </Button>
-      ]
-      dataFields.push(
-        <td key="buttons">
-          <ButtonGroup>{buttons}</ButtonGroup>
-        </td>
-      )
-    }
-    return <tr key={asset.id}>{dataFields}</tr>
-  }
-}
-
-interface AssetListProps {
-  assets: AssetData[]
-}
-
-class AssetList extends React.Component<AssetListProps, never> {
-  render() {
-    const assetRows = this.props.assets.map((asset) => <AssetListRow key={asset.id} showButtons={true} asset={asset} />)
-    return (
-      <Table responsive>
-        <thead>
-          <tr key="heading">
-            <th colSpan={5} align="center">
-              My Assets
-            </th>
-          </tr>
-          <tr key="labels">
-            <th>Asset Name</th>
-            <th>Asset Type</th>
-            <th>Owner</th>
-            <th>Status</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>{assetRows}</tbody>
-      </Table>
+function AssetListRow({ asset, showButtons }: AssetListRowProps) {
+  const dataFields = [<td key="name">{asset.name}</td>, <td key="type">{asset.type_name}</td>, <td key="owner">{asset.owner}</td>, <td key="status">{asset.status}</td>]
+  if (showButtons) {
+    dataFields.push(
+      <td key="buttons">
+        <ButtonGroup>
+          <Button key="interface" href={`/assets/${asset.id}/`}>
+            Interface
+          </Button>
+        </ButtonGroup>
+      </td>
     )
   }
+  return <tr key={asset.id}>{dataFields}</tr>
 }
 
-interface AssetListPageState {
-  knownAssets: AssetData[]
+function AssetList({ assets }: { assets: AssetData[] }) {
+  return (
+    <Table responsive>
+      <thead>
+        <tr key="heading">
+          <th colSpan={5} align="center">
+            My Assets
+          </th>
+        </tr>
+        <tr key="labels">
+          <th>Asset Name</th>
+          <th>Asset Type</th>
+          <th>Owner</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {assets.map((asset) => (
+          <AssetListRow key={asset.id} showButtons={true} asset={asset} />
+        ))}
+      </tbody>
+    </Table>
+  )
 }
 
-class AssetListPage extends React.Component<object, AssetListPageState> {
-  timer?: number
+function AssetListPage() {
+  const [assets, setAssets] = useState<AssetData[]>([])
 
-  constructor(props: object) {
-    super(props)
-
-    this.state = {
-      knownAssets: []
-    }
-  }
-
-  componentDidMount() {
-    this.updateData()
-    this.timer = setInterval(() => this.updateData(), 10000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
-    this.timer = undefined
-  }
-
-  async updateData() {
+  usePolling(async () => {
     const data = await smmGetJSON<{ assets: AssetData[] }>('/assets/', {})
-    this.setState({ knownAssets: data.assets })
-  }
+    setAssets(data.assets)
+  }, 10000)
 
-  render() {
-    return (
-      <div>
-        <AssetList assets={this.state.knownAssets} />
-      </div>
-    )
-  }
+  return (
+    <div>
+      <AssetList assets={assets} />
+    </div>
+  )
 }
 
 function createAssetList(elementId: string) {

--- a/frontend/asset/type_list.tsx
+++ b/frontend/asset/type_list.tsx
@@ -1,91 +1,56 @@
 import '../page-shell'
+import { useState } from 'react'
+import * as ReactDOM from 'react-dom/client'
 import { Table } from 'react-bootstrap'
 
-import React from 'react'
-import * as ReactDOM from 'react-dom/client'
-
 import { smmGetJSON } from '../ajax'
-
 import { SMMTopBar } from '../menu/topbar'
-
+import { usePolling } from '../hooks/usePolling'
 import { AssetTypeData } from './types'
 
-interface AssetTypeListRowProps {
-  assetType: AssetTypeData
+function AssetTypeListRow({ assetType }: { assetType: AssetTypeData }) {
+  return (
+    <tr key={assetType.id}>
+      <td key="type">{assetType.name}</td>
+    </tr>
+  )
 }
 
-class AssetTypeListRow extends React.Component<AssetTypeListRowProps, never> {
-  render() {
-    const { assetType } = this.props
-    const dataFields = []
-    dataFields.push(<td key="type">{assetType.name}</td>)
-
-    return <tr key={assetType.id}>{dataFields}</tr>
-  }
+function AssetTypeList({ assetTypes }: { assetTypes: AssetTypeData[] }) {
+  return (
+    <Table responsive>
+      <thead>
+        <tr key="heading">
+          <th colSpan={5} align="center">
+            Asset Types
+          </th>
+        </tr>
+        <tr key="labels">
+          <th>Asset Type</th>
+        </tr>
+      </thead>
+      <tbody>
+        {assetTypes.map((assetType) => (
+          <AssetTypeListRow key={assetType.id} assetType={assetType} />
+        ))}
+      </tbody>
+    </Table>
+  )
 }
 
-interface AssetTypeListProps {
-  assetTypes: AssetTypeData[]
-}
+function AssetTypeListPage() {
+  const [assetTypes, setAssetTypes] = useState<AssetTypeData[]>([])
 
-class AssetTypeList extends React.Component<AssetTypeListProps, never> {
-  render() {
-    const assetTypeRows = this.props.assetTypes.map((assetType) => <AssetTypeListRow key={assetType.id} assetType={assetType} />)
-    return (
-      <Table responsive>
-        <thead>
-          <tr key="heading">
-            <th colSpan={5} align="center">
-              Asset Types
-            </th>
-          </tr>
-          <tr key="labels">
-            <th>Asset Type</th>
-          </tr>
-        </thead>
-        <tbody>{assetTypeRows}</tbody>
-      </Table>
-    )
-  }
-}
-
-interface AssetTypeListPageState {
-  knownAssetTypes: AssetTypeData[]
-}
-
-class AssetTypeListPage extends React.Component<object, AssetTypeListPageState> {
-  timer?: number
-
-  constructor(props: object) {
-    super(props)
-
-    this.state = {
-      knownAssetTypes: []
-    }
-  }
-
-  componentDidMount() {
-    this.updateData()
-    this.timer = setInterval(() => this.updateData(), 10000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
-    this.timer = undefined
-  }
-
-  async updateData() {
+  usePolling(async () => {
     const data = await smmGetJSON<{ asset_types: AssetTypeData[] }>('/assets/assettypes/', {})
-    this.setState({ knownAssetTypes: data.asset_types })
-  }
+    setAssetTypes(data.asset_types)
+  }, 10000)
 
-  render() {
-    return (
-      <div>
-        <AssetTypeList assetTypes={this.state.knownAssetTypes} />
-      </div>
-    )
-  }
+  return (
+    <div>
+      <AssetTypeList assetTypes={assetTypes} />
+    </div>
+  )
 }
 
 function createAssetTypeList(elementId: string) {

--- a/frontend/icons/list.tsx
+++ b/frontend/icons/list.tsx
@@ -1,12 +1,11 @@
 import '../page-shell'
+import { useState } from 'react'
+import * as ReactDOM from 'react-dom/client'
 import { Table } from 'react-bootstrap'
 
-import React from 'react'
-import * as ReactDOM from 'react-dom/client'
-
 import { smmGetJSON } from '../ajax'
-
 import { SMMTopBar } from '../menu/topbar'
+import { usePolling } from '../hooks/usePolling'
 
 interface IconData {
   id: number
@@ -14,99 +13,53 @@ interface IconData {
   url: string
 }
 
-interface IconListRowProps {
-  icon: IconData
-}
-
-class IconListRow extends React.Component<IconListRowProps, never> {
-  render() {
-    const { icon } = this.props
-    const dataFields = []
-    dataFields.push(<td key="name">{icon.name}</td>)
-    dataFields.push(
+function IconListRow({ icon }: { icon: IconData }) {
+  return (
+    <tr key={icon.id}>
+      <td key="name">{icon.name}</td>
       <td key="img">
         <img src={icon.url} />
       </td>
-    )
-
-    return <tr key={icon.id}>{dataFields}</tr>
-  }
+    </tr>
+  )
 }
 
-interface IconListProps {
-  icons: IconData[]
+function IconList({ icons }: { icons: IconData[] }) {
+  return (
+    <Table responsive>
+      <thead>
+        <tr key="heading">
+          <th colSpan={5} align="center">
+            Icons
+          </th>
+        </tr>
+        <tr key="labels">
+          <th>Name</th>
+          <th>Image</th>
+        </tr>
+      </thead>
+      <tbody>
+        {icons.map((icon) => (
+          <IconListRow key={icon.id} icon={icon} />
+        ))}
+      </tbody>
+    </Table>
+  )
 }
 
-class IconList extends React.Component<IconListProps, never> {
-  render() {
-    const iconRows = this.props.icons.map((icon) => <IconListRow key={icon.id} icon={icon} />)
-    return (
-      <Table responsive>
-        <thead>
-          <tr key="heading">
-            <th colSpan={5} align="center">
-              Icons
-            </th>
-          </tr>
-          <tr key="labels">
-            <th>Name</th>
-            <th>Image</th>
-          </tr>
-        </thead>
-        <tbody>{iconRows}</tbody>
-      </Table>
-    )
-  }
-}
+function IconListPage() {
+  const [icons, setIcons] = useState<IconData[]>([])
 
-interface IconListPageState {
-  knownIcons?: IconData[]
-}
+  usePolling(async () => {
+    const data = await smmGetJSON<{ icons: IconData[] }>('/icons/', {})
+    setIcons(data.icons)
+  }, 10000)
 
-class IconListPage extends React.Component<object, IconListPageState> {
-  timer?: number
-  constructor(props: object) {
-    super(props)
-
-    this.state = {
-      knownIcons: []
-    }
-
-    this.updateIcons = this.updateIcons.bind(this)
-  }
-
-  componentDidMount() {
-    this.updateData()
-    this.timer = setInterval(() => this.updateData(), 10000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
-    this.timer = undefined
-  }
-
-  async updateData() {
-    await smmGetJSON('/icons/', {}, this.updateIcons)
-  }
-
-  updateIcons(data: { icons: IconData[] }) {
-    this.setState(function () {
-      return {
-        knownIcons: data.icons
-      }
-    })
-  }
-
-  render() {
-    if (this.state.knownIcons) {
-      return (
-        <div>
-          <IconList icons={this.state.knownIcons} />
-        </div>
-      )
-    }
-    return <div></div>
-  }
+  return (
+    <div>
+      <IconList icons={icons} />
+    </div>
+  )
 }
 
 function createIconList(elementId: string) {


### PR DESCRIPTION
## Description

Same conversion as mission/list.tsx applied to the three other top-level list pages: every class component becomes a function, the setInterval triple inside each *Page becomes a single usePolling call, and the leftover 'import React' goes away. No behaviour change.

## Summary by Sourcery

Refactor asset, asset type, and icon list pages to use functional React components with hook-based polling instead of class components and manual intervals.

Enhancements:
- Convert asset list page components to functional components using hooks for state and polling.
- Convert asset type list page components to functional components using hooks for state and polling.
- Convert icon list page components to functional components using hooks for state and polling and simplify data fetching API usage.
- Remove unused legacy React imports from list pages.