### PR TITLE
Guard against adding an organization asset before one is selected

### DIFF
--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -212,6 +212,7 @@ function OrganizationAssetAdd({ organizationId }: { organizationId: number }) {
   }, 10000)
 
   async function addOrganizationAsset() {
+    if (assetId === undefined) return
     await smmPost(`/organization/${organizationId}/assets/${assetId}/`, {})
     setAssetId(undefined)
   }


### PR DESCRIPTION
## Description

OrganizationAssetAdd.addOrganizationAsset POSTed to /organization/<id>/assets/<assetId>/ unconditionally. Before the first poll seeds the dropdown, assetId is undefined, so an early click sent a request to .../assets/undefined/. Bail out when no asset is selected, mirroring the existing guard in the member-add path.

## Summary by Sourcery

Bug Fixes:
- Prevent sending asset-add requests with an undefined assetId when the user clicks before an asset is selected.