### PR TITLE
Match Organization list heading colSpan to column count

### DIFF
--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -56,7 +56,7 @@ function OrganizationList({ organizations, showButtons }: OrganizationListProps)
     <Table responsive>
       <thead>
         <tr key="heading">
-          <th colSpan={4} align="center">
+          <th colSpan={5} align="center">
             Current Organizations
           </th>
         </tr>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix mismatch between the organization table heading colSpan and the actual number of columns.