### PR TITLE
Derive ExtRefField from ExtRefValues to keep editor in sync

### DIFF
--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -49,7 +49,13 @@ function MissionDetails({ mission }: { mission: MissionData }) {
   )
 }
 
-type ExtRefField = 'name' | 'code' | 'url' | 'notes'
+interface ExtRefValues {
+  name: string
+  code?: string
+  url?: string
+  notes?: string
+}
+type ExtRefField = keyof ExtRefValues
 
 interface MissionDetailsExternalReferencesRowProps {
   externalReference: MissionExternalReferenceData
@@ -57,7 +63,7 @@ interface MissionDetailsExternalReferencesRowProps {
 
 function MissionDetailsExternalReferencesRow({ externalReference: extRef }: MissionDetailsExternalReferencesRowProps) {
   const [editFields, setEditFields] = useState<Partial<Record<ExtRefField, boolean>>>({})
-  const [values, setValues] = useState({
+  const [values, setValues] = useState<ExtRefValues>({
     name: extRef.name,
     code: extRef.code,
     url: extRef.url,
@@ -84,7 +90,7 @@ function MissionDetailsExternalReferencesRow({ externalReference: extRef }: Miss
   }
 
   function update() {
-    smmPost(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`, values)
+    smmPost(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`, { ...values })
   }
 
   function deleteRow() {


### PR DESCRIPTION
## Description

Adding a new editable external-reference field now means updating one place (ExtRefValues) rather than remembering to keep the manually maintained ExtRefField union in step with the values shape.

## Summary by Sourcery

Derive the editable external reference field type from a shared values interface to keep the mission details external reference editor in sync with the underlying data shape.

Enhancements:
- Introduce a shared ExtRefValues interface and derive the ExtRefField union from its keys to keep editable fields consistent.
- Update the mission external reference update call to spread values into a new object before posting.