### PR TITLE
Seed external-reference edit fields from the latest props

### DIFF
--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -66,6 +66,11 @@ function MissionDetailsExternalReferencesRow({ externalReference: extRef }: Miss
   })
 
   function toggleEdit(field: ExtRefField) {
+    // Seed the field being opened from the current prop so editing always
+    // starts from the latest server value (the row persists across the
+    // 10s poll, keyed by id). Only this field is reset, leaving any other
+    // in-progress edits untouched.
+    setValues((prev) => ({ ...prev, [field]: extRef[field] }))
     setEditFields((prev) => ({ ...prev, [field]: true }))
   }
 


### PR DESCRIPTION
## Description

The row component persists across the 10s poll (keyed by id), and its local `values` state was only seeded at mount, so re-opening a field for editing could start from a stale snapshot if the server value had since changed. Seed the field from the current prop in toggleEdit, refreshing only the field being opened so any other in-progress edits are left intact. Avoids mirroring props into state via an effect.

## Summary by Sourcery

Bug Fixes:
- Prevent external reference edit forms from starting with outdated values by reseeding the specific field from current props when editing is toggled.