### PR TITLE
Build ext-ref update payload from latest props plus edited fields

### DIFF
--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -90,10 +90,18 @@ function MissionDetailsExternalReferencesRow({ externalReference: extRef }: Miss
   }
 
   function update() {
+    // Build the payload from the latest props, overlaying only the fields
+    // the user actually opened/edited. Fields never opened keep their
+    // current server value instead of a stale mount snapshot, so an
+    // untouched field can't clobber a newer value from a concurrent edit.
+    const payload: Record<string, string | undefined> = { name: extRef.name, code: extRef.code, url: extRef.url, notes: extRef.notes }
+    for (const field of Object.keys(editFields) as ExtRefField[]) {
+      payload[field] = values[field]
+    }
     // Leave edit mode only once the save succeeds; on failure the row
     // stays editable so the user can retry. The displayed values refresh
     // from props on the next 10s poll.
-    smmPost(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`, { ...values }, () => setEditFields({}))
+    smmPost(`/mission/${extRef.mission}/externalreferences/${extRef.id}/`, payload, () => setEditFields({}))
   }
 
   function deleteRow() {


### PR DESCRIPTION
## Description

update() posted the whole `values` object, but fields the user never opened could still hold the mount-time snapshot. If another user changed one of those fields in the meantime, saving an unrelated edit would overwrite the newer server value with the stale local one. Construct the payload from the current props and overlay only the fields present in editFields, so untouched fields carry the latest server value.

## Summary by Sourcery

Bug Fixes:
- Prevent stale, unopened external reference fields from clobbering newer server values when saving edits by only sending edited fields over the latest props.