### PR TITLE
Match icons + asset type list heading colSpan to column count

### DIFF
--- a/frontend/asset/type_list.tsx
+++ b/frontend/asset/type_list.tsx
@@ -22,9 +22,7 @@ function AssetTypeList({ assetTypes }: { assetTypes: AssetTypeData[] }) {
     <Table responsive>
       <thead>
         <tr key="heading">
-          <th colSpan={5} align="center">
-            Asset Types
-          </th>
+          <th align="center">Asset Types</th>
         </tr>
         <tr key="labels">
           <th>Asset Type</th>

--- a/frontend/icons/list.tsx
+++ b/frontend/icons/list.tsx
@@ -30,7 +30,7 @@ function IconList({ icons }: { icons: IconData[] }) {
     <Table responsive>
       <thead>
         <tr key="heading">
-          <th colSpan={5} align="center">
+          <th colSpan={2} align="center">
             Icons
           </th>
         </tr>


### PR DESCRIPTION
## Description

Both list pages had a heading row spanning five columns over tables that actually have two and one columns respectively, leaving the title floating well past the table edge.

## Summary by Sourcery

Align asset type and icon list table headings with their actual column counts to remove excessive heading span.

Enhancements:
- Adjust asset type list table heading to span only its single column.
- Update icon list table heading to span the correct number of columns.