### PR TITLE
Contain errors thrown by usePolling callbacks

### DIFF
--- a/frontend/hooks/usePolling.ts
+++ b/frontend/hooks/usePolling.ts
@@ -20,7 +20,14 @@ export function usePolling(fn: () => void | Promise<void>, intervalMs: number) {
     let cancelled = false
 
     const tick = () => {
-      if (!cancelled) fnRef.current()
+      if (cancelled) return
+      try {
+        Promise.resolve(fnRef.current()).catch((err) => {
+          console.error('usePolling callback rejected', err)
+        })
+      } catch (err) {
+        console.error('usePolling callback threw', err)
+      }
     }
 
     tick()


### PR DESCRIPTION
## Description

Sync throws and promise rejections from the polling callback now log instead of escaping as unhandled rejections, so a transient failure doesn't take down the polling loop or pollute the console with unhelpful warnings.

## Summary by Sourcery

Bug Fixes:
- Prevent unhandled synchronous throws and promise rejections from usePolling callbacks from terminating the polling loop or surfacing as unhandled rejection warnings.