### PR TITLE
Disambiguate MissionAssetData into Summary and Record

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -5,7 +5,7 @@ import { SMMRealtime } from '../smmmap'
 import '@canterbury-air-patrol/leaflet-dialog'
 import * as ReactDOM from 'react-dom/client'
 import { cookieJar } from '../cookies'
-import { MissionAssetData, AssetPointTime } from './types'
+import { MissionAssetSummary, AssetPointTime } from './types'
 
 import { smmGetJSON } from '../ajax'
 import { AssetPopup } from './AssetPopup'
@@ -115,7 +115,7 @@ class SMMAssets extends SMMRealtime {
   }
 
   async updateAssetNameMap() {
-    const data = await smmGetJSON<{ assets: Array<MissionAssetData> }>(`/mission/${this.missionId}/assets/?include_removed=true`, {})
+    const data = await smmGetJSON<{ assets: Array<MissionAssetSummary> }>(`/mission/${this.missionId}/assets/?include_removed=true`, {})
     // Rebuild the maps from scratch so an asset that drops its icon /
     // status / name on the server doesn't carry a stale entry forever.
     const names: { [key: number]: string } = {}

--- a/frontend/asset/types.ts
+++ b/frontend/asset/types.ts
@@ -80,7 +80,11 @@ interface MissionAssetStatusData {
   notes: string
 }
 
-interface MissionAssetData {
+/** Per-asset summary returned by /mission/<id>/assets/. Flat shape: the
+ *  asset fields are spread at the top level. Distinct from
+ *  mission/types:MissionAssetRecord, which carries the full nested
+ *  AssetData plus the per-mission membership metadata. */
+interface MissionAssetSummary {
   id: number
   name: string
   type_id: number
@@ -96,4 +100,15 @@ interface AssetPointTime {
   fix?: number
 }
 
-export { AssetTypeData, AssetData, AssetFullStatusData, AssetMissionData, AssetCommandData, AssetStatusValueData, AssetStatusData, MissionAssetData, AssetPointTime }
+export {
+  AssetTypeData,
+  AssetData,
+  AssetFullStatusData,
+  AssetMissionData,
+  AssetCommandData,
+  AssetStatusValueData,
+  AssetStatusData,
+  MissionAssetSummary,
+  MissionAssetStatusData,
+  AssetPointTime
+}

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -8,7 +8,7 @@ import { smmGetJSON, smmPost, smmPatch, smmDelete } from '../ajax'
 import { SMMMissionTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
 
-import { MissionAssetData, MissionData, MissionDetailsData, MissionExternalReferenceData, MissionOrganizationData, MissionUserData } from './types'
+import { MissionAssetRecord, MissionData, MissionDetailsData, MissionExternalReferenceData, MissionOrganizationData, MissionUserData } from './types'
 import { OrganizationData } from '../organization/types'
 import { AssetData } from '../asset/types'
 
@@ -444,7 +444,7 @@ function MissionDetailsUserAdd({ mission }: { mission: number }) {
   )
 }
 
-function MissionDetailsAssetRow({ missionAsset }: { missionAsset: MissionAssetData }) {
+function MissionDetailsAssetRow({ missionAsset }: { missionAsset: MissionAssetRecord }) {
   function remove() {
     smmDelete(`/mission/${missionAsset.mission}/assets/${missionAsset.asset.id}/`)
   }
@@ -487,7 +487,7 @@ function MissionDetailsAssetRow({ missionAsset }: { missionAsset: MissionAssetDa
   )
 }
 
-function MissionDetailsAssetList({ missionAssets }: { missionAssets: Array<MissionAssetData> }) {
+function MissionDetailsAssetList({ missionAssets }: { missionAssets: Array<MissionAssetRecord> }) {
   return (
     <Table>
       <thead>

--- a/frontend/mission/types.ts
+++ b/frontend/mission/types.ts
@@ -26,7 +26,12 @@ interface MissionUserData {
   }
 }
 
-interface MissionAssetData {
+/** Mission membership record for a single asset, returned as part of
+ *  /mission/<id>/details/. Carries the full nested AssetData plus the
+ *  added/removed timestamps. Distinct from asset/types:MissionAssetSummary
+ *  which is the flat per-asset summary returned by
+ *  /mission/<id>/assets/. */
+interface MissionAssetRecord {
   id: number
   mission: number
   asset: AssetData
@@ -44,16 +49,6 @@ interface MissionAssetStatusValueData {
   id: number
   name: string
   description: string
-}
-
-interface MissionAssetStatusData {
-  id: number
-  asset: string
-  asset_id: number
-  status: string
-  status_description: string
-  since: string
-  notes: string
 }
 
 interface MissionOrganizationData {
@@ -83,18 +78,9 @@ interface MissionDetailsData {
   can_add_organizations: boolean
   can_add_users: boolean
   mission_organizations: Array<MissionOrganizationData>
-  mission_assets: Array<MissionAssetData>
+  mission_assets: Array<MissionAssetRecord>
   mission_users: Array<MissionUserData>
   external_references: Array<MissionExternalReferenceData>
 }
 
-export {
-  MissionData,
-  MissionUserData,
-  MissionAssetData,
-  MissionAssetStatusValueData,
-  MissionAssetStatusData,
-  MissionOrganizationData,
-  MissionExternalReferenceData,
-  MissionDetailsData
-}
+export { MissionData, MissionUserData, MissionAssetRecord, MissionAssetStatusValueData, MissionOrganizationData, MissionExternalReferenceData, MissionDetailsData }

--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -1,7 +1,7 @@
 import { MissionId } from '../mission/MissionId'
 import { useEffect, useState } from 'react'
 
-import { MissionAssetData } from '../asset/types'
+import { MissionAssetSummary } from '../asset/types'
 import { smmGetJSON, smmPost } from '../ajax'
 import { FormInputGroup } from '../components/FormInputGroup'
 
@@ -18,7 +18,7 @@ export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: 
   const [selectedAssetId, setSelectedAssetId] = useState('')
 
   useEffect(() => {
-    smmGetJSON<{ assets: Array<MissionAssetData> }>(`/mission/${missionId}/assets/`, {}).then((d) => {
+    smmGetJSON<{ assets: Array<MissionAssetSummary> }>(`/mission/${missionId}/assets/`, {}).then((d) => {
       const filtered = d.assets.filter((a) => a.type_name === createdFor)
       setAssets(filtered)
       if (filtered.length > 0) setSelectedAssetId(String(filtered[0].id))


### PR DESCRIPTION
## Description

Two unrelated types both called MissionAssetData lived in asset/types.ts and mission/types.ts. They serialise different endpoints (the flat per-asset summary from /mission/<id>/assets/ vs the enriched mission membership record with nested AssetData from /mission/<id>/details/). Rename them MissionAssetSummary and MissionAssetRecord respectively, drop the duplicate MissionAssetStatusData export from mission/types.ts (asset/types.ts already declares the canonical shape), and update each call site (asset/map.tsx, search/SearchQueueDialog.tsx, mission/details.tsx) to import the right name.

## Summary by Sourcery

Disambiguate mission asset types into separate summary and detailed record shapes and update all mission and asset consumers accordingly.

Enhancements:
- Rename the mission details asset type to MissionAssetRecord and document its role as the enriched mission membership record.
- Rename the mission assets list type to MissionAssetSummary and document its role as the flat per-asset summary from the mission assets endpoint.
- Remove the redundant MissionAssetStatusData definition from mission/types in favor of the canonical definition in asset/types and streamline exports.