### PR TITLE
Drop unused per-popup CSS class noise

### DIFF
--- a/frontend/search/SearchPopup.tsx
+++ b/frontend/search/SearchPopup.tsx
@@ -1,6 +1,7 @@
+import React from 'react'
+
 import { MissionId, isSpecificMission } from '../mission/MissionId'
 import { formatLocalDateTime } from '../format'
-import React from 'react'
 import { SMMSearchObjectDetailsData } from './types'
 import { PopupButtonGroup, ButtonItem } from '../popup'
 
@@ -13,22 +14,22 @@ interface Props {
 }
 
 export function SearchPopup({ search, missionId, status, onDelete, onQueueDialog }: Props) {
-  const rows = [
-    { css: 'type', label: 'Search Type', value: search.search_type },
-    { css: 'status', label: 'Status', value: status },
-    { css: 'sweep-width', label: 'Sweep Width', value: `${search.sweep_width}m` },
-    { css: 'asset-type', label: 'Asset Type', value: search.created_for }
+  const rows: { label: string; value: string }[] = [
+    { label: 'Search Type', value: search.search_type },
+    { label: 'Status', value: status },
+    { label: 'Sweep Width', value: `${search.sweep_width}m` },
+    { label: 'Asset Type', value: search.created_for }
   ]
   if (search.completed_by) {
-    rows.push({ css: 'completed', label: 'Completed By', value: search.completed_by })
+    rows.push({ label: 'Completed By', value: search.completed_by })
   } else if (search.inprogress_by) {
-    rows.push({ css: 'inprogress', label: 'Inprogress By', value: search.inprogress_by })
+    rows.push({ label: 'Inprogress By', value: search.inprogress_by })
   }
   if (search.inprogress_at) {
-    rows.push({ css: 'inprogress', label: 'Search Started', value: formatLocalDateTime(search.inprogress_at) })
+    rows.push({ label: 'Search Started', value: formatLocalDateTime(search.inprogress_at) })
   }
   if (search.completed_at) {
-    rows.push({ css: 'completed', label: 'Search Completed', value: formatLocalDateTime(search.completed_at) })
+    rows.push({ label: 'Search Completed', value: formatLocalDateTime(search.completed_at) })
   }
 
   const buttons: ButtonItem[] = []
@@ -44,11 +45,11 @@ export function SearchPopup({ search, missionId, status, onDelete, onQueueDialog
 
   return (
     <div>
-      <dl className="search-data row">
-        {rows.map(({ css, label, value }) => (
+      <dl className="row">
+        {rows.map(({ label, value }) => (
           <React.Fragment key={label}>
-            <dt className={`search-${css}-label col-sm-6`}>{label}</dt>
-            <dd className={`search-${css}-value col-sm-6`}>{value}</dd>
+            <dt className="col-sm-6">{label}</dt>
+            <dd className="col-sm-6">{value}</dd>
           </React.Fragment>
         ))}
       </dl>

--- a/frontend/usergeo/POIPopup.tsx
+++ b/frontend/usergeo/POIPopup.tsx
@@ -30,7 +30,7 @@ export function POIPopup({ label, coords, pk, missionId, onEdit, onDelete, onCre
     : []
   return (
     <div>
-      <PopupDataList items={items} dlClass="poi row" />
+      <PopupDataList items={items} dlClass="row" />
       {buttons.length > 0 && <PopupButtonGroup buttons={buttons} />}
     </div>
   )


### PR DESCRIPTION
## Description

SearchPopup attached search-${css}-label / search-${css}-value classes to every dt/dd, and POIPopup labelled its PopupDataList wrapper with the bespoke 'poi row' class. None of these classes are defined in any stylesheet (grep search-*-label / image-* / 'poi row' across our CSS returns nothing); they were dead markup.

Drop them: SearchPopup keeps only the Bootstrap col-sm-6 column utility on each dt/dd, and POIPopup uses the same 'row' class as the other popups. No visual change.

## Summary by Sourcery

Remove unused CSS-specific classes from search and POI popups to simplify markup without changing behavior or appearance.

Enhancements:
- Simplify SearchPopup row metadata by dropping unused CSS identifiers and retaining only label/value data.
- Use the shared Bootstrap row class for POIPopup markup instead of a bespoke, unused CSS class.