### PR TITLE
Report browser-tracked asset positions via POST

### DIFF
--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -5,7 +5,7 @@ import { Table, Button } from 'react-bootstrap'
 import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 
 import { formatLocalDateTime } from '../format'
-import { smmGet, smmGetJSON, smmPost } from '../ajax'
+import { smmGetJSON, smmPost } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { MissionAssetStatus } from '../mission/asset/status'
 import { usePolling } from '../hooks/usePolling'
@@ -32,7 +32,7 @@ function AssetTrackAs({ asset }: AssetTrackAsProps) {
     setLongitude(coords.longitude)
     setAltitude(coords.altitude)
 
-    smmGet(`/data/assets/${asset}/position/add/`, {
+    smmPost(`/data/assets/${asset}/position/add/`, {
       lat: coords.latitude,
       lon: coords.longitude,
       alt: coords.altitude,


### PR DESCRIPTION
## Description

AssetTrackAs recorded positions with smmGet, turning a state-changing request into a cacheable/retriable GET. The endpoint (/data/assets/<id>/position/add/) is login_required and already accepts POST; the GET path exists only for very basic hardware trackers that can only hit a URL. The browser tracker has the CSRF token, so use smmPost, which sends it. Same field set; null alt/heading are still omitted by the form encoder as before.

## Summary by Sourcery

Bug Fixes:
- Avoid using a cacheable GET request for recording asset position updates by switching the browser tracker to POST.