### PR TITLE
Surface fetch failures on top-level list pages

### DIFF
--- a/frontend/asset/list.tsx
+++ b/frontend/asset/list.tsx
@@ -6,7 +6,7 @@ import { Table, Button, ButtonGroup } from 'react-bootstrap'
 import { smmGetJSON } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
-import { Loading } from '../components/Loading'
+import { Loading, LoadFailed } from '../components/Loading'
 import { AssetData } from './types'
 
 interface AssetListRowProps {
@@ -58,14 +58,21 @@ function AssetList({ assets }: { assets: AssetData[] }) {
 
 function AssetListPage() {
   const [assets, setAssets] = useState<AssetData[] | undefined>(undefined)
+  const [loadFailed, setLoadFailed] = useState(false)
 
   usePolling(async () => {
-    const data = await smmGetJSON<{ assets: AssetData[] }>('/assets/', {})
-    setAssets(data.assets)
+    try {
+      const data = await smmGetJSON<{ assets: AssetData[] }>('/assets/', {})
+      setAssets(data.assets)
+      setLoadFailed(false)
+    } catch (e) {
+      console.error('Failed to fetch assets:', e)
+      setLoadFailed(true)
+    }
   }, 10000)
 
   if (assets === undefined) {
-    return <Loading />
+    return loadFailed ? <LoadFailed /> : <Loading />
   }
 
   return (

--- a/frontend/asset/type_list.tsx
+++ b/frontend/asset/type_list.tsx
@@ -6,7 +6,7 @@ import { Table } from 'react-bootstrap'
 import { smmGetJSON } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
-import { Loading } from '../components/Loading'
+import { Loading, LoadFailed } from '../components/Loading'
 import { AssetTypeData } from './types'
 
 function AssetTypeListRow({ assetType }: { assetType: AssetTypeData }) {
@@ -41,14 +41,21 @@ function AssetTypeList({ assetTypes }: { assetTypes: AssetTypeData[] }) {
 
 function AssetTypeListPage() {
   const [assetTypes, setAssetTypes] = useState<AssetTypeData[] | undefined>(undefined)
+  const [loadFailed, setLoadFailed] = useState(false)
 
   usePolling(async () => {
-    const data = await smmGetJSON<{ asset_types: AssetTypeData[] }>('/assets/assettypes/', {})
-    setAssetTypes(data.asset_types)
+    try {
+      const data = await smmGetJSON<{ asset_types: AssetTypeData[] }>('/assets/assettypes/', {})
+      setAssetTypes(data.asset_types)
+      setLoadFailed(false)
+    } catch (e) {
+      console.error('Failed to fetch asset types:', e)
+      setLoadFailed(true)
+    }
   }, 10000)
 
   if (assetTypes === undefined) {
-    return <Loading />
+    return loadFailed ? <LoadFailed /> : <Loading />
   }
 
   return (

--- a/frontend/components/Loading.tsx
+++ b/frontend/components/Loading.tsx
@@ -6,3 +6,9 @@ import type { ReactNode } from 'react'
 export function Loading({ children = 'Loading ...' }: { children?: ReactNode }) {
   return <div className="text-muted">{children}</div>
 }
+
+/** Companion to Loading: shown when the first fetch has failed so the
+ *  page does not sit on "Loading ..." indefinitely. */
+export function LoadFailed({ children = 'Failed to load. Retrying ...' }: { children?: ReactNode }) {
+  return <div className="text-danger">{children}</div>
+}

--- a/frontend/icons/list.tsx
+++ b/frontend/icons/list.tsx
@@ -6,7 +6,7 @@ import { Table } from 'react-bootstrap'
 import { smmGetJSON } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
-import { Loading } from '../components/Loading'
+import { Loading, LoadFailed } from '../components/Loading'
 
 interface IconData {
   id: number
@@ -50,14 +50,21 @@ function IconList({ icons }: { icons: IconData[] }) {
 
 function IconListPage() {
   const [icons, setIcons] = useState<IconData[] | undefined>(undefined)
+  const [loadFailed, setLoadFailed] = useState(false)
 
   usePolling(async () => {
-    const data = await smmGetJSON<{ icons: IconData[] }>('/icons/', {})
-    setIcons(data.icons)
+    try {
+      const data = await smmGetJSON<{ icons: IconData[] }>('/icons/', {})
+      setIcons(data.icons)
+      setLoadFailed(false)
+    } catch (e) {
+      console.error('Failed to fetch icons:', e)
+      setLoadFailed(true)
+    }
   }, 10000)
 
   if (icons === undefined) {
-    return <Loading />
+    return loadFailed ? <LoadFailed /> : <Loading />
   }
 
   return (

--- a/frontend/mission/list.tsx
+++ b/frontend/mission/list.tsx
@@ -7,7 +7,7 @@ import { formatLocalDateTime } from '../format'
 import { smmGetJSON } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
-import { Loading } from '../components/Loading'
+import { Loading, LoadFailed } from '../components/Loading'
 import { MissionData } from './types'
 
 interface MissionListRowProps {
@@ -116,10 +116,17 @@ function CompletedMissionList({ missions }: { missions: MissionData[] }) {
 
 function MissionListPage() {
   const [missions, setMissions] = useState<MissionData[] | undefined>(undefined)
+  const [loadFailed, setLoadFailed] = useState(false)
 
   usePolling(async () => {
-    const data = await smmGetJSON<{ missions: MissionData[] }>('/mission/list/', {})
-    setMissions(data.missions)
+    try {
+      const data = await smmGetJSON<{ missions: MissionData[] }>('/mission/list/', {})
+      setMissions(data.missions)
+      setLoadFailed(false)
+    } catch (e) {
+      console.error('Failed to fetch missions:', e)
+      setLoadFailed(true)
+    }
   }, 10000)
 
   const { active, closed } = useMemo(
@@ -131,7 +138,7 @@ function MissionListPage() {
   )
 
   if (missions === undefined) {
-    return <Loading />
+    return loadFailed ? <LoadFailed /> : <Loading />
   }
 
   return (

--- a/frontend/organization/list.tsx
+++ b/frontend/organization/list.tsx
@@ -7,7 +7,7 @@ import { formatLocalDateTime } from '../format'
 import { smmGetJSON, smmPost } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
-import { Loading } from '../components/Loading'
+import { Loading, LoadFailed } from '../components/Loading'
 import { OrganizationData } from './types'
 
 interface OrganizationListRowProps {
@@ -117,18 +117,21 @@ function OrganizationAdd() {
 
 function OrganizationListPage() {
   const [organizations, setOrganizations] = useState<OrganizationData[] | undefined>(undefined)
+  const [loadFailed, setLoadFailed] = useState(false)
 
   usePolling(async () => {
     try {
       const data = await smmGetJSON<{ organizations: OrganizationData[] }>('/organization/', {})
       setOrganizations(data.organizations)
+      setLoadFailed(false)
     } catch (e) {
       console.error('Failed to fetch organizations:', e)
+      setLoadFailed(true)
     }
   }, 10000)
 
   if (organizations === undefined) {
-    return <Loading />
+    return loadFailed ? <LoadFailed /> : <Loading />
   }
 
   return (


### PR DESCRIPTION
## Description

A failed first poll left every list page on "Loading ..." forever. Add a shared LoadFailed component and toggle a per-page loadFailed flag in the polling catch so users see a "Failed to load. Retrying ..." state until a subsequent poll succeeds.

## Summary by Sourcery

Indicate initial load failures on top-level list pages instead of leaving them in a perpetual loading state.

Bug Fixes:
- Prevent asset, asset type, icon, mission, and organization list pages from remaining stuck on a loading indicator when the first polling request fails.

Enhancements:
- Introduce a shared LoadFailed component to show a retrying error state alongside existing loading indicators.