### PR TITLE
Use explicit null check for command response timestamp

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -139,7 +139,7 @@ function AssetCommandView({ asset, lastCommand }: AssetCommandViewProps) {
   const responseData = []
   const response = lastCommand?.response
   if (response) {
-    if (response.set) {
+    if (response.set != null) {
       responseData.push(
         <tr key="response">
           <td>


### PR DESCRIPTION
## Description

Restores the original semantics where only undefined/null `response.set` means "no response yet" - truthiness conflated an empty timestamp with a missing one and could have suppressed a present response form.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect suppression of command responses when the response timestamp is present but falsy.