### PR TITLE
Leave external-reference edit mode after a successful save

### DIFF
--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -85,7 +85,10 @@ function MissionDetailsExternalReferencesRow({ externalReference: extRef }: Miss
   }
 
   function update() {
-    smmPost(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`, { ...values })
+    // Leave edit mode only once the save succeeds; on failure the row
+    // stays editable so the user can retry. The displayed values refresh
+    // from props on the next 10s poll.
+    smmPost(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`, { ...values }, () => setEditFields({}))
   }
 
   function deleteRow() {


### PR DESCRIPTION
## Description

MissionDetailsExternalReferencesRow.update() POSTed the edited values but never cleared editFields, so the row stayed in edit mode showing inputs after a successful save (only Cancel reset it). Clear editFields from the smmPost success callback so the row returns to its display state on success while remaining editable if the save fails.

## Summary by Sourcery

Bug Fixes:
- Fix external reference rows remaining stuck in edit mode after a successful save by clearing edit state on successful POST callbacks.