### PR TITLE
Replace VendorVector any with structural interfaces

### DIFF
--- a/frontend/marine/leaflet.tsx
+++ b/frontend/marine/leaflet.tsx
@@ -15,8 +15,17 @@ interface CustomMarineVectorsProps {
   dialog: L.Control.Dialog
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type VendorVector = any
+interface CurrentVector {
+  timeFrom: Date
+  timeTo: Date
+  getVectorSpeed(): number
+  getVectorDirection(): number
+  getVectorDistance(): number
+}
+
+interface WindVector extends CurrentVector {
+  direction: number
+}
 
 class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
   onMap?: L.GeoJSON
@@ -51,7 +60,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
       wind_total: this.state.windVectors.length
     }
 
-    this.state.currentVectors.forEach((currVector: VendorVector, idx: number) => {
+    this.state.currentVectors.forEach((currVector: CurrentVector, idx: number) => {
       data['curr_' + idx + '_from'] = this.formatTime(currVector.timeFrom)
       data['curr_' + idx + '_to'] = this.formatTime(currVector.timeTo)
       data['curr_' + idx + '_speed'] = currVector.getVectorSpeed()
@@ -59,7 +68,7 @@ class CustomMarineVectors extends MarineVectors<CustomMarineVectorsProps> {
       data['curr_' + idx + '_distance'] = currVector.getVectorDistance()
     })
 
-    this.state.windVectors.forEach((windVector: VendorVector, idx: number) => {
+    this.state.windVectors.forEach((windVector: WindVector, idx: number) => {
       data['wind_' + idx + '_from'] = this.formatTime(windVector.timeFrom)
       data['wind_' + idx + '_to'] = this.formatTime(windVector.timeTo)
       data['wind_' + idx + '_from_direction'] = windVector.direction


### PR DESCRIPTION
## Description

The current and wind vectors only get six fields read off them in getData; capture those as CurrentVector/WindVector interfaces so the forEach callbacks have real types instead of any, without taking a dependency on the vendor module's full shape.

## Summary by Sourcery

Enhancements:
- Introduce CurrentVector and WindVector interfaces capturing the fields actually used by the marine leaflet component to replace the previous any-typed vendor vector.