### PR TITLE
Restore the Bootstrap bundle in pretty.tsx

### DIFF
--- a/frontend/pretty.tsx
+++ b/frontend/pretty.tsx
@@ -1,0 +1,6 @@
+/* The "pretty" bundle is the Bootstrap-only page shell used by Django
+ * templates that only need form styling (mission create, asset add,
+ * timeline forms, etc.). Importing page-shell pulls in the Bootstrap
+ * bundle (Popper included) and the Bootstrap CSS via esbuild's CSS
+ * pipeline, which Django templates then load as pretty.js + pretty.css. */
+import './page-shell'


### PR DESCRIPTION
## Description

The page-shell refactor's sed accidentally emptied frontend/pretty.tsx instead of replacing its two bootstrap imports with the new shared './page-shell' import. That left dist/pretty.js at 25 bytes; the Django templates that include pretty.js (mission_create, mission_user_add, mission_asset_add, mission_user_details, typhoon-upload, ...) silently lost Bootstrap JS, so dropdowns, tooltips and the navbar collapse on those pages stopped working.

Put the './page-shell' import back so esbuild emits the full ~82KB Bootstrap bundle into dist/pretty.js again. Add a one-line header explaining what this entrypoint is for.

## Summary by Sourcery

Restore the pretty.tsx entrypoint so the Bootstrap JavaScript bundle is emitted again for pages that rely on pretty.js.

Bug Fixes:
- Reinstate the page-shell import in pretty.tsx so Bootstrap JS is bundled into pretty.js and interactive UI elements work again on affected pages.

Documentation:
- Add a brief header comment to pretty.tsx describing the purpose of this entrypoint.