### PR TITLE
Make AssetStatus select controlled so polling updates show

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -367,7 +367,6 @@ function AssetStatus({ asset, details }: AssetStatusProps) {
       value_id: selectedValueId,
       notes
     })
-    setSelectedValueId(undefined)
     setNotes('')
   }
 
@@ -395,7 +394,7 @@ function AssetStatus({ asset, details }: AssetStatusProps) {
         <tr>
           <td>Status:</td>
           <td>
-            <select onChange={(e: ChangeEvent<HTMLSelectElement>) => setSelectedValueId(Number(e.target.value))} defaultValue={selectedValueId}>
+            <select onChange={(e: ChangeEvent<HTMLSelectElement>) => setSelectedValueId(Number(e.target.value))} value={selectedValueId ?? ''}>
               {statusValues.map((v) => (
                 <option key={v.id} value={v.id}>
                   {v.name}


### PR DESCRIPTION
## Description

Switching from defaultValue to value keeps the rendered selection in sync with state. Also keeps the user's choice across a submit instead of resetting selectedValueId to undefined, which used to leave the UI showing the old option while the next submission posted undefined.

## Summary by Sourcery

Bug Fixes:
- Preserve the selected asset status across form submissions instead of resetting to an undefined value that could cause incorrect status to be posted.