### PR TITLE
Make IconControl keyboard-activatable and clean up its listeners

### DIFF
--- a/frontend/components/iconControl.ts
+++ b/frontend/components/iconControl.ts
@@ -14,28 +14,57 @@ interface IconControlOptions {
  * (POI / Line / Polygon / ImageUploader / Admin) share this shape, so
  * the boilerplate of L.Control.extend lives in one place.
  */
+interface IconControlInstance {
+  _link?: HTMLAnchorElement
+  _activate?: (ev: Event) => void
+  _onKeyDown?: (ev: Event) => void
+}
+
 export function createIconControl(opts: IconControlOptions): L.Control {
   const Ctrl = L.Control.extend({
     options: { position: opts.position ?? 'topleft' },
 
-    onAdd(map: L.Map) {
+    onAdd(this: IconControlInstance, map: L.Map) {
       const container = L.DomUtil.create('div', `${opts.cssPrefix}-container leaflet-bar`)
       const link = L.DomUtil.create('a', '', container)
       link.href = '#'
       link.title = opts.title
+      link.setAttribute('role', 'button')
+      link.tabIndex = 0
 
       const img = L.DomUtil.create('img', `${opts.cssPrefix}-marker`, link)
       img.src = opts.iconUrl
       img.alt = opts.title
 
+      const activate = (ev: Event) => {
+        L.DomEvent.stop(ev)
+        opts.onClick(map)
+      }
+      const onKeyDown = (ev: Event) => {
+        const key = (ev as KeyboardEvent).key
+        if (key === 'Enter' || key === ' ') activate(ev)
+      }
+
       L.DomEvent.disableClickPropagation(link)
-      L.DomEvent.on(link, 'click', L.DomEvent.stop)
-      L.DomEvent.on(link, 'click', () => opts.onClick(map))
+      L.DomEvent.on(link, 'click', activate)
+      L.DomEvent.on(link, 'keydown', onKeyDown)
+
+      this._link = link
+      this._activate = activate
+      this._onKeyDown = onKeyDown
 
       return container
     },
 
-    onRemove() {}
+    onRemove(this: IconControlInstance) {
+      if (this._link && this._activate && this._onKeyDown) {
+        L.DomEvent.off(this._link, 'click', this._activate)
+        L.DomEvent.off(this._link, 'keydown', this._onKeyDown)
+        this._link = undefined
+        this._activate = undefined
+        this._onKeyDown = undefined
+      }
+    }
   })
   return new Ctrl()
 }


### PR DESCRIPTION
## Description

Adds role/tabIndex so the bar control is reachable by Tab, handles Enter/Space the same as click, and unbinds both listeners in onRemove so re-adding the control does not stack handlers.

## Summary by Sourcery

Make the map icon control keyboard-accessible and ensure its DOM event listeners are correctly cleaned up when the control is removed.

New Features:
- Allow the icon control to be focused via keyboard and activated with Enter or Space as a button-like control.

Bug Fixes:
- Prevent duplicate event handlers from accumulating when the icon control is removed and re-added by unregistering its click and keydown listeners on removal.