### PR TITLE
Discard stale dialog fetches when their inputs change

### DIFF
--- a/frontend/Admin/AssetCommandDialog.tsx
+++ b/frontend/Admin/AssetCommandDialog.tsx
@@ -29,13 +29,18 @@ export function AssetCommandDialog({ map, missionId, onClose }: Props) {
   const gotoPos = useRef<L.LatLng>(map.getCenter())
 
   useEffect(() => {
+    let cancelled = false
     smmGetJSON<CommandFormData>(`/mission/${missionId}/assets/command/set/`, {}).then((data) => {
+      if (cancelled) return
       setAssets(data.assets)
       setCommands(data.commands)
       setRequiresPosition(data.requires_position)
       if (data.assets.length > 0) setAssetId(String(data.assets[0].id))
       if (data.commands.length > 0) setCommand(data.commands[0].value)
     })
+    return () => {
+      cancelled = true
+    }
   }, [missionId])
 
   function handleSet() {

--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -18,11 +18,16 @@ export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: 
   const [selectedAssetId, setSelectedAssetId] = useState('')
 
   useEffect(() => {
+    let cancelled = false
     smmGetJSON<{ assets: Array<MissionAssetSummary> }>(`/mission/${missionId}/assets/`, {}).then((d) => {
+      if (cancelled) return
       const filtered = d.assets.filter((a) => a.type_name === createdFor)
       setAssets(filtered)
       if (filtered.length > 0) setSelectedAssetId(String(filtered[0].id))
     })
+    return () => {
+      cancelled = true
+    }
   }, [missionId, createdFor])
 
   async function handleQueue() {


### PR DESCRIPTION
## Description

Both dialogs fetch on mount and again whenever their key props change, but a slow response for an old missionId/createdFor could land after the props had moved on, overwriting newer state. Wrap each effect with a cancelled flag so late responses are ignored.

## Summary by Sourcery

Bug Fixes:
- Guard asset and search queue dialogs against late-arriving fetch responses overwriting newer state.