### PR TITLE
Convert MissionTimeLine and its entry form to function components

### DIFF
--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -1,128 +1,67 @@
 import '../page-shell'
-import { formatLocalDateTime } from '../format'
-import { Table, Button } from 'react-bootstrap'
-
-import React from 'react'
+import { ChangeEvent, useState } from 'react'
 import * as ReactDOM from 'react-dom/client'
-
-import { smmGetJSON, smmPost } from '../ajax'
-
+import { Table, Button } from 'react-bootstrap'
 import DateTimePicker from 'react-datetime-picker'
 import 'react-datetime-picker/dist/DateTimePicker.css'
 
+import { formatLocalDateTime } from '../format'
+import { smmGetJSON, smmPost } from '../ajax'
 import { MissionHeader } from './header'
 import { SMMMissionTopBar } from '../menu/topbar'
+import { usePolling } from '../hooks/usePolling'
 import { MissionData } from './types'
 
 interface MissionTimeLineEntryAddProps {
   missionId: number
 }
 
-interface MissionTimeLineEntryAddState {
-  timeNow: boolean
-  specificDateTime: Date
-  message: string
-  url: string
-}
+function MissionTimeLineEntryAdd({ missionId }: MissionTimeLineEntryAddProps) {
+  const [timeNow, setTimeNow] = useState(true)
+  const [specificDateTime, setSpecificDateTime] = useState<Date>(() => new Date())
+  const [message, setMessage] = useState('')
+  const [url, setUrl] = useState('')
 
-class MissionTimeLineEntryAdd extends React.Component<MissionTimeLineEntryAddProps, MissionTimeLineEntryAddState> {
-  constructor(props: MissionTimeLineEntryAddProps) {
-    super(props)
-
-    this.state = {
-      timeNow: true,
-      specificDateTime: new Date(),
-      message: '',
-      url: ''
-    }
-
-    this.changeNow = this.changeNow.bind(this)
-    this.changeDateTime = this.changeDateTime.bind(this)
-    this.changeMessage = this.changeMessage.bind(this)
-    this.changeUrl = this.changeUrl.bind(this)
-    this.submit = this.submit.bind(this)
-  }
-
-  changeNow(event: React.ChangeEvent<HTMLInputElement>) {
-    const { target } = event
-
-    this.setState({
-      timeNow: target.checked
-    })
-  }
-
-  changeDateTime(value: Date | null) {
-    if (value !== null) {
-      this.setState({
-        specificDateTime: value
-      })
-    }
-  }
-
-  changeMessage(event: React.ChangeEvent<HTMLInputElement>) {
-    const { target } = event
-    this.setState({
-      message: target.value
-    })
-  }
-
-  changeUrl(event: React.ChangeEvent<HTMLInputElement>) {
-    const { target } = event
-    this.setState({
-      url: target.value
-    })
-  }
-
-  submit() {
-    let timestamp = this.state.specificDateTime
-    if (this.state.timeNow) {
-      timestamp = new Date()
-    }
-    smmPost(`/mission/${this.props.missionId}/timeline/`, {
+  function submit() {
+    const timestamp = timeNow ? new Date() : specificDateTime
+    smmPost(`/mission/${missionId}/timeline/`, {
       timestamp: timestamp.toISOString(),
-      message: this.state.message,
-      url: this.state.url
+      message,
+      url
     })
-    this.setState({
-      timeNow: true,
-      specificDateTime: new Date()
-    })
+    setTimeNow(true)
+    setSpecificDateTime(new Date())
   }
 
-  render() {
-    let datePicker = null
-    if (this.state.timeNow === false) {
-      datePicker = <DateTimePicker onChange={this.changeDateTime} value={this.state.specificDateTime} format="y-MM-dd HH:mm:ss" />
-    }
-    return (
-      <Table>
-        <thead>
-          <tr>
-            <td>Date/Time:</td>
-            <td>Entry:</td>
-            <td>URL:</td>
-            <td></td>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              Now: <input type="checkbox" checked={this.state.timeNow} onChange={this.changeNow} /> {datePicker}
-            </td>
-            <td>
-              <input type="text" value={this.state.message} onChange={this.changeMessage} />
-            </td>
-            <td>
-              <input type="text" value={this.state.url} onChange={this.changeUrl} />
-            </td>
-            <td>
-              <Button onClick={this.submit}>Add</Button>
-            </td>
-          </tr>
-        </tbody>
-      </Table>
-    )
-  }
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <td>Date/Time:</td>
+          <td>Entry:</td>
+          <td>URL:</td>
+          <td></td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            Now: <input type="checkbox" checked={timeNow} onChange={(e: ChangeEvent<HTMLInputElement>) => setTimeNow(e.target.checked)} />{' '}
+            {!timeNow && <DateTimePicker onChange={(value) => value !== null && setSpecificDateTime(value)} value={specificDateTime} format="y-MM-dd HH:mm:ss" />}
+          </td>
+          <td>
+            <input type="text" value={message} onChange={(e: ChangeEvent<HTMLInputElement>) => setMessage(e.target.value)} />
+          </td>
+          <td>
+            <input type="text" value={url} onChange={(e: ChangeEvent<HTMLInputElement>) => setUrl(e.target.value)} />
+          </td>
+          <td>
+            <Button onClick={submit}>Add</Button>
+          </td>
+        </tr>
+      </tbody>
+    </Table>
+  )
 }
 
 interface TimeLineEntry {
@@ -134,127 +73,59 @@ interface TimeLineEntry {
   url: string
 }
 
-interface MissionTimelineEntryProps {
-  timelineEntry: TimeLineEntry
-}
-
-class MissionTimelineEntry extends React.Component<MissionTimelineEntryProps, never> {
-  render() {
-    const entry = this.props.timelineEntry
-    return (
-      <tr>
-        <td>{formatLocalDateTime(entry.timestamp)}</td>
-        <td>{entry.creator}</td>
-        <td>{entry.event_type}</td>
-        <td>{entry.message}</td>
-        <td>{entry.url}</td>
-      </tr>
-    )
-  }
+function MissionTimelineEntry({ timelineEntry }: { timelineEntry: TimeLineEntry }) {
+  return (
+    <tr>
+      <td>{formatLocalDateTime(timelineEntry.timestamp)}</td>
+      <td>{timelineEntry.creator}</td>
+      <td>{timelineEntry.event_type}</td>
+      <td>{timelineEntry.message}</td>
+      <td>{timelineEntry.url}</td>
+    </tr>
+  )
 }
 
 interface MissionTimeLineProps {
   missionId: number
 }
 
-interface MissionTimelineState {
-  timelineEntries: TimeLineEntry[]
-  missionData?: MissionData
-  missionClosed: boolean
-}
+export function MissionTimeLine({ missionId }: MissionTimeLineProps) {
+  const [timelineEntries, setTimelineEntries] = useState<TimeLineEntry[]>([])
+  const [missionData, setMissionData] = useState<MissionData | undefined>(undefined)
 
-export class MissionTimeLine extends React.Component<MissionTimeLineProps, MissionTimelineState> {
-  timer?: number
+  usePolling(async () => {
+    const data = await smmGetJSON<{ timeline: TimeLineEntry[]; mission: MissionData }>(`/mission/${missionId}/timeline/`, {})
+    setTimelineEntries(data.timeline)
+    setMissionData(data.mission)
+  }, 10000)
 
-  constructor(props: MissionTimeLineProps) {
-    super(props)
-
-    this.state = {
-      timelineEntries: [],
-      missionData: undefined,
-      missionClosed: false
-    }
-  }
-
-  componentDidMount() {
-    this.updateData()
-    this.timer = setInterval(() => this.updateData(), 10000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
-    this.timer = undefined
-  }
-
-  async updateData() {
-    const data = await smmGetJSON<{ timeline: TimeLineEntry[]; mission: MissionData }>(`/mission/${this.props.missionId}/timeline/`, {})
-    this.updateTimeline(data.timeline)
-    this.updateMission(data.mission)
-    if (!this.state.missionClosed && data.mission.closed !== null) {
-      this.setMissionClosed()
-    }
-  }
-
-  updateTimeline(timelineEntries: TimeLineEntry[]) {
-    this.setState(function () {
-      return {
-        timelineEntries
-      }
-    })
-  }
-
-  updateMission(missionData: MissionData) {
-    this.setState(function () {
-      return {
-        missionData
-      }
-    })
-  }
-
-  setMissionClosed() {
-    this.setState(function () {
-      return {
-        missionClosed: true
-      }
-    })
-  }
-
-  render() {
-    const timelineEntries = this.state.timelineEntries.map((timelineEntry) => <MissionTimelineEntry key={timelineEntry.id} timelineEntry={timelineEntry}></MissionTimelineEntry>)
-
-    let missionData = null
-    let timelineAdd = null
-    if (this.state.missionData !== undefined) {
-      missionData = <MissionHeader key="missionHeader" mission={this.state.missionData} />
-      if (!this.state.missionClosed) {
-        timelineAdd = <MissionTimeLineEntryAdd missionId={this.props.missionId} />
-      }
-    }
-
-    return (
-      <div>
-        {missionData}
-        {timelineAdd}
-        <Table responsive>
-          <thead>
-            <tr>
-              <td key="heading" colSpan={5} align="center">
-                Timeline
-              </td>
-            </tr>
-            <tr key="labels">
-              <td>At</td>
-              <td>User</td>
-              <td>Action</td>
-              <td>Message</td>
-              <td></td>
-            </tr>
-          </thead>
-          <tbody>{timelineEntries}</tbody>
-        </Table>
-      </div>
-    )
-  }
+  return (
+    <div>
+      {missionData && <MissionHeader key="missionHeader" mission={missionData} />}
+      {missionData && !missionData.closed && <MissionTimeLineEntryAdd missionId={missionId} />}
+      <Table responsive>
+        <thead>
+          <tr>
+            <td key="heading" colSpan={5} align="center">
+              Timeline
+            </td>
+          </tr>
+          <tr key="labels">
+            <td>At</td>
+            <td>User</td>
+            <td>Action</td>
+            <td>Message</td>
+            <td></td>
+          </tr>
+        </thead>
+        <tbody>
+          {timelineEntries.map((entry) => (
+            <MissionTimelineEntry key={entry.id} timelineEntry={entry} />
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  )
 }
 
 export function createMissionTimeline(elementId: string, missionId: number) {


### PR DESCRIPTION
## Description

The 'missionClosed' bool that the previous bug-fix corrected becomes redundant once the form's render guard reads missionData.closed directly - drop the extra state field and let useState fall out of the simpler derivation.

MissionTimeLine uses usePolling for the 10s timeline refresh and MissionTimeLineEntryAdd becomes a five-state-hook FC with a single submit() closure.

## Summary by Sourcery

Convert mission timeline components to React function components and simplify mission closing logic.

Enhancements:
- Refactor MissionTimeLineEntryAdd, MissionTimelineEntry, and MissionTimeLine from class-based to function components using React hooks.
- Replace manual interval management with a shared usePolling hook for periodic timeline refresh.
- Simplify mission closed handling by deriving it directly from missionData.closed instead of tracking separate missionClosed state.