### PR TITLE
Fix Misssion typo in MissionHeader

### DIFF
--- a/frontend/mission/header.tsx
+++ b/frontend/mission/header.tsx
@@ -12,7 +12,7 @@ function MissionHeader({ mission }: MissionHeaderProps) {
     <Table responsive>
       <thead>
         <tr>
-          <td>Misssion</td>
+          <td>Mission</td>
           <td>Created</td>
           <td>By</td>
           <td>Closed</td>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix a typo in the MissionHeader table column label from 'Misssion' to 'Mission'.