### PR TITLE
Skip overlapping ticks while a usePolling callback is in flight

### DIFF
--- a/frontend/hooks/usePolling.ts
+++ b/frontend/hooks/usePolling.ts
@@ -18,15 +18,29 @@ export function usePolling(fn: () => void | Promise<void>, intervalMs: number) {
 
   useEffect(() => {
     let cancelled = false
+    // Skip a tick while a previous async callback is still pending so a
+    // slow endpoint doesn't stack overlapping requests. Synchronous
+    // callbacks complete within tick() and never set this.
+    let inFlight = false
 
     const tick = () => {
-      if (cancelled) return
+      if (cancelled || inFlight) return
+      let result: void | Promise<void>
       try {
-        Promise.resolve(fnRef.current()).catch((err) => {
-          console.error('usePolling callback rejected', err)
-        })
+        result = fnRef.current()
       } catch (err) {
         console.error('usePolling callback threw', err)
+        return
+      }
+      if (result instanceof Promise) {
+        inFlight = true
+        result
+          .catch((err) => {
+            console.error('usePolling callback rejected', err)
+          })
+          .finally(() => {
+            inFlight = false
+          })
       }
     }
 


### PR DESCRIPTION
## Description

usePolling fired on every interval regardless of whether the previous invocation had settled, so a callback slower than intervalMs could stack overlapping requests. Track an in-flight flag for async callbacks and skip ticks until the pending promise settles (including the immediate mount tick and the visibility-resume tick). Synchronous callbacks return a non-Promise and are unaffected. Callbacks rely on ajax's request timeout to ensure the promise always settles and re-enables polling.

## Summary by Sourcery

Bug Fixes:
- Avoid stacking overlapping requests in usePolling when the callback duration exceeds the polling interval by skipping ticks while an async callback is still in flight.