### PR TITLE
Rebuild asset name/icon/status maps from each refresh

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -116,15 +116,19 @@ class SMMAssets extends SMMRealtime {
 
   async updateAssetNameMap() {
     const data = await smmGetJSON<{ assets: Array<MissionAssetData> }>(`/mission/${this.missionId}/assets/?include_removed=true`, {})
+    // Rebuild the maps from scratch so an asset that drops its icon /
+    // status / name on the server doesn't carry a stale entry forever.
+    const names: { [key: number]: string } = {}
+    const icons: { [key: number]: string } = {}
+    const statuses: { [key: number]: { status: string; notes: string } } = {}
     for (const asset of data.assets) {
-      this.assetNameMap[asset.id] = asset.name
-      if (asset.status) {
-        this.assetStatusMap[asset.id] = asset.status
-      }
-      if (asset.icon_url) {
-        this.assetIconMap[asset.id] = asset.icon_url
-      }
+      names[asset.id] = asset.name
+      if (asset.status) statuses[asset.id] = asset.status
+      if (asset.icon_url) icons[asset.id] = asset.icon_url
     }
+    this.assetNameMap = names
+    this.assetIconMap = icons
+    this.assetStatusMap = statuses
   }
 
   realtime() {


### PR DESCRIPTION
## Description

updateAssetNameMap appended to long-lived dictionaries and only ever overwrote entries; an asset that lost its icon_url, status, or even name on the server kept the stale field in memory for the lifetime of the session. Build fresh local dictionaries each tick and swap them in atomically so removed fields actually go away.

## Summary by Sourcery

Bug Fixes:
- Ensure asset name, icon, and status entries are fully replaced on each refresh instead of accumulating and retaining stale values for removed or cleared fields.