### PR TITLE
Convert SMMObjectDetails, SearchDetailsPage, UserGeoDetailsPage to FCs

### DIFF
--- a/frontend/SMMObjects/details.tsx
+++ b/frontend/SMMObjects/details.tsx
@@ -1,7 +1,7 @@
-import { formatLocalDateTime } from '../format'
+import { ReactElement, ReactNode } from 'react'
 import { Table } from 'react-bootstrap'
 
-import React from 'react'
+import { formatLocalDateTime } from '../format'
 
 interface SMMObjectData {
   created_at: string
@@ -12,70 +12,61 @@ interface SMMObjectData {
   replaced_by?: string
 }
 
-interface SMMObjectDetailsProps {
-  data: SMMObjectData
+/** Common row set every SMM object detail page shows above its
+ *  model-specific rows: created/deleted/replaced metadata. */
+function commonRows(data: SMMObjectData): ReactElement[] {
+  const rows: ReactElement[] = [
+    <tr key="created_at">
+      <td>Created:</td>
+      <td>{formatLocalDateTime(data.created_at)}</td>
+    </tr>,
+    <tr key="created_by">
+      <td>Creator:</td>
+      <td>{data.created_by}</td>
+    </tr>
+  ]
+  if (data.deleted_at) {
+    rows.push(
+      <tr key="deleted_at">
+        <td>Deleted:</td>
+        <td>{formatLocalDateTime(data.deleted_at)}</td>
+      </tr>,
+      <tr key="deleted_by">
+        <td>Deleted By:</td>
+        <td>{data.deleted_by}</td>
+      </tr>
+    )
+  }
+  if (data.replaced_at) {
+    rows.push(
+      <tr key="replaced_at">
+        <td>Replaced:</td>
+        <td>{formatLocalDateTime(data.replaced_at)}</td>
+      </tr>,
+      <tr key="replaced_by">
+        <td>Replacement:</td>
+        <td>{data.replaced_by}</td>
+      </tr>
+    )
+  }
+  return rows
 }
 
-class SMMObjectDetails extends React.Component<SMMObjectDetailsProps, never> {
-  renderCreatedDeletedReplaced(tableRows: React.JSX.Element[], data: SMMObjectData) {
-    tableRows.push(
-      <tr key="created_at">
-        <td>Created:</td>
-        <td>{formatLocalDateTime(data.created_at)}</td>
-      </tr>
-    )
-    tableRows.push(
-      <tr key="created_by">
-        <td>Creator:</td>
-        <td>{data.created_by}</td>
-      </tr>
-    )
-    if (data.deleted_at) {
-      tableRows.push(
-        <tr key="deleted_at">
-          <td>Deleted:</td>
-          <td>{formatLocalDateTime(data.deleted_at)}</td>
-        </tr>
-      )
-      tableRows.push(
-        <tr key="deleted_by">
-          <td>Deleted By:</td>
-          <td>{data.deleted_by}</td>
-        </tr>
-      )
-    }
-    if (data.replaced_at) {
-      tableRows.push(
-        <tr key="replaced_at">
-          <td>Replaced:</td>
-          <td>{formatLocalDateTime(data.replaced_at)}</td>
-        </tr>
-      )
-      tableRows.push(
-        <tr key="replaced_by">
-          <td>Replacement:</td>
-          <td>{data.replaced_by}</td>
-        </tr>
-      )
-    }
-  }
+interface SMMObjectDetailsProps {
+  data: SMMObjectData
+  /** Model-specific rows appended after the common metadata. */
+  children?: ReactNode
+}
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  renderModelSpecificData(tableRows: React.JSX.Element[], data: SMMObjectData) {}
-
-  render() {
-    const data = this.props.data
-    const tableRows: React.JSX.Element[] = []
-
-    this.renderCreatedDeletedReplaced(tableRows, data)
-    this.renderModelSpecificData(tableRows, data)
-
-    return (
-      <Table responsive>
-        <tbody>{tableRows}</tbody>
-      </Table>
-    )
-  }
+function SMMObjectDetails({ data, children }: SMMObjectDetailsProps) {
+  return (
+    <Table responsive>
+      <tbody>
+        {commonRows(data)}
+        {children}
+      </tbody>
+    </Table>
+  )
 }
 
 export { SMMObjectDetails, SMMObjectData }

--- a/frontend/search/details.tsx
+++ b/frontend/search/details.tsx
@@ -1,113 +1,101 @@
 import '../page-shell'
-import { formatLocalDateTime } from '../format'
-
-import React from 'react'
+import { ReactElement, useState } from 'react'
 import * as ReactDOM from 'react-dom/client'
 import Collapsible from 'react-collapsible'
 import { Button } from 'react-bootstrap'
 
+import { formatLocalDateTime } from '../format'
 import { smmGetJSON } from '../ajax'
-
 import { SMMObjectDetails } from '../SMMObjects/details'
 import { GeometryPoints, GeometryJSON } from '../geometry/details'
 import { GeoJsonMap } from '../geomap'
 import { ExpandingBoxSearch, SearchPattern, SectorSearch } from '@canterbury-air-patrol/sar-search-patterns'
 import { SearchRunner } from '@canterbury-air-patrol/sar-search-runner'
+import { usePolling } from '../hooks/usePolling'
 import { SMMSearchObjectDetailsData } from './types'
 
-class SearchDetails extends SMMObjectDetails {
-  renderModelSpecificData(tableRows: React.JSX.Element[], data: SMMSearchObjectDetailsData) {
-    tableRows.push(
-      <tr key="search_type">
-        <td>Type:</td>
-        <td>{data.search_type}</td>
+function SearchDetails({ data }: { data: SMMSearchObjectDetailsData }) {
+  const rows: ReactElement[] = [
+    <tr key="search_type">
+      <td>Type:</td>
+      <td>{data.search_type}</td>
+    </tr>,
+    <tr key="created_for">
+      <td>Asset Type:</td>
+      <td>{data.created_for}</td>
+    </tr>,
+    <tr key="datum">
+      <td>Created From:</td>
+      <td>
+        <Button href={`/data/usergeo/${data.datum}/`}>{data.datum}</Button>
+      </td>
+    </tr>
+  ]
+
+  if (data.inprogress_by && data.inprogress_at) {
+    rows.push(
+      <tr key="inprogress_at">
+        <td>In Progress Since:</td>
+        <td>{formatLocalDateTime(data.inprogress_at)}</td>
+      </tr>,
+      <tr key="inprogress_by">
+        <td>In Progress By:</td>
+        <td>{data.inprogress_by}</td>
       </tr>
     )
+  }
 
-    tableRows.push(
-      <tr key="created_for">
-        <td>Asset Type:</td>
-        <td>{data.created_for}</td>
+  if (data.queued_at) {
+    rows.push(
+      <tr key="queued_at">
+        <td>Queued:</td>
+        <td>{formatLocalDateTime(data.queued_at)}</td>
       </tr>
     )
-
-    tableRows.push(
-      <tr key="datum">
-        <td>Created From:</td>
-        <td>
-          <Button href={`/data/usergeo/${data.datum}/`}>{data.datum}</Button>
-        </td>
-      </tr>
-    )
-
-    if (data.inprogress_by && data.inprogress_at) {
-      tableRows.push(
-        <tr key="inprogress_at">
-          <td>In Progress Since:</td>
-          <td>{formatLocalDateTime(data.inprogress_at)}</td>
-        </tr>
-      )
-      tableRows.push(
-        <tr>
-          <td>In Progress By:</td>
-          <td>{data.inprogress_by}</td>
-        </tr>
-      )
-    }
-
-    if (data.queued_at) {
-      tableRows.push(
-        <tr key="queued_at">
-          <td>Queued:</td>
-          <td>{formatLocalDateTime(data.queued_at)}</td>
-        </tr>
-      )
-      if (data.queued_for_asset !== null) {
-        tableRows.push(
-          <tr key="queued_for">
-            <td>Queued For:</td>
-            <td>{data.queued_for_asset}</td>
-          </tr>
-        )
-      }
-    }
-
-    if (data.sweep_width !== null) {
-      tableRows.push(
-        <tr key="sweep_width">
-          <td>Sweep Width:</td>
-          <td>{data.sweep_width}m</td>
-        </tr>
-      )
-    }
-
-    if (data.iterations !== null) {
-      tableRows.push(
-        <tr key="iterations">
-          <td>Iterations:</td>
-          <td>{data.iterations}</td>
-        </tr>
-      )
-    }
-
-    if (data.first_bearing !== null) {
-      tableRows.push(
-        <tr key="first_bearing">
-          <td>First Bearing:</td>
-          <td>{data.first_bearing}</td>
-        </tr>
-      )
-    }
-
-    if (data.width !== null) {
-      tableRows.push(
-        <tr key="width">
-          <td>Width:</td>
-          <td>{data.width}m</td>
+    if (data.queued_for_asset !== null) {
+      rows.push(
+        <tr key="queued_for">
+          <td>Queued For:</td>
+          <td>{data.queued_for_asset}</td>
         </tr>
       )
     }
   }
+
+  if (data.sweep_width !== null) {
+    rows.push(
+      <tr key="sweep_width">
+        <td>Sweep Width:</td>
+        <td>{data.sweep_width}m</td>
+      </tr>
+    )
+  }
+  if (data.iterations !== null) {
+    rows.push(
+      <tr key="iterations">
+        <td>Iterations:</td>
+        <td>{data.iterations}</td>
+      </tr>
+    )
+  }
+  if (data.first_bearing !== null) {
+    rows.push(
+      <tr key="first_bearing">
+        <td>First Bearing:</td>
+        <td>{data.first_bearing}</td>
+      </tr>
+    )
+  }
+  if (data.width !== null) {
+    rows.push(
+      <tr key="width">
+        <td>Width:</td>
+        <td>{data.width}m</td>
+      </tr>
+    )
+  }
+
+  return <SMMObjectDetails data={data}>{rows}</SMMObjectDetails>
 }
 
 function createSearch(data: SMMSearchObjectDetailsData) {
@@ -120,79 +108,40 @@ function createSearch(data: SMMSearchObjectDetailsData) {
   return undefined
 }
 
-interface SearchDetailsPageProps {
-  searchId: number
-}
+function SearchDetailsPage({ searchId }: { searchId: number }) {
+  const [data, setData] = useState<SMMSearchObjectDetailsData | undefined>(undefined)
+  const [search, setSearch] = useState<SearchPattern | undefined>(undefined)
+  const [geometry, setGeometry] = useState<GeometryJSON | undefined>(undefined)
 
-interface SearchDetailsPageState {
-  data?: SMMSearchObjectDetailsData
-  search?: SearchPattern
-  geometry?: GeometryJSON
-}
-
-class SearchDetailsPage extends React.Component<SearchDetailsPageProps, SearchDetailsPageState> {
-  timer?: number
-  constructor(props: SearchDetailsPageProps) {
-    super(props)
-
-    this.state = {
-      data: undefined,
-      search: undefined,
-      geometry: undefined
+  usePolling(async () => {
+    type Response = {
+      features: { properties: SMMSearchObjectDetailsData; geometry: GeometryJSON }[]
     }
-    this.updateDataResponse = this.updateDataResponse.bind(this)
-  }
+    const resp = await smmGetJSON<Response>(`/search/${searchId}/`, {})
+    const feature = resp.features[0]
+    setData(feature.properties)
+    setSearch(createSearch(feature.properties))
+    setGeometry(feature.geometry)
+  }, 10000)
 
-  componentDidMount() {
-    this.updateData()
-    this.timer = setInterval(() => this.updateData(), 10000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
-    this.timer = undefined
-  }
-
-  updateDataResponse(data: {
-    features: {
-      properties: SMMSearchObjectDetailsData
-      geometry: GeometryJSON
-    }[]
-  }) {
-    const search = createSearch(data.features['0'].properties)
-    this.setState({
-      data: data.features['0'].properties,
-      search,
-      geometry: data.features['0'].geometry
-    })
-  }
-
-  async updateData() {
-    await smmGetJSON(`/search/${this.props.searchId}/`, {}, this.updateDataResponse)
-  }
-
-  render() {
-    const parts = []
-    if (this.state.data) {
-      parts.push(<SearchDetails key="details" data={this.state.data} />)
-    }
-    if (this.state.search) {
-      parts.push(
+  return (
+    <div>
+      {data && <SearchDetails key="details" data={data} />}
+      {search && (
         <Collapsible key="runner" trigger="Runner">
-          <SearchRunner search={this.state.search} />
+          <SearchRunner search={search} />
         </Collapsible>
-      )
-    }
-    if (this.state.geometry) {
-      parts.push(
-        <Collapsible key="points" trigger="Coordinates">
-          <GeometryPoints geometry={this.state.geometry} />
-        </Collapsible>
-      )
-      parts.push(<GeoJsonMap key="map" geometry={this.state.geometry} />)
-    }
-    return <div>{parts}</div>
-  }
+      )}
+      {geometry && (
+        <>
+          <Collapsible key="points" trigger="Coordinates">
+            <GeometryPoints geometry={geometry} />
+          </Collapsible>
+          <GeoJsonMap key="map" geometry={geometry} />
+        </>
+      )}
+    </div>
+  )
 }
 
 function createSearchDetailsPage(elementId: string, missionId: number, searchId: number) {

--- a/frontend/usergeo/details.tsx
+++ b/frontend/usergeo/details.tsx
@@ -1,13 +1,12 @@
 import '../page-shell'
-
-import React from 'react'
+import { useState } from 'react'
 import * as ReactDOM from 'react-dom/client'
 
 import { smmGetJSON } from '../ajax'
-
 import { SMMObjectDetails } from '../SMMObjects/details'
 import { GeometryPoints, GeometryJSON } from '../geometry/details'
 import { GeoJsonMap } from '../geomap'
+import { usePolling } from '../hooks/usePolling'
 
 interface SMMUserGeoObjectData {
   label: string
@@ -15,72 +14,45 @@ interface SMMUserGeoObjectData {
   created_by: string
 }
 
-class UserGeoDetails extends SMMObjectDetails {
-  renderModelSpecificData(tableRows: React.JSX.Element[], data: SMMUserGeoObjectData) {
-    tableRows.push(
+function UserGeoDetails({ data }: { data: SMMUserGeoObjectData }) {
+  return (
+    <SMMObjectDetails data={data}>
       <tr key="label">
         <td>Label:</td>
         <td>{data.label}</td>
       </tr>
-    )
-  }
+    </SMMObjectDetails>
+  )
 }
 
 interface UserGeoDetailsPageProps {
   userGeoId: number
 }
 
-interface UserGeoDetailsPageState {
-  data?: SMMUserGeoObjectData
-  geometry?: GeometryJSON
-}
+function UserGeoDetailsPage({ userGeoId }: UserGeoDetailsPageProps) {
+  const [data, setData] = useState<SMMUserGeoObjectData | undefined>(undefined)
+  const [geometry, setGeometry] = useState<GeometryJSON | undefined>(undefined)
 
-class UserGeoDetailsPage extends React.Component<UserGeoDetailsPageProps, UserGeoDetailsPageState> {
-  timer?: number
-  constructor(props: UserGeoDetailsPageProps) {
-    super(props)
-
-    this.state = {
-      data: undefined,
-      geometry: undefined
+  usePolling(async () => {
+    type Response = {
+      features: { properties: SMMUserGeoObjectData; geometry: GeometryJSON }[]
     }
-  }
+    const resp = await smmGetJSON<Response>(`/data/usergeo/${userGeoId}/`, {})
+    setData(resp.features[0].properties)
+    setGeometry(resp.features[0].geometry)
+  }, 10000)
 
-  componentDidMount() {
-    this.updateData()
-    this.timer = setInterval(() => this.updateData(), 10000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
-    this.timer = undefined
-  }
-
-  async updateData() {
-    type GeoResponse = {
-      features: {
-        properties: SMMUserGeoObjectData
-        geometry: GeometryJSON
-      }[]
-    }
-    const data = await smmGetJSON<GeoResponse>(`/data/usergeo/${this.props.userGeoId}/`, {})
-    this.setState({
-      data: data.features[0].properties,
-      geometry: data.features[0].geometry
-    })
-  }
-
-  render() {
-    const parts = []
-    if (this.state.data) {
-      parts.push(<UserGeoDetails key="details" data={this.state.data} />)
-    }
-    if (this.state.geometry) {
-      parts.push(<GeometryPoints key="points" geometry={this.state.geometry} />)
-      parts.push(<GeoJsonMap key="map" geometry={this.state.geometry} />)
-    }
-    return <div>{parts}</div>
-  }
+  return (
+    <div>
+      {data && <UserGeoDetails key="details" data={data} />}
+      {geometry && (
+        <>
+          <GeometryPoints key="points" geometry={geometry} />
+          <GeoJsonMap key="map" geometry={geometry} />
+        </>
+      )}
+    </div>
+  )
 }
 
 function createUserGeoDetailsPage(elementId: string, missionId: number, userGeoId: number) {


### PR DESCRIPTION
## Description

SMMObjectDetails previously used the renderModelSpecificData inheritance hook so SearchDetails and UserGeoDetails could extend it and append rows. Replace that pattern with a children prop: the parent renders the common created/deleted/replaced rows from a commonRows helper and slots whatever the caller passes after them.

SearchDetailsPage and UserGeoDetailsPage become FCs that use usePolling, three useState hooks (data + search + geometry, or data + geometry), and dispatch each row block as JSX children.

The SearchDetails and UserGeoDetails subclasses are now plain functions that build their rows and wrap them in SMMObjectDetails.

## Summary by Sourcery

Convert SMM object detail and page components to functional components with a shared common metadata row helper and polling hook.

New Features:
- Introduce a reusable commonRows helper to render shared SMM object metadata rows.
- Allow SMMObjectDetails consumers to supply model-specific detail rows via children props.

Enhancements:
- Refactor SMMObjectDetails, SearchDetailsPage, and UserGeoDetailsPage from class-based components to functional components using hooks for state and polling.
- Simplify SearchDetails and UserGeoDetails into plain functional components that compose SMMObjectDetails.
- Use a shared usePolling hook for periodic data refresh in search and user-geometry detail pages.