### PR TITLE
Fix asset popup hiding zero altitude/heading and showing id as name

### DIFF
--- a/frontend/asset/AssetPopup.tsx
+++ b/frontend/asset/AssetPopup.tsx
@@ -16,10 +16,10 @@ export function AssetPopup({ assetName, coords, alt, heading, fix, status }: Pro
     { label: 'Lat', value: degreesToDM(coords[1], 'lat') },
     { label: 'Long', value: degreesToDM(coords[0], 'lon') }
   ]
-  if (alt) {
+  if (alt != null) {
     items.push({ label: 'Altitude', value: alt.toString() })
   }
-  if (heading) {
+  if (heading != null) {
     items.push({ label: 'Heading', value: heading.toString() })
   }
   if (fix) {

--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -159,7 +159,8 @@ class SMMAssets extends SMMRealtime {
   createPopup(asset: { properties: { asset: number }; geometry: { coordinates: [number, number] } }, layer: L.Layer) {
     const assetId = asset.properties.asset
     this.popups[assetId]?.unmount()
-    this.popups[assetId] = mountPopup(layer, <AssetPopup assetName={String(assetId)} coords={asset.geometry.coordinates} />, { minWidth: 200 })
+    const assetName = this.assetNameMap[assetId] ?? String(assetId)
+    this.popups[assetId] = mountPopup(layer, <AssetPopup assetName={assetName} coords={asset.geometry.coordinates} />, { minWidth: 200 })
     layer.once('remove', () => delete this.popups[assetId])
   }
 


### PR DESCRIPTION
## Description

AssetPopup used truthiness checks (`if (alt)` / `if (heading)`) which hid legitimate zero values - notably a heading of 0 (due north), a common bearing, and altitude 0 (sea level). Use `!= null` so only missing values are skipped.

SMMAssets.createPopup rendered the initial popup with the numeric asset id as the name until the first assetUpdate replaced it. The name map is already populated, so use it (falling back to the id only when unknown).

## Summary by Sourcery

Ensure asset popups display correct metadata for known assets.

Bug Fixes:
- Show altitude and heading values of zero in asset popups instead of treating them as missing.
- Initialize asset popups with the resolved asset name from the name map, falling back to the id only when the name is unknown.