### PR TITLE
Zero-pad marine vector times before posting to the backend

### DIFF
--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -33,7 +33,11 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   }
 
   formatTime(time: Date) {
-    return `${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}`
+    // Backend stores these on TimeField (HH:MM:SS). Pad each component so
+    // 9:5:3 doesn't slip through; convert_time on the server still treats
+    // the value as a time-of-day, not a full ISO timestamp.
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${pad(time.getHours())}:${pad(time.getMinutes())}:${pad(time.getSeconds())}`
   }
 
   getData() {


### PR DESCRIPTION
## Description

formatTime returned '${getHours}:${getMinutes}:${getSeconds}' without padding, so 9:5:3 could land in the payload. The backend's convert_time helper only inserts a colon when one is missing; it still expects a TimeField-compatible HH:MM:SS string. Pad each component to two digits so the server-side parse is deterministic.

(The original TODO suggested toISOString(), which would break the TimeField columns on the server. Documented inline.)

## Summary by Sourcery

Bug Fixes:
- Pad hours, minutes, and seconds in marine vector timestamps to produce valid TimeField-compatible HH:MM:SS strings for the backend.