### PR TITLE
Derive ExtRefValues from MissionExternalReferenceData

### DIFF
--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -49,12 +49,7 @@ function MissionDetails({ mission }: { mission: MissionData }) {
   )
 }
 
-interface ExtRefValues {
-  name: string
-  code?: string
-  url?: string
-  notes?: string
-}
+type ExtRefValues = Pick<MissionExternalReferenceData, 'name' | 'code' | 'url' | 'notes'>
 type ExtRefField = keyof ExtRefValues
 
 interface MissionDetailsExternalReferencesRowProps {


### PR DESCRIPTION
## Description

Drops the locally-redeclared name/code/url/notes shape and Picks them off the backing data type instead, so future changes to that type flow through to the editable-fields union automatically.

## Summary by Sourcery

Derive the external reference editable field values directly from MissionExternalReferenceData to keep them aligned with the backing data type.