### PR TITLE
Make the long-lived cookie maxAge explicit per call site

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -4,7 +4,7 @@ import L from 'leaflet'
 import { SMMRealtime } from '../smmmap'
 import '@canterbury-air-patrol/leaflet-dialog'
 import * as ReactDOM from 'react-dom/client'
-import { cookieJar } from '../cookies'
+import { cookieJar, PREFERENCE_COOKIE_OPTS } from '../cookies'
 import { MissionAssetSummary, AssetPointTime } from './types'
 
 import { smmGetJSON } from '../ajax'
@@ -45,7 +45,7 @@ class SMMAsset {
   }
 
   updateColor(color: string) {
-    cookieJar.set(`asset_${this.assetId}_track_color`, color)
+    cookieJar.set(`asset_${this.assetId}_track_color`, color, PREFERENCE_COOKIE_OPTS)
     this.color = color
     this.polyline.setStyle({ color: this.color })
     if (this.swatch) this.swatch.style.backgroundColor = color

--- a/frontend/cookies.ts
+++ b/frontend/cookies.ts
@@ -1,5 +1,11 @@
-import Cookies from 'universal-cookie'
+import Cookies, { CookieSetOptions } from 'universal-cookie'
 
-const cookieJar = new Cookies(null, { path: '/', maxAge: 31536000, sameSite: 'strict' })
+const cookieJar = new Cookies(null, { path: '/', sameSite: 'strict' })
+
+/** Long-lived (~1 year) cookie options for storing UI preferences such
+ *  as layer toggles and per-asset track colours. Don't apply to cookies
+ *  whose lifetime should be governed by the server (e.g. csrftoken). */
+const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60
+export const PREFERENCE_COOKIE_OPTS: CookieSetOptions = { maxAge: ONE_YEAR_SECONDS }
 
 export { cookieJar }

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -12,7 +12,7 @@ import '@canterbury-air-patrol/leaflet-dialog'
 import '@canterbury-air-patrol/leaflet-dialog/Leaflet.Dialog.css'
 import { LocateControl } from 'leaflet.locatecontrol'
 import 'leaflet.locatecontrol/dist/L.Control.Locate.min.css'
-import { cookieJar } from './cookies'
+import { cookieJar, PREFERENCE_COOKIE_OPTS } from './cookies'
 
 import './Admin/admin'
 import './ImageUploader/ImageUploader'
@@ -70,7 +70,7 @@ class SMMMap {
   }
 
   layerStateChanged(e: L.LayersControlEvent) {
-    cookieJar.set(`layer_${this.convertCookieName(e.name)}_on_map`, e.type === 'overlayadd')
+    cookieJar.set(`layer_${this.convertCookieName(e.name)}_on_map`, e.type === 'overlayadd', PREFERENCE_COOKIE_OPTS)
   }
 
   mapLayersCallback(data: {

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -3,7 +3,7 @@ import L from 'leaflet'
 
 import { SMMRealtime } from '../smmmap'
 import * as ReactDOM from 'react-dom/client'
-import { cookieJar } from '../cookies'
+import { cookieJar, PREFERENCE_COOKIE_OPTS } from '../cookies'
 import { smmGetJSON } from '../ajax'
 import { SMMMissionUserPointTimeGeoJSON } from './types'
 import { UserPopup } from './UserPopup'
@@ -41,7 +41,7 @@ class SMMUserPosition {
   }
 
   updateColor(color: string) {
-    cookieJar.set(`user_${this.userName}_track_color`, color)
+    cookieJar.set(`user_${this.userName}_track_color`, color, PREFERENCE_COOKIE_OPTS)
     this.color = color
     this.polyline.setStyle({ color: this.color })
     if (this.swatch) this.swatch.style.backgroundColor = color


### PR DESCRIPTION
## Description

cookieJar's constructor applied { path:'/', maxAge: 31536000, sameSite:'strict' } to every cookie set. That value is correct for the three UI preferences we persist (layer toggles, per-asset/user track colours) but masked the intent at the call sites and would quietly extend any future server-owned cookie (e.g. csrftoken) if it were ever written through this jar.

Drop maxAge from the constructor default and export a PREFERENCE_COOKIE_OPTS bag the three preference call sites now pass explicitly.

## Summary by Sourcery

Make cookie lifetime for UI preference cookies explicit at call sites instead of relying on a global default.

Enhancements:
- Remove the global maxAge default from the shared cookie jar so server-owned cookies are not unintentionally made long-lived.
- Introduce a shared PREFERENCE_COOKIE_OPTS configuration for one-year UI preference cookies and apply it to layer state and track colour cookies.