### PR TITLE
Surface search begin/finish failures inline

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -224,12 +224,17 @@ interface AssetMissionDetailsProps {
 
 function CurrentSearchRow({ details, onAction }: { details: AssetFullStatusData; onAction?: () => void }) {
   const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   async function markComplete() {
     setBusy(true)
+    setError(null)
     try {
       await smmPost(`/search/${details.current_search_id}/finished/`, { asset_id: details.asset_id })
       onAction?.()
+    } catch (e) {
+      console.error('Failed to mark search as completed:', e)
+      setError('Failed - try again')
     } finally {
       setBusy(false)
     }
@@ -247,6 +252,7 @@ function CurrentSearchRow({ details, onAction }: { details: AssetFullStatusData;
           <Button onClick={markComplete} disabled={busy}>
             Mark as Completed
           </Button>
+          {error && <span className="text-danger ms-2">{error}</span>}
         </td>
       </tr>
     )
@@ -265,12 +271,17 @@ function CurrentSearchRow({ details, onAction }: { details: AssetFullStatusData;
 
 function QueuedSearchRow({ details, onAction }: { details: AssetFullStatusData; onAction?: () => void }) {
   const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   async function begin() {
     setBusy(true)
+    setError(null)
     try {
       await smmPost(`/search/${details.queued_search_id}/begin/`, { asset_id: details.asset_id })
       onAction?.()
+    } catch (e) {
+      console.error('Failed to begin search:', e)
+      setError('Failed - try again')
     } finally {
       setBusy(false)
     }
@@ -289,6 +300,7 @@ function QueuedSearchRow({ details, onAction }: { details: AssetFullStatusData; 
           <Button onClick={begin} disabled={busy}>
             Begin Search
           </Button>
+          {error && <span className="text-danger ms-2">{error}</span>}
         </td>
       )
     } else {


### PR DESCRIPTION
## Description

Mark-as-completed and begin-search posts previously swallowed errors in a try/finally, so a failed POST looked identical to success until the next 10s poll. Catch the error, log it, and show a small inline "Failed - try again" notice next to the button so the user knows the action didn't take.

## Summary by Sourcery

Bug Fixes:
- Show an inline "Failed - try again" message when mark-as-completed or begin-search actions fail, so users know the operation did not succeed.