### PR TITLE
Rename snake_case and PascalCase props to camelCase

### DIFF
--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -52,10 +52,10 @@ function MissionDetails({ mission }: { mission: MissionData }) {
 type ExtRefField = 'name' | 'code' | 'url' | 'notes'
 
 interface MissionDetailsExternalReferencesRowProps {
-  ExternalReference: MissionExternalReferenceData
+  externalReference: MissionExternalReferenceData
 }
 
-function MissionDetailsExternalReferencesRow({ ExternalReference: extRef }: MissionDetailsExternalReferencesRowProps) {
+function MissionDetailsExternalReferencesRow({ externalReference: extRef }: MissionDetailsExternalReferencesRowProps) {
   const [editFields, setEditFields] = useState<Partial<Record<ExtRefField, boolean>>>({})
   const [values, setValues] = useState({
     name: extRef.name,
@@ -170,11 +170,11 @@ function MissionDetailsExternalReferenceAdd({ mission }: MissionDetailsExternalR
 }
 
 interface MissionDetailsExternalReferencesListProps {
-  ExternalReferences: Array<MissionExternalReferenceData>
+  externalReferences: Array<MissionExternalReferenceData>
   mission: number
 }
 
-function MissionDetailsExternalReferencesList({ ExternalReferences, mission }: MissionDetailsExternalReferencesListProps) {
+function MissionDetailsExternalReferencesList({ externalReferences, mission }: MissionDetailsExternalReferencesListProps) {
   return (
     <Table>
       <thead>
@@ -187,8 +187,8 @@ function MissionDetailsExternalReferencesList({ ExternalReferences, mission }: M
         </tr>
       </thead>
       <tbody>
-        {ExternalReferences.map((extRef) => (
-          <MissionDetailsExternalReferencesRow key={extRef.id} ExternalReference={extRef} />
+        {externalReferences.map((extRef) => (
+          <MissionDetailsExternalReferencesRow key={extRef.id} externalReference={extRef} />
         ))}
         <MissionDetailsExternalReferenceAdd mission={mission} />
       </tbody>
@@ -564,7 +564,7 @@ function MissionDetailPage({ missionId }: { missionId: number }) {
   return (
     <>
       <MissionDetails mission={missionDetails.mission} />
-      <MissionDetailsExternalReferencesList mission={missionId} ExternalReferences={missionDetails.external_references} />
+      <MissionDetailsExternalReferencesList mission={missionId} externalReferences={missionDetails.external_references} />
       <MissionDetailsOrganizationsList mission={missionId} missionOrganizations={missionDetails.mission_organizations} isAdmin={missionDetails.admin} />
       {missionDetails.can_add_organizations && <MissionDetailsOrganizationAdd mission={missionId} />}
       <MissionDetailsUsersList mission={missionId} me={missionDetails.me} missionUsers={missionDetails.mission_users} isAdmin={missionDetails.admin} />

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -20,26 +20,22 @@ const ROLE_NAME_TO_CODE: Record<string, string> = {
 
 interface OrganizationMemberRowProps {
   organizationId: number
-  organization_member: OrganizationMemberData
+  member: OrganizationMemberData
   showButtons: boolean
 }
 
-function OrganizationMemberRow({ organizationId, organization_member, showButtons }: OrganizationMemberRowProps) {
-  const [selectedRole, setSelectedRole] = useState(ROLE_NAME_TO_CODE[organization_member.role] ?? 'M')
+function OrganizationMemberRow({ organizationId, member, showButtons }: OrganizationMemberRowProps) {
+  const [selectedRole, setSelectedRole] = useState(ROLE_NAME_TO_CODE[member.role] ?? 'M')
 
   async function deleteRow() {
-    await smmDelete(`/organization/${organizationId}/user/${organization_member.user}/`)
+    await smmDelete(`/organization/${organizationId}/user/${member.user}/`)
   }
 
   function saveChanges() {
-    smmPost(`/organization/${organizationId}/user/${organization_member.user}/`, { role: selectedRole })
+    smmPost(`/organization/${organizationId}/user/${member.user}/`, { role: selectedRole })
   }
 
-  const dataFields = [
-    <td key="name">{organization_member.user}</td>,
-    <td key="created">{formatLocalDateTime(organization_member.added)}</td>,
-    <td key="creator">{organization_member.added_by}</td>
-  ]
+  const dataFields = [<td key="name">{member.user}</td>, <td key="created">{formatLocalDateTime(member.added)}</td>, <td key="creator">{member.added_by}</td>]
 
   if (showButtons) {
     dataFields.push(
@@ -62,25 +58,25 @@ function OrganizationMemberRow({ organizationId, organization_member, showButton
     )
   }
 
-  return <tr key={organization_member.id}>{dataFields}</tr>
+  return <tr key={member.id}>{dataFields}</tr>
 }
 
 interface OrganizationAssetRowProps {
   organizationId: number
-  organization_asset: OrganizationAssetData
+  asset: OrganizationAssetData
   showButtons: boolean
 }
 
-function OrganizationAssetRow({ organizationId, organization_asset, showButtons }: OrganizationAssetRowProps) {
+function OrganizationAssetRow({ organizationId, asset, showButtons }: OrganizationAssetRowProps) {
   async function deleteRow() {
-    await smmDelete(`/organization/${organizationId}/assets/${organization_asset.asset.id}/`)
+    await smmDelete(`/organization/${organizationId}/assets/${asset.asset.id}/`)
   }
 
   const dataFields = [
-    <td key="name">{organization_asset.asset.name}</td>,
-    <td key="status">{organization_asset.asset.status}</td>,
-    <td key="created">{formatLocalDateTime(organization_asset.added)}</td>,
-    <td key="creator">{organization_asset.added_by}</td>
+    <td key="name">{asset.asset.name}</td>,
+    <td key="status">{asset.asset.status}</td>,
+    <td key="created">{formatLocalDateTime(asset.added)}</td>,
+    <td key="creator">{asset.added_by}</td>
   ]
 
   if (showButtons) {
@@ -95,16 +91,16 @@ function OrganizationAssetRow({ organizationId, organization_asset, showButtons 
     )
   }
 
-  return <tr key={organization_asset.id}>{dataFields}</tr>
+  return <tr key={asset.id}>{dataFields}</tr>
 }
 
 interface OrganizationMemberListProps {
   organizationId: number
-  organization_members?: OrganizationMemberData[]
+  members?: OrganizationMemberData[]
   showButtons: boolean
 }
 
-function OrganizationMemberList({ organizationId, organization_members, showButtons }: OrganizationMemberListProps) {
+function OrganizationMemberList({ organizationId, members, showButtons }: OrganizationMemberListProps) {
   return (
     <Table responsive>
       <thead>
@@ -121,8 +117,8 @@ function OrganizationMemberList({ organizationId, organization_members, showButt
         </tr>
       </thead>
       <tbody>
-        {organization_members?.map((member) => (
-          <OrganizationMemberRow key={member.id} organizationId={organizationId} organization_member={member} showButtons={showButtons} />
+        {members?.map((member) => (
+          <OrganizationMemberRow key={member.id} organizationId={organizationId} member={member} showButtons={showButtons} />
         ))}
       </tbody>
     </Table>
@@ -176,10 +172,10 @@ function OrganizationMemberAdd({ organizationId }: { organizationId: number }) {
 
 interface OrganizationAssetListProps {
   organizationId: number
-  organization_assets?: OrganizationAssetData[]
+  assets?: OrganizationAssetData[]
 }
 
-function OrganizationAssetList({ organizationId, organization_assets }: OrganizationAssetListProps) {
+function OrganizationAssetList({ organizationId, assets }: OrganizationAssetListProps) {
   return (
     <Table responsive>
       <thead>
@@ -197,8 +193,8 @@ function OrganizationAssetList({ organizationId, organization_assets }: Organiza
         </tr>
       </thead>
       <tbody>
-        {organization_assets?.map((asset) => (
-          <OrganizationAssetRow key={asset.id} organizationId={organizationId} organization_asset={asset} showButtons />
+        {assets?.map((asset) => (
+          <OrganizationAssetRow key={asset.id} organizationId={organizationId} asset={asset} showButtons />
         ))}
       </tbody>
     </Table>
@@ -282,18 +278,13 @@ function OrganizationDetailsPage({ organizationId, updateRadioOperator }: Organi
         <OrganizationListRow organization={organizationDetails} showButtons={false} />
       </tbody>
     </Table>,
-    <OrganizationMemberList
-      key="org_members"
-      organizationId={organizationId}
-      organization_members={organizationDetails.members}
-      showButtons={organizationDetails.role === 'Admin'}
-    />
+    <OrganizationMemberList key="org_members" organizationId={organizationId} members={organizationDetails.members} showButtons={organizationDetails.role === 'Admin'} />
   ]
 
   if (organizationDetails.role === 'Admin') {
     sections.push(<OrganizationMemberAdd key="org_add_member" organizationId={organizationId} />)
   }
-  sections.push(<OrganizationAssetList key="org_assets" organizationId={organizationId} organization_assets={organizationDetails.assets} />)
+  sections.push(<OrganizationAssetList key="org_assets" organizationId={organizationId} assets={organizationDetails.assets} />)
   sections.push(<OrganizationAssetAdd key="org_asset_add" organizationId={organizationId} />)
 
   return <div>{sections}</div>


### PR DESCRIPTION
## Description

OrganizationMemberRow / OrganizationAssetRow / OrganizationMemberList / OrganizationAssetList carried backend-styled snake_case props (organization_member, organization_asset, organization_members, organization_assets) into the JSX layer. Rename them to plain camelCase (member, asset, members, assets); the underlying backend field names on the data objects are left alone.

MissionDetailsExternalReferencesRow / List used PascalCase (ExternalReference, ExternalReferences) - rename to camelCase too.

No runtime change.

## Summary by Sourcery

Rename frontend React component props from snake_case and PascalCase to camelCase for organization members/assets and mission external references.

Enhancements:
- Align organization member and asset component props to camelCase naming for consistency with JSX conventions.
- Standardize mission external reference component props to camelCase without changing underlying backend field names.