### PR TITLE
Centralise the custom asset marker icon and handle URL clearing

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -186,17 +186,7 @@ class SMMAssets extends SMMRealtime {
   assetLayer(asset: { properties: { asset: number } }, latlng: L.LatLng) {
     const iconUrl = this.getAssetIcon(asset.properties.asset)
     const title = this.assetNameMap[asset.properties.asset]
-    if (iconUrl) {
-      return L.marker(latlng, {
-        title,
-        icon: L.icon({
-          iconUrl,
-          iconSize: [50, 50],
-          iconAnchor: [25, 50]
-        })
-      })
-    }
-    return L.marker(latlng, { title })
+    return L.marker(latlng, iconUrl ? { title, icon: customAssetIcon(iconUrl) } : { title })
   }
 
   assetUpdate(asset: { properties: { asset: number; alt?: number; heading?: number; fix?: string }; geometry: { type: string; coordinates: Array<number> } }, oldLayer: L.Marker) {
@@ -231,23 +221,21 @@ class SMMAssets extends SMMRealtime {
       }
       oldLayer.options.title = newTitle
 
-      const currentIcon = oldLayer.getIcon()
-      if (assetId in this.assetIconMap) {
-        const iconUrl = this.assetIconMap[assetId]
-        if (currentIcon.options.iconUrl !== iconUrl) {
-          oldLayer.setIcon(
-            L.icon({
-              iconUrl,
-              iconSize: [50, 50],
-              iconAnchor: [25, 50]
-            })
-          )
-        }
+      const desiredIconUrl = this.assetIconMap[assetId] // undefined when the asset has no custom icon
+      const currentIconUrl = oldLayer.getIcon().options.iconUrl
+      if (desiredIconUrl !== currentIconUrl) {
+        oldLayer.setIcon(desiredIconUrl ? customAssetIcon(desiredIconUrl) : new L.Icon.Default())
       }
 
       return oldLayer
     }
   }
+}
+
+/** Constant icon dimensions for assets that ship a custom icon_url.
+ *  Centralising here means assetLayer/assetUpdate can't drift. */
+function customAssetIcon(iconUrl: string): L.Icon {
+  return L.icon({ iconUrl, iconSize: [50, 50], iconAnchor: [25, 50] })
 }
 
 export { SMMAssets }


### PR DESCRIPTION
## Description

assetLayer and assetUpdate each declared the iconSize/iconAnchor literal for custom-icon assets, so the two could drift apart. Extract customAssetIcon() and call it from both.

While here, fix the URL-clearing branch in assetUpdate: it only reset the icon when assetIconMap had an entry whose url differed from the current one. If the asset previously had a custom icon and the server later cleared it, the marker kept the old custom icon. Detect both URL changes and the present->absent transition by comparing the desired url against the current icon's url (undefined means revert to the default marker via new L.Icon.Default()).

## Summary by Sourcery

Centralise creation of custom asset marker icons and ensure markers correctly update when a custom icon URL changes or is cleared.

Bug Fixes:
- Ensure asset markers revert to the default icon when a previously set custom icon URL is cleared on the server.
- Keep marker icons in sync with the configured custom icon URL by updating whenever the desired URL differs from the current icon.

Enhancements:
- Introduce a shared helper for constructing custom asset icons so assetLayer and assetUpdate use consistent icon dimensions.