### PR TITLE
Use th cells in MissionHeader thead

### DIFF
--- a/frontend/mission/header.tsx
+++ b/frontend/mission/header.tsx
@@ -12,11 +12,11 @@ function MissionHeader({ mission }: MissionHeaderProps) {
     <Table responsive>
       <thead>
         <tr>
-          <td>Mission</td>
-          <td>Created</td>
-          <td>By</td>
-          <td>Closed</td>
-          <td>By</td>
+          <th scope="col">Mission</th>
+          <th scope="col">Created</th>
+          <th scope="col">By</th>
+          <th scope="col">Closed</th>
+          <th scope="col">By</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
## Description

Header cells inside thead should be th, not td, so assistive tech can associate them with the data row below. Adds scope="col" to match the convention used elsewhere.

## Summary by Sourcery

Update mission table header cells to use proper column header semantics.

Enhancements:
- Replace td elements with th elements in the mission table header for improved accessibility semantics.
- Add scope="col" attributes to mission header cells to align with table header conventions.