### PR TITLE
Give each radio-operator asset its own table

### DIFF
--- a/frontend/organization/radio-operator.tsx
+++ b/frontend/organization/radio-operator.tsx
@@ -18,7 +18,7 @@ function RadioOperatorAsset({ asset }: { asset: number }) {
     missionStatus = <MissionAssetStatus mission={details.mission_id} asset={asset} />
   }
   return (
-    <>
+    <Table responsive>
       <thead>
         <tr>
           <td colSpan={2} align="center" style={{ fontWeight: 'bold' }} className="bg-info">
@@ -37,7 +37,7 @@ function RadioOperatorAsset({ asset }: { asset: number }) {
           </td>
         </tr>
       </tbody>
-    </>
+    </Table>
   )
 }
 
@@ -50,11 +50,11 @@ function OrganizationRadioOperatorPage({ organizationId }: { organizationId: num
   }, 10000)
 
   return (
-    <Table responsive>
+    <div>
       {assets.map((asset) => (
         <RadioOperatorAsset key={asset.id} asset={asset.asset.id} />
       ))}
-    </Table>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Description

OrganizationRadioOperatorPage mapped every asset into a single <Table>, with each RadioOperatorAsset emitting its own <thead>/<tbody> fragment. Multiple <thead> elements in one table is invalid HTML and relied on the browser to recover. Move the <Table> into RadioOperatorAsset so each asset renders as a self-contained table, and have the page wrap the list in a plain <div>.

## Summary by Sourcery

Enhancements:
- Wrap the organization radio-operator asset list in a simple div while moving the table markup into RadioOperatorAsset so each asset renders as a standalone table.