### PR TITLE
Distinguish loading from empty on the list pages

### DIFF
--- a/frontend/asset/list.tsx
+++ b/frontend/asset/list.tsx
@@ -6,6 +6,7 @@ import { Table, Button, ButtonGroup } from 'react-bootstrap'
 import { smmGetJSON } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
+import { Loading } from '../components/Loading'
 import { AssetData } from './types'
 
 interface AssetListRowProps {
@@ -56,12 +57,16 @@ function AssetList({ assets }: { assets: AssetData[] }) {
 }
 
 function AssetListPage() {
-  const [assets, setAssets] = useState<AssetData[]>([])
+  const [assets, setAssets] = useState<AssetData[] | undefined>(undefined)
 
   usePolling(async () => {
     const data = await smmGetJSON<{ assets: AssetData[] }>('/assets/', {})
     setAssets(data.assets)
   }, 10000)
+
+  if (assets === undefined) {
+    return <Loading />
+  }
 
   return (
     <div>

--- a/frontend/asset/type_list.tsx
+++ b/frontend/asset/type_list.tsx
@@ -6,6 +6,7 @@ import { Table } from 'react-bootstrap'
 import { smmGetJSON } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
+import { Loading } from '../components/Loading'
 import { AssetTypeData } from './types'
 
 function AssetTypeListRow({ assetType }: { assetType: AssetTypeData }) {
@@ -39,12 +40,16 @@ function AssetTypeList({ assetTypes }: { assetTypes: AssetTypeData[] }) {
 }
 
 function AssetTypeListPage() {
-  const [assetTypes, setAssetTypes] = useState<AssetTypeData[]>([])
+  const [assetTypes, setAssetTypes] = useState<AssetTypeData[] | undefined>(undefined)
 
   usePolling(async () => {
     const data = await smmGetJSON<{ asset_types: AssetTypeData[] }>('/assets/assettypes/', {})
     setAssetTypes(data.asset_types)
   }, 10000)
+
+  if (assetTypes === undefined) {
+    return <Loading />
+  }
 
   return (
     <div>

--- a/frontend/components/Loading.tsx
+++ b/frontend/components/Loading.tsx
@@ -1,0 +1,8 @@
+import type { ReactNode } from 'react'
+
+/** Minimal "loading" indicator for top-level pages. Use while the
+ *  initial data fetch is in flight so an empty result is visually
+ *  distinct from data not yet arrived. */
+export function Loading({ children = 'Loading ...' }: { children?: ReactNode }) {
+  return <div className="text-muted">{children}</div>
+}

--- a/frontend/icons/list.tsx
+++ b/frontend/icons/list.tsx
@@ -6,6 +6,7 @@ import { Table } from 'react-bootstrap'
 import { smmGetJSON } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
+import { Loading } from '../components/Loading'
 
 interface IconData {
   id: number
@@ -48,12 +49,16 @@ function IconList({ icons }: { icons: IconData[] }) {
 }
 
 function IconListPage() {
-  const [icons, setIcons] = useState<IconData[]>([])
+  const [icons, setIcons] = useState<IconData[] | undefined>(undefined)
 
   usePolling(async () => {
     const data = await smmGetJSON<{ icons: IconData[] }>('/icons/', {})
     setIcons(data.icons)
   }, 10000)
+
+  if (icons === undefined) {
+    return <Loading />
+  }
 
   return (
     <div>

--- a/frontend/mission/list.tsx
+++ b/frontend/mission/list.tsx
@@ -7,6 +7,7 @@ import { formatLocalDateTime } from '../format'
 import { smmGetJSON } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
+import { Loading } from '../components/Loading'
 import { MissionData } from './types'
 
 interface MissionListRowProps {
@@ -114,7 +115,7 @@ function CompletedMissionList({ missions }: { missions: MissionData[] }) {
 }
 
 function MissionListPage() {
-  const [missions, setMissions] = useState<MissionData[]>([])
+  const [missions, setMissions] = useState<MissionData[] | undefined>(undefined)
 
   usePolling(async () => {
     const data = await smmGetJSON<{ missions: MissionData[] }>('/mission/list/', {})
@@ -123,11 +124,15 @@ function MissionListPage() {
 
   const { active, closed } = useMemo(
     () => ({
-      active: missions.filter((m) => !m.closed),
-      closed: missions.filter((m) => m.closed)
+      active: missions?.filter((m) => !m.closed) ?? [],
+      closed: missions?.filter((m) => m.closed) ?? []
     }),
     [missions]
   )
+
+  if (missions === undefined) {
+    return <Loading />
+  }
 
   return (
     <div>

--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -7,6 +7,7 @@ import { formatLocalDateTime } from '../format'
 import { smmGetJSON, smmPost } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
+import { Loading } from '../components/Loading'
 import { OrganizationData } from './types'
 
 interface OrganizationListRowProps {
@@ -115,7 +116,7 @@ function OrganizationAdd() {
 }
 
 function OrganizationListPage() {
-  const [organizations, setOrganizations] = useState<OrganizationData[]>([])
+  const [organizations, setOrganizations] = useState<OrganizationData[] | undefined>(undefined)
 
   usePolling(async () => {
     try {
@@ -125,6 +126,10 @@ function OrganizationListPage() {
       console.error('Failed to fetch organizations:', e)
     }
   }, 10000)
+
+  if (organizations === undefined) {
+    return <Loading />
+  }
 
   return (
     <div>


### PR DESCRIPTION
## Description

Each list page initialised its data state to an empty array, so the first paint of an empty result and the not-yet-loaded paint looked identical (an empty table). Switch the five top-level list pages (mission, asset, asset-type, icon, organization) to undefined-as- loading and render a small <Loading /> component until the first fetch resolves; only then drop into the list components, which now trust that they always receive real data.

## Summary by Sourcery

Distinguish initial loading state from genuinely empty results across top-level list pages by introducing a shared loading indicator and deferring list rendering until data is fetched.

New Features:
- Add a reusable Loading component for displaying a minimal loading indicator on top-level pages while data is being fetched.

Enhancements:
- Update mission, asset, asset-type, icon, and organization list pages to treat undefined data as a loading state and render the loading indicator before showing list contents.