### PR TITLE
Replace HTML-string layer-control labels with real DOM nodes

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -11,6 +11,7 @@ import { smmGetJSON } from '../ajax'
 import { AssetPopup } from './AssetPopup'
 import { ColorPickerDialog } from './ColorPickerDialog'
 import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
+import { buildSwatchLabel } from '../components/swatchLabel'
 
 class SMMAsset {
   map: L.Map
@@ -18,6 +19,7 @@ class SMMAsset {
   assetId: number
   assetName: string
   color: string
+  swatch?: HTMLElement
   lastUpdate?: string
   path: Array<L.LatLng>
   updating: boolean
@@ -45,9 +47,8 @@ class SMMAsset {
   updateColor(color: string) {
     cookieJar.set(`asset_${this.assetId}_track_color`, color)
     this.color = color
-    this.polyline.setStyle({
-      color: this.color
-    })
+    this.polyline.setStyle({ color: this.color })
+    if (this.swatch) this.swatch.style.backgroundColor = color
   }
 
   colorPicker() {
@@ -88,13 +89,13 @@ class SMMAsset {
 }
 
 class SMMAssets extends SMMRealtime {
-  overlayAdd: (name: string, overlay: L.Layer) => void
+  overlayAdd: (name: string | HTMLElement, overlay: L.Layer) => void
   assetObjects: { [key: number]: SMMAsset }
   assetNameMap: { [key: number]: string }
   assetIconMap: { [key: number]: string }
   assetStatusMap: { [key: number]: { status: string; notes: string } }
   popupRoots: { [key: number]: ReactDOM.Root }
-  constructor(map: L.Map, missionId: MissionId, interval: number, color: string, overlayAdd: (name: string, overlay: L.Layer) => void) {
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string, overlayAdd: (name: string | HTMLElement, overlay: L.Layer) => void) {
     super(map, missionId, interval, color)
     this.overlayAdd = overlayAdd
     this.assetObjects = {}
@@ -149,22 +150,12 @@ class SMMAssets extends SMMRealtime {
       return null
     }
     if (!(assetId in this.assetObjects)) {
-      /* Create an overlay for this object */
       const color = cookieJar.get(`asset_${assetId}_track_color`)
       const assetObject = new SMMAsset(this.map, this.missionId, assetId, this.assetNameMap[assetId], color !== undefined ? color : this.color)
       this.assetObjects[assetId] = assetObject
-      this.overlayAdd(`${this.assetNameMap[assetId]} <div id='assetNamePicker${assetId}' />`, assetObject.overlay())
+      this.overlayAdd(buildSwatchLabel(this.assetNameMap[assetId], assetObject), assetObject.overlay())
     }
-    const assetObject = this.assetObjects[assetId]
-    const pickerDiv = document.getElementById(`assetNamePicker${assetId}`)
-    if (pickerDiv) {
-      Object.assign(pickerDiv.style, { width: '15px', height: '15px', display: 'inline-block', backgroundColor: assetObject.color })
-      if (pickerDiv.dataset.smmListenerBound !== '1') {
-        pickerDiv.dataset.smmListenerBound = '1'
-        pickerDiv.addEventListener('click', assetObject.colorPicker)
-      }
-    }
-    return assetObject
+    return this.assetObjects[assetId]
   }
 
   getAssetIcon(assetId: number) {

--- a/frontend/components/swatchLabel.ts
+++ b/frontend/components/swatchLabel.ts
@@ -1,0 +1,23 @@
+/** Build a layer-control label that places the name text next to a
+ *  coloured swatch. Clicking the swatch invokes the owner's
+ *  colorPicker callback. The label is a DOM node, not an HTML string,
+ *  so a name with HTML characters can't break the layer control or
+ *  inject markup. The swatch is stored on the owner so updateColor
+ *  can repaint it without rebuilding the label. */
+export function buildSwatchLabel(name: string, owner: { color: string; colorPicker: () => void; swatch?: HTMLElement }): HTMLElement {
+  const label = document.createElement('span')
+  label.textContent = `${name} `
+
+  const swatch = document.createElement('span')
+  Object.assign(swatch.style, {
+    width: '15px',
+    height: '15px',
+    display: 'inline-block',
+    backgroundColor: owner.color
+  })
+  swatch.addEventListener('click', owner.colorPicker)
+  owner.swatch = swatch
+
+  label.appendChild(swatch)
+  return label
+}

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -176,15 +176,15 @@ class SMMMap {
     this.overlayAdd('Marine - Total Drift Vectors', this.marineVectors.realtime())
   }
 
-  overlayAdd(name: string, layer: L.Layer) {
+  overlayAdd(name: string | HTMLElement, layer: L.Layer) {
     this.layerControl.addOverlay(layer, name)
   }
 
-  overlayAddAsset(name: string, layer: L.Layer) {
+  overlayAddAsset(name: string | HTMLElement, layer: L.Layer) {
     this.layerControlAssets.addOverlay(layer, name)
   }
 
-  overlayAddUser(name: string, layer: L.Layer) {
+  overlayAddUser(name: string | HTMLElement, layer: L.Layer) {
     this.layerControlUsers.addOverlay(layer, name)
   }
 }

--- a/frontend/types/leaflet-overrides.d.ts
+++ b/frontend/types/leaflet-overrides.d.ts
@@ -1,0 +1,13 @@
+/* Leaflet's Control.Layers.addOverlay accepts a string or an HTMLElement
+ * at runtime, but @types/leaflet only types the string overload. Widen
+ * the type so we can pass DOM nodes (e.g. labels with a colour swatch). */
+import 'leaflet'
+
+declare module 'leaflet' {
+  namespace Control {
+    interface Layers {
+      addBaseLayer(layer: Layer, name: string | HTMLElement): this
+      addOverlay(layer: Layer, name: string | HTMLElement): this
+    }
+  }
+}

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -9,12 +9,14 @@ import { SMMMissionUserPointTimeGeoJSON } from './types'
 import { UserPopup } from './UserPopup'
 import { ColorPickerDialog } from '../asset/ColorPickerDialog'
 import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
+import { buildSwatchLabel } from '../components/swatchLabel'
 
 class SMMUserPosition {
   map: L.Map
   missionId: MissionId
   userName: string
   color: string
+  swatch?: HTMLElement
   popupRoot?: ReactDOM.Root
   lastUpdate?: string
   path: L.LatLng[]
@@ -41,9 +43,8 @@ class SMMUserPosition {
   updateColor(color: string) {
     cookieJar.set(`user_${this.userName}_track_color`, color)
     this.color = color
-    this.polyline.setStyle({
-      color: this.color
-    })
+    this.polyline.setStyle({ color: this.color })
+    if (this.swatch) this.swatch.style.backgroundColor = color
   }
 
   colorPicker() {
@@ -85,8 +86,8 @@ class SMMUserPosition {
 
 class SMMUserPositions extends SMMRealtime {
   userObjects: { [key: string]: SMMUserPosition }
-  overlayAdd: (name: string, overlay: L.Layer) => void
-  constructor(map: L.Map, missionId: MissionId, interval: number, color: string, overlayAdd: (name: string, overlay: L.Layer) => void) {
+  overlayAdd: (name: string | HTMLElement, overlay: L.Layer) => void
+  constructor(map: L.Map, missionId: MissionId, interval: number, color: string, overlayAdd: (name: string | HTMLElement, overlay: L.Layer) => void) {
     super(map, missionId, interval, color)
     this.overlayAdd = overlayAdd
     this.userObjects = {}
@@ -119,22 +120,12 @@ class SMMUserPositions extends SMMRealtime {
 
   createUser(userName: string) {
     if (!(userName in this.userObjects)) {
-      /* Create an overlay for this object */
       const color = cookieJar.get(`user_${userName}_track_color`)
       const userObject = new SMMUserPosition(this.map, this.missionId, userName, color !== undefined ? color : this.color)
       this.userObjects[userName] = userObject
-      this.overlayAdd(`${userName} <div id='userNamePicker${userName}' />`, userObject.overlay())
+      this.overlayAdd(buildSwatchLabel(userName, userObject), userObject.overlay())
     }
-    const userObject = this.userObjects[userName]
-    const pickerDiv = document.getElementById(`userNamePicker${userName}`)
-    if (pickerDiv) {
-      Object.assign(pickerDiv.style, { width: '15px', height: '15px', display: 'inline-block', backgroundColor: userObject.color })
-      if (pickerDiv.dataset.smmListenerBound !== '1') {
-        pickerDiv.dataset.smmListenerBound = '1'
-        pickerDiv.addEventListener('click', userObject.colorPicker)
-      }
-    }
-    return userObject
+    return this.userObjects[userName]
   }
 
   createPopup(user: SMMMissionUserPointTimeGeoJSON, layer: L.Layer) {


### PR DESCRIPTION
## Description

The asset/user swatch overlays previously hand-rolled an HTML string that mixed the (untrusted) name with a fixed-id placeholder div, then located the placeholder via document.getElementById and patched its style and click listener on every realtime tick. Two problems:
- a name containing HTML characters can either break the layer control DOM or land unsanitised in the page;
- the id-based lookup forces a global DOM scan and a sentinel guard to avoid binding the listener twice.

Introduce frontend/components/swatchLabel.ts that returns a span containing the text + a coloured swatch with the click listener bound exactly once at construction. The owner stores the swatch node so updateColor can repaint it without re-finding the element.

Widen overlayAdd / Control.Layers.addOverlay (via a leaflet module augmentation) to accept HTMLElement. Drop the per-tick getElementById calls and the smmListenerBound sentinel from SMMAssets/SMMUserPositions.

## Summary by Sourcery

Replace HTML-string layer-control labels with DOM-based labels that include a clickable colour swatch and eliminate per-tick DOM lookups.

Bug Fixes:
- Prevent unsafe injection and DOM breakage by avoiding HTML string concatenation for layer-control labels and using real DOM nodes instead.

Enhancements:
- Allow Leaflet layer controls to accept HTMLElement labels so overlays can use richer, interactive content.
- Share a reusable swatchLabel helper that builds a label with a text name and clickable colour swatch and stores the swatch for efficient colour updates.
- Stop performing per-tick document.getElementById scans and sentinel checks for asset and user overlay swatches by binding listeners once at construction.