### PR TITLE
Make the asset command response-type select controlled

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -161,7 +161,7 @@ function AssetCommandView({ asset, lastCommand }: AssetCommandViewProps) {
           <td>
             Response:
             <br />
-            <select onChange={(e) => setType(e.target.value)} defaultValue={type}>
+            <select onChange={(e) => setType(e.target.value)} value={type}>
               <option value="Accepted">Accept</option>
               <option value="More Info">More Info</option>
               <option value="Unable">Unable</option>


### PR DESCRIPTION
## Description

AssetCommandView's response select used defaultValue={type} while the choice is tracked in state, so the displayed option could drift from state (the same class of issue fixed for the other selects). Bind it to value={type}; type always has an initial value ('Accepted'), so it is controlled from first render.

## Summary by Sourcery

Bug Fixes:
- Bind the asset command response-type select to the tracked state value instead of using a default value to prevent UI and state from drifting out of sync.