### PR TITLE
Collapse smmPostBody into smmPost with auto-detect on body type

### DIFF
--- a/frontend/ImageUploader/ImageUploaderDialog.tsx
+++ b/frontend/ImageUploader/ImageUploaderDialog.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react'
 import L from 'leaflet'
 
 import { LatLngMarkerInput } from '../LatLngMarkerInput'
-import { smmPostBody } from '../ajax'
+import { smmPost } from '../ajax'
 
 interface Props {
   map: L.Map
@@ -24,7 +24,7 @@ export function ImageUploaderDialog({ map, missionId, onClose }: Props) {
     if (fileRef.current?.files?.[0]) {
       formData.append('file', fileRef.current.files[0])
     }
-    smmPostBody(`/mission/${missionId}/image/upload/`, formData)
+    smmPost(`/mission/${missionId}/image/upload/`, formData)
     onClose()
   }
 

--- a/frontend/ajax.ts
+++ b/frontend/ajax.ts
@@ -85,12 +85,14 @@ function smmGetJSON<T = unknown>(url: string, data?: RequestData, success?: (dat
   return request<T>(appendQueryString(url, data), { headers: { Accept: 'application/json' } }, (r) => r.json(), success, error)
 }
 
-function smmPost(url: string, data: RequestData, success?: (data: unknown) => void, error?: (data?: unknown) => void) {
-  return request(url, { method: 'POST', headers: csrfHeaders(), body: buildSearchParams(data) }, (r) => r.text(), success, error)
-}
-
-function smmPostBody(url: string, body: FormData | URLSearchParams, success?: (data: unknown) => void, error?: (data?: unknown) => void) {
-  return request(url, { method: 'POST', headers: csrfHeaders(), body }, (r) => r.text(), success, error, null)
+/** POST helper. Pass a flat object for an x-www-form-urlencoded body
+ *  (subject to the default request timeout), or a FormData / URLSearchParams
+ *  to use it as the body verbatim (no timeout - typical for uploads). */
+function smmPost(url: string, data: RequestData | FormData | URLSearchParams, success?: (data: unknown) => void, error?: (data?: unknown) => void) {
+  const isRaw = data instanceof FormData || data instanceof URLSearchParams
+  const body = isRaw ? data : buildSearchParams(data)
+  const timeoutMs = data instanceof FormData ? null : DEFAULT_TIMEOUT_MS
+  return request(url, { method: 'POST', headers: csrfHeaders(), body }, (r) => r.text(), success, error, timeoutMs)
 }
 
 function smmPatch(url: string, data: Record<string, unknown>, success?: (data: string) => void, error?: (data?: unknown) => void) {
@@ -101,4 +103,4 @@ function smmDelete(url: string, success?: (data: void) => void, error?: (data?: 
   return request<void>(url, { method: 'DELETE', headers: csrfHeaders() }, async () => {}, success, error)
 }
 
-export { smmGet, smmGetJSON, smmPost, smmPostBody, smmPatch, smmDelete }
+export { smmGet, smmGetJSON, smmPost, smmPatch, smmDelete }


### PR DESCRIPTION
## Description

The split between smmPost (RequestData -> URLSearchParams) and smmPostBody (FormData/URLSearchParams pass-through, no timeout) was fuzzy and called from one place each. Widen smmPost's data parameter to accept FormData / URLSearchParams as well: when it's already a body-typed instance we send it verbatim, and for FormData we also skip the request timeout (uploads can take longer than 30s). ImageUploaderDialog moves over; the dedicated smmPostBody export goes.

## Summary by Sourcery

Unify POST helper functionality to support both encoded objects and raw body types while simplifying consumers.

Enhancements:
- Extend the generic POST helper to accept FormData and URLSearchParams directly and auto-select timeout behavior based on body type.
- Remove the dedicated smmPostBody helper in favor of the enhanced smmPost and update the image upload dialog to use it.