### PR TITLE
Add mountPopup helper and route every feature popup through it

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -3,7 +3,6 @@ import L from 'leaflet'
 
 import { SMMRealtime } from '../smmmap'
 import '@canterbury-air-patrol/leaflet-dialog'
-import * as ReactDOM from 'react-dom/client'
 import { cookieJar, PREFERENCE_COOKIE_OPTS } from '../cookies'
 import { MissionAssetSummary, AssetPointTime } from './types'
 
@@ -12,6 +11,7 @@ import { AssetPopup } from './AssetPopup'
 import { ColorPickerDialog } from './ColorPickerDialog'
 import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 import { buildSwatchLabel } from '../components/swatchLabel'
+import { mountPopup } from '../components/mountPopup'
 
 class SMMAsset {
   map: L.Map
@@ -94,12 +94,12 @@ class SMMAssets extends SMMRealtime {
   assetNameMap: { [key: number]: string }
   assetIconMap: { [key: number]: string }
   assetStatusMap: { [key: number]: { status: string; notes: string } }
-  popupRoots: { [key: number]: ReactDOM.Root }
+  popups: { [key: number]: ReturnType<typeof mountPopup> }
   constructor(map: L.Map, missionId: MissionId, interval: number, color: string, overlayAdd: (name: string | HTMLElement, overlay: L.Layer) => void) {
     super(map, missionId, interval, color)
     this.overlayAdd = overlayAdd
     this.assetObjects = {}
-    this.popupRoots = {}
+    this.popups = {}
     this.createPopup = this.createPopup.bind(this)
     this.assetUpdate = this.assetUpdate.bind(this)
     this.assetLayer = this.assetLayer.bind(this)
@@ -158,15 +158,9 @@ class SMMAssets extends SMMRealtime {
 
   createPopup(asset: { properties: { asset: number }; geometry: { coordinates: [number, number] } }, layer: L.Layer) {
     const assetId = asset.properties.asset
-    const container = document.createElement('div')
-    const root = ReactDOM.createRoot(container)
-    this.popupRoots[assetId] = root
-    root.render(<AssetPopup assetName={String(assetId)} coords={asset.geometry.coordinates} />)
-    layer.bindPopup(container, { minWidth: 200 })
-    layer.once('remove', () => {
-      root.unmount()
-      delete this.popupRoots[assetId]
-    })
+    this.popups[assetId]?.unmount()
+    this.popups[assetId] = mountPopup(layer, <AssetPopup assetName={String(assetId)} coords={asset.geometry.coordinates} />, { minWidth: 200 })
+    layer.once('remove', () => delete this.popups[assetId])
   }
 
   assetPathUpdate(assetId: number) {
@@ -189,7 +183,7 @@ class SMMAssets extends SMMRealtime {
 
     const coords = asset.geometry.coordinates as [number, number]
     const { alt, heading, fix } = asset.properties
-    this.popupRoots[assetId]?.render(
+    this.popups[assetId]?.rerender(
       <AssetPopup
         assetName={this.assetNameMap[assetId]}
         coords={coords}

--- a/frontend/components/mountPopup.ts
+++ b/frontend/components/mountPopup.ts
@@ -1,0 +1,44 @@
+import * as ReactDOM from 'react-dom/client'
+import type { ReactElement } from 'react'
+import type L from 'leaflet'
+
+interface MountedPopup {
+  /** The DOM node the popup binds to. Don't touch its contents directly. */
+  container: HTMLElement
+  /** Replace the popup body with a new React element. Safe to call any
+   *  number of times; reuses the same root and so the same DOM subtree. */
+  rerender(element: ReactElement): void
+  /** Drop the popup root explicitly. Normally called for you when the
+   *  layer is removed; safe to call again afterwards (idempotent). */
+  unmount(): void
+}
+
+/**
+ * Render React into a popup attached to `layer`. Every feature-popup
+ * creator used to hand-roll this dance with subtly different lifecycle
+ * handling; consolidate it so the unmount is always idempotent, the
+ * remove listener is always `once`, and a follow-up rerender reuses the
+ * existing root instead of leaking a new one.
+ */
+export function mountPopup(layer: L.Layer, element: ReactElement, options?: L.PopupOptions): MountedPopup {
+  const container = document.createElement('div')
+  const root = ReactDOM.createRoot(container)
+  root.render(element)
+  layer.bindPopup(container, options)
+
+  let unmounted = false
+  const unmount = () => {
+    if (unmounted) return
+    unmounted = true
+    root.unmount()
+  }
+  layer.once('remove', unmount)
+
+  return {
+    container,
+    rerender: (next: ReactElement) => {
+      if (!unmounted) root.render(next)
+    },
+    unmount
+  }
+}

--- a/frontend/image/map.tsx
+++ b/frontend/image/map.tsx
@@ -1,11 +1,11 @@
 import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
-import * as ReactDOM from 'react-dom/client'
 
 import { SMMRealtime } from '../smmmap'
 import { SMMImageGeoJSON } from './types'
 import { smmPatch } from '../ajax'
 import { ImagePopup } from './ImagePopup'
+import { mountPopup } from '../components/mountPopup'
 
 abstract class SMMImage extends SMMRealtime {
   constructor(map: L.Map, missionId: MissionId, interval: number, color: string) {
@@ -27,10 +27,9 @@ abstract class SMMImage extends SMMRealtime {
   }
 
   createPopup(image: SMMImageGeoJSON, layer: L.Layer) {
-    const container = document.createElement('div')
-    const root = ReactDOM.createRoot(container)
     const imageID = image.properties.pk
-    root.render(
+    mountPopup(
+      layer,
       <ImagePopup
         description={image.properties.description}
         pk={imageID}
@@ -41,8 +40,6 @@ abstract class SMMImage extends SMMRealtime {
         onDeprioritize={() => smmPatch(`/image/${imageID}/priority/`, { priority: false })}
       />
     )
-    layer.bindPopup(container)
-    layer.once('remove', () => root.unmount())
   }
 }
 

--- a/frontend/marine/vectors.tsx
+++ b/frontend/marine/vectors.tsx
@@ -1,11 +1,11 @@
 import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
-import * as ReactDOM from 'react-dom/client'
 
 import { SMMRealtime } from '../smmmap'
 import { TotalDriftVectorData } from './types'
 import { smmDelete } from '../ajax'
 import { MarineVectorPopup } from './MarineVectorPopup'
+import { mountPopup } from '../components/mountPopup'
 
 class SMMMarineVector extends SMMRealtime {
   constructor(map: L.Map, missionId: MissionId, interval: number, color: string) {
@@ -20,12 +20,7 @@ class SMMMarineVector extends SMMRealtime {
 
   createPopup(tdv: { properties: TotalDriftVectorData }, layer: L.Layer) {
     const tdvID = tdv.properties.pk
-
-    const container = document.createElement('div')
-    const root = ReactDOM.createRoot(container)
-    root.render(<MarineVectorPopup pk={tdvID} missionId={this.missionId} onDelete={() => smmDelete(`/sar/marine/vectors/${tdvID}/`)} />)
-    layer.bindPopup(container)
-    layer.once('remove', () => root.unmount())
+    mountPopup(layer, <MarineVectorPopup pk={tdvID} missionId={this.missionId} onDelete={() => smmDelete(`/sar/marine/vectors/${tdvID}/`)} />)
   }
 }
 

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -10,12 +10,13 @@ import { SMMSearchObjectDetailsData } from './types'
 import { smmDelete } from '../ajax'
 import { SearchQueueDialog } from './SearchQueueDialog'
 import { SearchPopup } from './SearchPopup'
+import { mountPopup } from '../components/mountPopup'
 
 class SMMSearch {
   parent: SMMSearches
   search: SMMSearchObjectDetailsData
   QueueDialog?: L.Control.Dialog
-  popupRoot?: ReactDOM.Root
+  private popup?: ReturnType<typeof mountPopup>
   constructor(parent: SMMSearches, search: SMMSearchObjectDetailsData) {
     this.parent = parent
     this.search = search
@@ -52,26 +53,18 @@ class SMMSearch {
   }
 
   createPopup(layer: L.Layer) {
-    this.popupRoot?.unmount()
-    const container = document.createElement('div')
-    const root = ReactDOM.createRoot(container)
-    this.popupRoot = root
-    root.render(
+    this.popup?.unmount()
+    this.popup = mountPopup(
+      layer,
       <SearchPopup
         search={this.search}
         missionId={this.parent.missionId}
         status={this.parent.searchStatus(this.search)}
         onDelete={this.deleteCallback}
         onQueueDialog={this.searchQueueDialog}
-      />
+      />,
+      { minWidth: 200 }
     )
-    layer.bindPopup(container, { minWidth: 200 })
-    layer.once('remove', () => {
-      root.unmount()
-      if (this.popupRoot === root) {
-        this.popupRoot = undefined
-      }
-    })
   }
 }
 

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -2,7 +2,6 @@ import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 
 import { SMMRealtime } from '../smmmap'
-import * as ReactDOM from 'react-dom/client'
 import { cookieJar, PREFERENCE_COOKIE_OPTS } from '../cookies'
 import { smmGetJSON } from '../ajax'
 import { SMMMissionUserPointTimeGeoJSON } from './types'
@@ -10,6 +9,7 @@ import { UserPopup } from './UserPopup'
 import { ColorPickerDialog } from '../asset/ColorPickerDialog'
 import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 import { buildSwatchLabel } from '../components/swatchLabel'
+import { mountPopup } from '../components/mountPopup'
 
 class SMMUserPosition {
   map: L.Map
@@ -17,7 +17,7 @@ class SMMUserPosition {
   userName: string
   color: string
   swatch?: HTMLElement
-  popupRoot?: ReactDOM.Root
+  popup?: ReturnType<typeof mountPopup>
   lastUpdate?: string
   path: L.LatLng[]
   updating: boolean
@@ -121,14 +121,10 @@ class SMMUserPositions extends SMMRealtime {
   createPopup(user: SMMMissionUserPointTimeGeoJSON, layer: L.Layer) {
     const userName = user.properties.user
     const userObject = this.createUser(userName)
-    const container = document.createElement('div')
-    const root = ReactDOM.createRoot(container)
-    userObject.popupRoot = root
-    root.render(<UserPopup userName={userName} />)
-    layer.bindPopup(container, { minWidth: 200 })
+    userObject.popup?.unmount()
+    userObject.popup = mountPopup(layer, <UserPopup userName={userName} />, { minWidth: 200 })
     layer.once('remove', () => {
-      root.unmount()
-      userObject.popupRoot = undefined
+      userObject.popup = undefined
     })
   }
 
@@ -153,7 +149,7 @@ class SMMUserPositions extends SMMRealtime {
     const coords = user.geometry.coordinates as [number, number]
     const { alt } = user.properties
 
-    this.userObjects[userName]?.popupRoot?.render(<UserPopup userName={userName} coords={coords} alt={alt} />)
+    this.userObjects[userName]?.popup?.rerender(<UserPopup userName={userName} coords={coords} alt={alt} />)
 
     if (user.geometry.type === 'Point') {
       const c = user.geometry.coordinates

--- a/frontend/usergeo/base.tsx
+++ b/frontend/usergeo/base.tsx
@@ -1,21 +1,21 @@
 import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 import React from 'react'
-import * as ReactDOM from 'react-dom/client'
 
 import { smmDelete } from '../ajax'
 import { SMMRealtime } from '../smmmap'
+import { mountPopup } from '../components/mountPopup'
 import { SMMUserGeoLabelData } from './types'
 
 /**
  * Abstract base for per-feature geo objects (SMMPOI, SMMLine, SMMPolygon).
- * Handles deleteCallback and the createPopup lifecycle (container, root, bind, unmount).
+ * Handles deleteCallback and the createPopup lifecycle via mountPopup.
  */
 abstract class SMMUserGeoLayer {
   map: L.Map
   missionId: MissionId
   data: SMMUserGeoLabelData
-  popupRoot?: ReactDOM.Root
+  private popup?: ReturnType<typeof mountPopup>
 
   constructor(map: L.Map, missionId: MissionId, data: SMMUserGeoLabelData) {
     this.map = map
@@ -39,18 +39,8 @@ abstract class SMMUserGeoLayer {
   }
 
   createPopup(layer: L.Layer) {
-    this.popupRoot?.unmount()
-    const container = document.createElement('div')
-    const root = ReactDOM.createRoot(container)
-    this.popupRoot = root
-    root.render(this.renderPopup())
-    layer.bindPopup(container, this.getPopupOptions())
-    layer.once('remove', () => {
-      root.unmount()
-      if (this.popupRoot === root) {
-        this.popupRoot = undefined
-      }
-    })
+    this.popup?.unmount()
+    this.popup = mountPopup(layer, this.renderPopup(), this.getPopupOptions())
   }
 }
 


### PR DESCRIPTION
## Description

Six call sites (asset, user, search, image, marine vector, usergeo base) each hand-rolled their own ReactDOM.createRoot + bindPopup + layer.once('remove', ...) sequence, with subtly different lifecycle handling: some kept a popupRoot field on the cached feature so the realtime updater could rerender, some unmounted defensively before recreating, some relied on layer.once but used layer.on, ...

Introduce frontend/components/mountPopup.ts that returns { container, rerender, unmount }. The unmount is idempotent and the layer.once('remove', ...) is always attached. Asset/user feature classes hold the returned handle and call rerender from their realtime updateFeature instead of poking root.render directly.

## Summary by Sourcery

Introduce a shared helper for mounting React-based Leaflet popups and route existing feature popups through it for consistent lifecycle handling.

Enhancements:
- Refactor asset, user, search, image, marine vector, and usergeo feature popups to use a common mountPopup helper instead of hand-rolled ReactDOM root and bindPopup logic.
- Ensure popup unmounting is idempotent and consistently tied to Leaflet layer removal, while allowing safe rerendering of popup contents for realtime updates.