### PR TITLE
Move form rows out of <thead> and use <th> for column headers

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -91,9 +91,9 @@ function AssetTrackAs({ asset }: AssetTrackAsProps) {
     <Table responsive>
       <thead>
         <tr>
-          <td>Latitude</td>
-          <td>Longitude</td>
-          <td>Altitude</td>
+          <th>Latitude</th>
+          <th>Longitude</th>
+          <th>Altitude</th>
         </tr>
       </thead>
       <tbody>
@@ -196,7 +196,7 @@ function AssetCommandView({ asset, lastCommand }: AssetCommandViewProps) {
 
   return (
     <Table responsive>
-      <thead>
+      <tbody>
         <tr>
           <td>
             <b>{lastCommand?.action_txt}</b>
@@ -210,7 +210,7 @@ function AssetCommandView({ asset, lastCommand }: AssetCommandViewProps) {
           <td colSpan={2}>{lastCommand?.reason}</td>
         </tr>
         {responseData}
-      </thead>
+      </tbody>
     </Table>
   )
 }
@@ -359,7 +359,7 @@ function AssetStatus({ asset, details }: AssetStatusProps) {
   }
   return (
     <Table responsive>
-      <thead>
+      <tbody>
         {rows}
         <tr>
           <td>Status:</td>
@@ -382,8 +382,7 @@ function AssetStatus({ asset, details }: AssetStatusProps) {
             <textarea onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setNotes(e.target.value)} value={notes}></textarea>
           </td>
         </tr>
-        <tr></tr>
-      </thead>
+      </tbody>
     </Table>
   )
 }

--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -85,10 +85,10 @@ function MissionAssetStatus({ asset, mission }: MissionAssetStatusProps) {
       <Table>
         <thead>
           <tr>
-            <td>Mission Status</td>
-            <td>Description</td>
-            <td>Notes</td>
-            <td>Since</td>
+            <th>Mission Status</th>
+            <th>Description</th>
+            <th>Notes</th>
+            <th>Since</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Description

AssetCommandView and AssetStatus wrapped their entire body inside <thead>, which screen readers misannounce as a table header row when the cells are really form controls. Move them into <tbody>.

While here, promote the real column-header cells from <td> to <th> in AssetTrackAs and MissionAssetStatus so assistive tech identifies them as headers and the visual style picks up Bootstrap's th defaults.

## Summary by Sourcery

Improve accessibility and semantic HTML structure for asset-related tables.

Enhancements:
- Move form and status rows from table headers into table bodies in asset views so table structure reflects content semantics.
- Change column header cells from data cells to header cells in asset and mission status tables to provide proper header semantics and styling.