### PR TITLE
Make status/add-form selects controlled so they track state

### DIFF
--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -48,7 +48,7 @@ function MissionAssetStatusForm({ asset, mission }: MissionAssetStatusFormProps)
   return (
     <tr>
       <td>
-        <select onChange={(e: ChangeEvent<HTMLSelectElement>) => setSelectedValueId(Number(e.target.value))} defaultValue={selectedValueId}>
+        <select onChange={(e: ChangeEvent<HTMLSelectElement>) => setSelectedValueId(Number(e.target.value))} value={selectedValueId ?? ''}>
           {statusValues.map((v) => (
             <option key={v.id} value={v.id}>
               {v.name}

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -153,7 +153,7 @@ function OrganizationMemberAdd({ organizationId }: { organizationId: number }) {
       <tbody>
         <tr>
           <td>
-            <select onChange={(e: ChangeEvent<HTMLSelectElement>) => setUserId(Number(e.target.value))}>
+            <select value={userId ?? ''} onChange={(e: ChangeEvent<HTMLSelectElement>) => setUserId(Number(e.target.value))}>
               {userList.map((user) => (
                 <option key={user.id} value={user.id}>
                   {user.username}
@@ -227,7 +227,7 @@ function OrganizationAssetAdd({ organizationId }: { organizationId: number }) {
       <tbody>
         <tr>
           <td>
-            <select onChange={(e: ChangeEvent<HTMLSelectElement>) => setAssetId(Number(e.target.value))}>
+            <select value={assetId ?? ''} onChange={(e: ChangeEvent<HTMLSelectElement>) => setAssetId(Number(e.target.value))}>
               {assetList.map((asset) => (
                 <option key={asset.id} value={asset.id}>
                   {asset.name}


### PR DESCRIPTION
## Description

Three dropdowns drove their selection from React state via onChange but weren't controlled, so the displayed option could drift from state:

- mission/asset/status.tsx used defaultValue (applied only on first render), so the async-loaded selectedValueId and the post-submit reset to undefined weren't reflected.
- organization/details.tsx member-add and asset-add selects had no value prop at all, so the browser selection could diverge from the id in state, especially as the option list re-polls every 10s.

Bind each to value={... ?? ''}, matching the existing controlled select in asset/ui.tsx AssetStatus.

## Summary by Sourcery

Enhancements:
- Bind organization member, organization asset, and mission asset status selects to their corresponding state values instead of relying on default or uncontrolled selection behavior.