### PR TITLE
Add featureOptions hook so SMMRealtime owns the L.realtime call

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -131,22 +131,12 @@ class SMMAssets extends SMMRealtime {
     this.assetStatusMap = statuses
   }
 
-  realtime() {
-    return L.realtime(
-      {
-        url: this.getUrl(),
-        type: 'json'
-      },
-      {
-        interval: this.interval,
-        onEachFeature: this.createPopup,
-        updateFeature: this.assetUpdate,
-        getFeatureId: function (feature: { properties: { asset: number } }) {
-          return feature.properties.asset
-        },
-        pointToLayer: this.assetLayer
-      }
-    )
+  protected featureOptions() {
+    return {
+      updateFeature: this.assetUpdate,
+      getFeatureId: (feature: { properties: { asset: number } }) => feature.properties.asset,
+      pointToLayer: this.assetLayer
+    }
   }
 
   createAsset(assetId: number) {

--- a/frontend/image/map.tsx
+++ b/frontend/image/map.tsx
@@ -14,29 +14,16 @@ abstract class SMMImage extends SMMRealtime {
     this.createPopup = this.createPopup.bind(this)
   }
 
-  realtime() {
-    return L.realtime(
-      {
-        url: this.getUrl(),
-        type: 'json'
-      },
-      {
-        interval: this.interval,
-        color: this.color,
-        onEachFeature: this.createPopup,
-        getFeatureId: function (feature: SMMImageGeoJSON) {
-          return feature.properties.pk
-        },
-        pointToLayer: function (feature: SMMImageGeoJSON, latlng: L.LatLng) {
-          return L.marker(latlng, {
-            icon: L.icon({
-              iconUrl: '/static/icons/image-x-generic.png',
-              iconSize: [24, 24]
-            })
+  protected featureOptions() {
+    return {
+      pointToLayer: (_feature: SMMImageGeoJSON, latlng: L.LatLng) =>
+        L.marker(latlng, {
+          icon: L.icon({
+            iconUrl: '/static/icons/image-x-generic.png',
+            iconSize: [24, 24]
           })
-        }
-      }
-    )
+        })
+    }
   }
 
   createPopup(image: SMMImageGeoJSON, layer: L.Layer) {

--- a/frontend/smmmap.tsx
+++ b/frontend/smmmap.tsx
@@ -18,19 +18,23 @@ abstract class SMMRealtime {
   abstract getUrl(): string
   abstract createPopup(feature: { properties: object }, layer: L.Layer): void
 
-  realtime() {
+  /** Override to supply leaflet-realtime options on top of the base
+   *  ({ interval, color, onEachFeature, getFeatureId }). Typical extras
+   *  are updateFeature, pointToLayer, or a feature-specific
+   *  getFeatureId. */
+  protected featureOptions(): L.RealtimeOptions {
+    return {}
+  }
+
+  realtime(): L.Realtime {
     return L.realtime(
-      {
-        url: this.getUrl(),
-        type: 'json'
-      },
+      { url: this.getUrl(), type: 'json' },
       {
         interval: this.interval,
         color: this.color,
         onEachFeature: this.createPopup,
-        getFeatureId: function (feature: { properties: { pk: number } }) {
-          return feature.properties.pk
-        }
+        getFeatureId: (feature: { properties: { pk: number } }) => feature.properties.pk,
+        ...this.featureOptions()
       }
     )
   }

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -100,22 +100,12 @@ class SMMUserPositions extends SMMRealtime {
     return `/mission/${this.missionId}/data/users/positions/latest/`
   }
 
-  realtime() {
-    return L.realtime(
-      {
-        url: this.getUrl(),
-        type: 'json'
-      },
-      {
-        interval: this.interval,
-        onEachFeature: this.createPopup,
-        updateFeature: this.userUpdate,
-        getFeatureId: function (feature: SMMMissionUserPointTimeGeoJSON) {
-          return feature.properties.user
-        },
-        pointToLayer: this.userLayer
-      }
-    )
+  protected featureOptions() {
+    return {
+      updateFeature: this.userUpdate,
+      getFeatureId: (feature: SMMMissionUserPointTimeGeoJSON) => feature.properties.user,
+      pointToLayer: this.userLayer
+    }
   }
 
   createUser(userName: string) {


### PR DESCRIPTION
## Description

Half the SMMRealtime subclasses bypassed the base realtime() because they needed updateFeature, pointToLayer, or a non-pk getFeatureId. The result was three copies of the same L.realtime({url,type:'json'}, {interval, color, onEachFeature, ...}) wrapping.

Add a protected featureOptions() hook that returns an object spread on top of the base. SMMAssets, SMMUserPositions and SMMImage override just their bespoke fields; the base now controls the rest.

## Summary by Sourcery

Centralize Leaflet realtime layer creation in the SMMRealtime base class with an overridable featureOptions hook.

Enhancements:
- Introduce a protected featureOptions hook in SMMRealtime to allow subclasses to extend Leaflet realtime options without reimplementing the base realtime call.
- Update SMMAssets, SMMUserPositions, and SMMImage to override featureOptions for their custom update and rendering behavior while delegating common configuration to the base class.