### PR TITLE
Narrow DateTimePicker onChange to Date instances

### DIFF
--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -47,7 +47,15 @@ function MissionTimeLineEntryAdd({ missionId }: MissionTimeLineEntryAddProps) {
         <tr>
           <td>
             Now: <input type="checkbox" checked={timeNow} onChange={(e: ChangeEvent<HTMLInputElement>) => setTimeNow(e.target.checked)} />{' '}
-            {!timeNow && <DateTimePicker onChange={(value) => value !== null && setSpecificDateTime(value)} value={specificDateTime} format="y-MM-dd HH:mm:ss" />}
+            {!timeNow && (
+              <DateTimePicker
+                onChange={(value) => {
+                  if (value instanceof Date) setSpecificDateTime(value)
+                }}
+                value={specificDateTime}
+                format="y-MM-dd HH:mm:ss"
+              />
+            )}
           </td>
           <td>
             <input type="text" value={message} onChange={(e: ChangeEvent<HTMLInputElement>) => setMessage(e.target.value)} />


### PR DESCRIPTION
## Description

react-datetime-picker's onChange is typed Date | Date[] | null. The old handler treated any non-null value as a Date, which would break if the picker was ever configured to return an array. Switch to an instanceof Date check so only single-date values flow through.

## Summary by Sourcery

Bug Fixes:
- Prevent mission timeline date-time selection from incorrectly treating non-null array values from the date-time picker as single Date instances.