### PR TITLE
Allow beginning a queued search when current_search_id is null

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -294,7 +294,7 @@ function QueuedSearchRow({ details, onAction }: { details: AssetFullStatusData; 
         <Button href={`/search/${details.queued_search_id}/`}>Details</Button>
       </td>
     )
-    if (details.current_search_id === undefined) {
+    if (!Number.isInteger(details.current_search_id)) {
       data.push(
         <td key="begin">
           <Button onClick={begin} disabled={busy}>


### PR DESCRIPTION
## Description

QueuedSearchRow gated the "Begin Search" button on `current_search_id === undefined`, but CurrentSearchRow treats the current search as absent via `Number.isInteger(current_search_id)`. The merged asset/mission state comes from JSON, where Django sends an explicit null rather than omitting the key, so `=== undefined` was false and the Begin button stayed hidden even with no current search. Use the same Number.isInteger check so the two rows agree.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect check for current_search_id that hid the Begin Search button when the current search was null.