### PR TITLE
Guard against an empty features array on detail pages

### DIFF
--- a/frontend/search/details.tsx
+++ b/frontend/search/details.tsx
@@ -119,6 +119,7 @@ function SearchDetailsPage({ searchId }: { searchId: number }) {
     }
     const resp = await smmGetJSON<Response>(`/search/${searchId}/`, {})
     const feature = resp.features[0]
+    if (!feature) return
     setData(feature.properties)
     setSearch(createSearch(feature.properties))
     setGeometry(feature.geometry)

--- a/frontend/usergeo/details.tsx
+++ b/frontend/usergeo/details.tsx
@@ -38,8 +38,10 @@ function UserGeoDetailsPage({ userGeoId }: UserGeoDetailsPageProps) {
       features: { properties: SMMUserGeoObjectData; geometry: GeometryJSON }[]
     }
     const resp = await smmGetJSON<Response>(`/data/usergeo/${userGeoId}/`, {})
-    setData(resp.features[0].properties)
-    setGeometry(resp.features[0].geometry)
+    const feature = resp.features[0]
+    if (!feature) return
+    setData(feature.properties)
+    setGeometry(feature.geometry)
   }, 10000)
 
   return (


### PR DESCRIPTION
## Description

SearchDetailsPage and UserGeoDetailsPage dereferenced resp.features[0] unconditionally. noUncheckedIndexedAccess is off, so TypeScript typed the element as present, but an empty features array (e.g. the object was deleted between polls, or a permission change hid it) would throw and break the page. Bail out of the poll callback when features[0] is missing, leaving the last-rendered state in place.

## Summary by Sourcery

Guard against empty feature arrays in detail page polling callbacks to avoid runtime errors when no features are returned.

Bug Fixes:
- Prevent SearchDetailsPage from crashing when the search response returns an empty features array during polling.
- Prevent UserGeoDetailsPage from crashing when the user geo response returns an empty features array during polling.