### PR TITLE
Convert small no-state class components to functions

### DIFF
--- a/frontend/geomap.tsx
+++ b/frontend/geomap.tsx
@@ -1,6 +1,6 @@
 import './page-shell'
 import 'leaflet/dist/leaflet.css'
-import React from 'react'
+import { ReactElement } from 'react'
 
 import './leaflet-setup'
 import { MapContainer, Polyline, Polygon, Marker, TileLayer } from 'react-leaflet'
@@ -13,46 +13,39 @@ interface GeoJsonMapProps {
   geometry: GeometryJSON
 }
 
-class GeoJsonMap extends React.Component<GeoJsonMapProps, never> {
-  render() {
-    const { geometry } = this.props
-    let firstPoint = { lat: 0, lng: 0 }
-    const objects = []
+function GeoJsonMap({ geometry }: GeoJsonMapProps) {
+  let firstPoint = { lat: 0, lng: 0 }
+  const objects: ReactElement[] = []
 
-    switch (geometry.type) {
-      case 'LineString': {
-        const coordinates = mapCoordinates(geometry.coordinates)
-        firstPoint = coordinates[0]
-        objects.push(<Polyline key="linestring" positions={coordinates} />)
-        break
-      }
-      case 'Polygon': {
-        const coordinates = mapCoordinates(geometry.coordinates[0])
-        firstPoint = coordinates[0]
-        objects.push(<Polygon key="polygon" positions={coordinates} />)
-        break
-      }
-      case 'Point':
-        firstPoint = coordinateToLatLng(geometry.coordinates)
-        objects.push(<Marker key="point" position={firstPoint} />)
-        break
+  switch (geometry.type) {
+    case 'LineString': {
+      const coordinates = mapCoordinates(geometry.coordinates)
+      firstPoint = coordinates[0]
+      objects.push(<Polyline key="linestring" positions={coordinates} />)
+      break
     }
+    case 'Polygon': {
+      const coordinates = mapCoordinates(geometry.coordinates[0])
+      firstPoint = coordinates[0]
+      objects.push(<Polygon key="polygon" positions={coordinates} />)
+      break
+    }
+    case 'Point':
+      firstPoint = coordinateToLatLng(geometry.coordinates)
+      objects.push(<Marker key="point" position={firstPoint} />)
+      break
+  }
 
-    const tileLayers = [
+  return (
+    <MapContainer center={firstPoint} zoom={13} className="dialog-map">
       <TileLayer
         key="layer-base"
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
-    ]
-
-    return (
-      <MapContainer center={firstPoint} zoom={13} className="dialog-map">
-        {tileLayers}
-        {objects}
-      </MapContainer>
-    )
-  }
+      {objects}
+    </MapContainer>
+  )
 }
 
 export { GeoJsonMap }

--- a/frontend/geometry/details.tsx
+++ b/frontend/geometry/details.tsx
@@ -1,7 +1,5 @@
 import { Table } from 'react-bootstrap'
 
-import React from 'react'
-
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 
 interface Point {
@@ -32,40 +30,37 @@ interface GeometryPointsProps {
   geometry: GeometryJSON
 }
 
-class GeometryPoints extends React.Component<GeometryPointsProps, never> {
-  pointsFromGeometry(): Point[] {
-    const { geometry } = this.props
-    switch (geometry.type) {
-      case 'Point':
-        return [coordinateToLatLng(geometry.coordinates)]
-      case 'LineString':
-        return mapCoordinates(geometry.coordinates)
-      case 'Polygon':
-        return mapCoordinates(geometry.coordinates[0])
-    }
+function pointsFromGeometry(geometry: GeometryJSON): Point[] {
+  switch (geometry.type) {
+    case 'Point':
+      return [coordinateToLatLng(geometry.coordinates)]
+    case 'LineString':
+      return mapCoordinates(geometry.coordinates)
+    case 'Polygon':
+      return mapCoordinates(geometry.coordinates[0])
   }
+}
 
-  render() {
-    const points = this.pointsFromGeometry()
-
-    const tableRows = points.map((point, index) => (
-      <tr key={index}>
-        <td>{degreesToDM(point.lng, 'lon')}</td>
-        <td>{degreesToDM(point.lat, 'lat')}</td>
-      </tr>
-    ))
-    return (
-      <Table responsive>
-        <thead>
-          <tr>
-            <td>Longitude</td>
-            <td>Latitude</td>
+function GeometryPoints({ geometry }: GeometryPointsProps) {
+  const points = pointsFromGeometry(geometry)
+  return (
+    <Table responsive>
+      <thead>
+        <tr>
+          <td>Longitude</td>
+          <td>Latitude</td>
+        </tr>
+      </thead>
+      <tbody>
+        {points.map((point, index) => (
+          <tr key={index}>
+            <td>{degreesToDM(point.lng, 'lon')}</td>
+            <td>{degreesToDM(point.lat, 'lat')}</td>
           </tr>
-        </thead>
-        <tbody>{tableRows}</tbody>
-      </Table>
-    )
-  }
+        ))}
+      </tbody>
+    </Table>
+  )
 }
 
 export { GeometryPoints, mapCoordinates, coordinateToLatLng }

--- a/frontend/menu/topbar.tsx
+++ b/frontend/menu/topbar.tsx
@@ -1,46 +1,41 @@
-import { MissionId } from '../mission/MissionId'
 import '../page-shell'
-import React from 'react'
 import * as ReactDOM from 'react-dom/client'
-
 import { Nav, Navbar, NavbarBrand } from 'react-bootstrap'
 
-class SMMTopBar extends React.Component<object, never> {
-  render() {
-    return (
-      <Navbar expand="lg" bg="secondary" data-bs-theme="dark" collapseOnSelect>
-        <NavbarBrand href="https://github.com/canterbury-air-patrol/search-management-map/">Search Management Map</NavbarBrand>
-        <Navbar.Toggle aria-controls="responsive-navbar-nav" />
-        <Navbar.Collapse id="responsive-navbar-nav">
-          <Nav>
-            <Nav.Link href="/">Missions</Nav.Link>
-            <Nav.Link href="/organization/">Organizations</Nav.Link>
-            <Nav.Link href="/assets/">Assets</Nav.Link>
-          </Nav>
-        </Navbar.Collapse>
-      </Navbar>
-    )
-  }
+import { MissionId } from '../mission/MissionId'
+
+function SMMTopBar() {
+  return (
+    <Navbar expand="lg" bg="secondary" data-bs-theme="dark" collapseOnSelect>
+      <NavbarBrand href="https://github.com/canterbury-air-patrol/search-management-map/">Search Management Map</NavbarBrand>
+      <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+      <Navbar.Collapse id="responsive-navbar-nav">
+        <Nav>
+          <Nav.Link href="/">Missions</Nav.Link>
+          <Nav.Link href="/organization/">Organizations</Nav.Link>
+          <Nav.Link href="/assets/">Assets</Nav.Link>
+        </Nav>
+      </Navbar.Collapse>
+    </Navbar>
+  )
 }
 
 interface SMMMissionTopBarProps {
   missionId: MissionId
 }
 
-class SMMMissionTopBar extends React.Component<SMMMissionTopBarProps, never> {
-  render() {
-    return (
-      <Navbar bg="secondary" data-bs-theme="dark">
-        <Nav>
-          <Nav.Link href="/">Mission List</Nav.Link>
-          <Nav.Link href={`/mission/${this.props.missionId}/details/`}>Details</Nav.Link>
-          <Nav.Link href={`/mission/${this.props.missionId}/map/`}>Map</Nav.Link>
-          <Nav.Link href={`/mission/${this.props.missionId}/timeline/`}>Timeline</Nav.Link>
-          <Nav.Link href={`/mission/${this.props.missionId}/sar/marine/sac/`}>Search Area Calculator</Nav.Link>
-        </Nav>
-      </Navbar>
-    )
-  }
+function SMMMissionTopBar({ missionId }: SMMMissionTopBarProps) {
+  return (
+    <Navbar bg="secondary" data-bs-theme="dark">
+      <Nav>
+        <Nav.Link href="/">Mission List</Nav.Link>
+        <Nav.Link href={`/mission/${missionId}/details/`}>Details</Nav.Link>
+        <Nav.Link href={`/mission/${missionId}/map/`}>Map</Nav.Link>
+        <Nav.Link href={`/mission/${missionId}/timeline/`}>Timeline</Nav.Link>
+        <Nav.Link href={`/mission/${missionId}/sar/marine/sac/`}>Search Area Calculator</Nav.Link>
+      </Nav>
+    </Navbar>
+  )
 }
 
 function createSMMMissionTopBar(elementId: string, missionId: number) {
@@ -55,33 +50,24 @@ interface SMMOrganizationTopBarProps {
   showRadioOperator: boolean
 }
 
-class SMMOrganizationTopBar extends React.Component<SMMOrganizationTopBarProps, never> {
-  constructor(props: SMMOrganizationTopBarProps) {
-    super(props)
-  }
-
-  render() {
-    const links = [
-      <Nav.Link href="/organization/" key="orgList">
-        Organization List
-      </Nav.Link>,
-      <Nav.Link href={`/organization/${this.props.organizationId}/`} key="orgDetails">
-        Details
-      </Nav.Link>
-    ]
-    if (this.props.showRadioOperator) {
-      links.push(
-        <Nav.Link href={`/organization/${this.props.organizationId}/radio/operator/`} key="orgRadioOperator">
-          Radio Operator
+function SMMOrganizationTopBar({ organizationId, showRadioOperator }: SMMOrganizationTopBarProps) {
+  return (
+    <Navbar bg="secondary" data-bs-theme="dark">
+      <Nav>
+        <Nav.Link href="/organization/" key="orgList">
+          Organization List
         </Nav.Link>
-      )
-    }
-    return (
-      <Navbar bg="secondary" data-bs-theme="dark">
-        <Nav>{links}</Nav>
-      </Navbar>
-    )
-  }
+        <Nav.Link href={`/organization/${organizationId}/`} key="orgDetails">
+          Details
+        </Nav.Link>
+        {showRadioOperator && (
+          <Nav.Link href={`/organization/${organizationId}/radio/operator/`} key="orgRadioOperator">
+            Radio Operator
+          </Nav.Link>
+        )}
+      </Nav>
+    </Navbar>
+  )
 }
 
 function createSMMOrganizationTopBar(elementId: string, organizationId: number, showRadioOperator: boolean) {

--- a/frontend/mission/header.tsx
+++ b/frontend/mission/header.tsx
@@ -1,7 +1,5 @@
 import { Table } from 'react-bootstrap'
 
-import React from 'react'
-
 import { MissionListRow } from './list'
 import { MissionData } from './types'
 
@@ -9,25 +7,23 @@ interface MissionHeaderProps {
   mission: MissionData
 }
 
-class MissionHeader extends React.Component<MissionHeaderProps, never> {
-  render() {
-    return (
-      <Table responsive>
-        <thead>
-          <tr>
-            <td>Misssion</td>
-            <td>Created</td>
-            <td>By</td>
-            <td>Closed</td>
-            <td>By</td>
-          </tr>
-        </thead>
-        <tbody>
-          <MissionListRow mission={this.props.mission} showButtons={false} showClosed={true} />
-        </tbody>
-      </Table>
-    )
-  }
+function MissionHeader({ mission }: MissionHeaderProps) {
+  return (
+    <Table responsive>
+      <thead>
+        <tr>
+          <td>Misssion</td>
+          <td>Created</td>
+          <td>By</td>
+          <td>Closed</td>
+          <td>By</td>
+        </tr>
+      </thead>
+      <tbody>
+        <MissionListRow mission={mission} showButtons={false} showClosed={true} />
+      </tbody>
+    </Table>
+  )
 }
 
 export { MissionHeader }


### PR DESCRIPTION
## Description

Convert the last presentation-only class components:

- menu/topbar.tsx: SMMTopBar, SMMMissionTopBar, SMMOrganizationTopBar
- mission/header.tsx: MissionHeader
- geomap.tsx: GeoJsonMap
- geometry/details.tsx: GeometryPoints (with a helper pointsFromGeometry)

No behaviour change.

## Summary by Sourcery

Convert remaining presentational React class components to function components without changing behaviour.

Enhancements:
- Refactor SMM top bar, mission top bar, and organization top bar components into stateless function components.
- Refactor GeometryPoints into a function component with a standalone helper for deriving points from geometry.
- Refactor GeoJsonMap and MissionHeader into function components while preserving existing UI and logic.