### PR TITLE
Extract a shared TrackedPath base for asset and user tracks

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -3,88 +3,28 @@ import L from 'leaflet'
 
 import { SMMRealtime } from '../smmmap'
 import '@canterbury-air-patrol/leaflet-dialog'
-import { cookieJar, PREFERENCE_COOKIE_OPTS } from '../cookies'
-import { MissionAssetSummary, AssetPointTime } from './types'
+import { cookieJar } from '../cookies'
+import { MissionAssetSummary } from './types'
 
 import { smmGetJSON } from '../ajax'
 import { AssetPopup } from './AssetPopup'
-import { ColorPickerDialog } from './ColorPickerDialog'
-import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 import { buildSwatchLabel } from '../components/swatchLabel'
 import { mountPopup } from '../components/mountPopup'
+import { TrackedPath } from '../components/TrackedPath'
 
-class SMMAsset {
-  map: L.Map
-  missionId: MissionId
+class SMMAsset extends TrackedPath {
   assetId: number
-  assetName: string
-  color: string
-  swatch?: HTMLElement
-  lastUpdate?: string
-  path: Array<L.LatLng>
-  updating: boolean
-  polyline: L.Polyline
   constructor(map: L.Map, missionId: MissionId, assetId: number, assetName: string, color: string) {
-    this.missionId = missionId
+    super(map, missionId, assetName, color)
     this.assetId = assetId
-    this.assetName = assetName
-    this.color = color
-    this.lastUpdate = undefined
-    this.path = []
-    this.updating = false
-    this.map = map
-    this.polyline = L.polyline([], { color: this.color })
-    this.updateColor = this.updateColor.bind(this)
-    this.colorPicker = this.colorPicker.bind(this)
-    this.updateNewRoute = this.updateNewRoute.bind(this)
-    this.updateFailed = this.updateFailed.bind(this)
   }
 
-  overlay() {
-    return this.polyline
+  protected colorCookieKey() {
+    return `asset_${this.assetId}_track_color`
   }
 
-  updateColor(color: string) {
-    cookieJar.set(`asset_${this.assetId}_track_color`, color, PREFERENCE_COOKIE_OPTS)
-    this.color = color
-    this.polyline.setStyle({ color: this.color })
-    if (this.swatch) this.swatch.style.backgroundColor = color
-  }
-
-  colorPicker() {
-    renderInLeafletDialog(this.map, (onClose) => <ColorPickerDialog name={this.assetName} color={this.color} onColorChange={this.updateColor} onClose={onClose} />, {
-      initOpen: true
-    })
-  }
-
-  updateNewRoute(route: { features: Array<{ geometry: { coordinates: Array<number> }; properties: AssetPointTime }> }) {
-    for (const feature of route.features) {
-      const lon = feature.geometry.coordinates[0]
-      const lat = feature.geometry.coordinates[1]
-      this.path.push(L.latLng(lat, lon))
-      this.lastUpdate = feature.properties.created_at
-    }
-    this.polyline.setLatLngs(this.path)
-    this.updating = false
-  }
-
-  updateFailed() {
-    this.updating = false
-  }
-
-  update() {
-    if (this.updating) {
-      return
-    }
-    this.updating = true
-
-    const assetUrl = `/mission/${this.missionId}/data/assets/${this.assetId}/position/history/`
-    const params: Record<string, string | undefined> = { oldest: 'last' }
-    if (this.lastUpdate) {
-      params.from = this.lastUpdate
-    }
-
-    smmGetJSON<{ features: Array<{ geometry: { coordinates: Array<number> }; properties: AssetPointTime }> }>(assetUrl, params).then(this.updateNewRoute).catch(this.updateFailed)
+  protected historyUrl() {
+    return `/mission/${this.missionId}/data/assets/${this.assetId}/position/history/`
   }
 }
 

--- a/frontend/components/TrackedPath.tsx
+++ b/frontend/components/TrackedPath.tsx
@@ -1,0 +1,97 @@
+import { MissionId } from '../mission/MissionId'
+import L from 'leaflet'
+
+import { cookieJar, PREFERENCE_COOKIE_OPTS } from '../cookies'
+import { smmGetJSON } from '../ajax'
+import { ColorPickerDialog } from '../asset/ColorPickerDialog'
+import { renderInLeafletDialog } from './renderInLeafletDialog'
+
+/** Minimal shape the history endpoints share: a list of point features in
+ *  [lon, lat] order, each carrying the time it was recorded. Both the
+ *  asset and user position-history responses are supersets of this. */
+interface PositionHistory {
+  features: Array<{ geometry: { coordinates: number[] }; properties: { created_at: string } }>
+}
+
+/**
+ * Shared behaviour for a single moving entity rendered as a growing
+ * polyline (SMMAsset, SMMUserPosition): the accumulated path, the track
+ * colour with its persisted preference and swatch, the colour-picker
+ * dialog, and the in-flight-guarded incremental history fetch.
+ *
+ * Subclasses supply only what differs: the cookie key the colour is
+ * stored under and the endpoint that returns the position history.
+ */
+export abstract class TrackedPath {
+  map: L.Map
+  missionId: MissionId
+  /** Human-readable label shown in the colour-picker dialog. */
+  displayName: string
+  color: string
+  swatch?: HTMLElement
+  lastUpdate?: string
+  path: L.LatLng[]
+  updating: boolean
+  polyline: L.Polyline
+
+  constructor(map: L.Map, missionId: MissionId, displayName: string, color: string) {
+    this.map = map
+    this.missionId = missionId
+    this.displayName = displayName
+    this.color = color
+    this.path = []
+    this.updating = false
+    this.polyline = L.polyline([], { color: this.color })
+  }
+
+  /** Cookie key under which this track's colour preference is stored. */
+  protected abstract colorCookieKey(): string
+  /** Endpoint returning this track's position history (GeoJSON features). */
+  protected abstract historyUrl(): string
+
+  overlay() {
+    return this.polyline
+  }
+
+  updateColor = (color: string) => {
+    cookieJar.set(this.colorCookieKey(), color, PREFERENCE_COOKIE_OPTS)
+    this.color = color
+    this.polyline.setStyle({ color: this.color })
+    if (this.swatch) this.swatch.style.backgroundColor = color
+  }
+
+  colorPicker = () => {
+    renderInLeafletDialog(this.map, (onClose) => <ColorPickerDialog name={this.displayName} color={this.color} onColorChange={this.updateColor} onClose={onClose} />, {
+      initOpen: true
+    })
+  }
+
+  private applyHistory = (route: PositionHistory) => {
+    for (const feature of route.features) {
+      const lon = feature.geometry.coordinates[0]
+      const lat = feature.geometry.coordinates[1]
+      this.path.push(L.latLng(lat, lon))
+      this.lastUpdate = feature.properties.created_at
+    }
+    this.polyline.setLatLngs(this.path)
+    this.updating = false
+  }
+
+  private updateFailed = () => {
+    this.updating = false
+  }
+
+  update() {
+    if (this.updating) {
+      return
+    }
+    this.updating = true
+
+    const params: Record<string, string | undefined> = { oldest: 'last' }
+    if (this.lastUpdate != null) {
+      params.from = this.lastUpdate
+    }
+
+    smmGetJSON<PositionHistory>(this.historyUrl(), params).then(this.applyHistory).catch(this.updateFailed)
+  }
+}

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -2,85 +2,27 @@ import { MissionId } from '../mission/MissionId'
 import L from 'leaflet'
 
 import { SMMRealtime } from '../smmmap'
-import { cookieJar, PREFERENCE_COOKIE_OPTS } from '../cookies'
-import { smmGetJSON } from '../ajax'
+import { cookieJar } from '../cookies'
 import { SMMMissionUserPointTimeGeoJSON } from './types'
 import { UserPopup } from './UserPopup'
-import { ColorPickerDialog } from '../asset/ColorPickerDialog'
-import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 import { buildSwatchLabel } from '../components/swatchLabel'
 import { mountPopup } from '../components/mountPopup'
+import { TrackedPath } from '../components/TrackedPath'
 
-class SMMUserPosition {
-  map: L.Map
-  missionId: MissionId
+class SMMUserPosition extends TrackedPath {
   userName: string
-  color: string
-  swatch?: HTMLElement
   popup?: ReturnType<typeof mountPopup>
-  lastUpdate?: string
-  path: L.LatLng[]
-  updating: boolean
-  polyline: L.Polyline
   constructor(map: L.Map, missionId: MissionId, userName: string, color: string) {
-    this.missionId = missionId
+    super(map, missionId, userName, color)
     this.userName = userName
-    this.color = color
-    this.map = map
-    this.path = []
-    this.updating = false
-    this.polyline = L.polyline([], { color: this.color })
-    this.updateColor = this.updateColor.bind(this)
-    this.colorPicker = this.colorPicker.bind(this)
-    this.updateNewPosition = this.updateNewPosition.bind(this)
-    this.updateError = this.updateError.bind(this)
   }
 
-  overlay() {
-    return this.polyline
+  protected colorCookieKey() {
+    return `user_${this.userName}_track_color`
   }
 
-  updateColor(color: string) {
-    cookieJar.set(`user_${this.userName}_track_color`, color, PREFERENCE_COOKIE_OPTS)
-    this.color = color
-    this.polyline.setStyle({ color: this.color })
-    if (this.swatch) this.swatch.style.backgroundColor = color
-  }
-
-  colorPicker() {
-    renderInLeafletDialog(this.map, (onClose) => <ColorPickerDialog name={this.userName} color={this.color} onColorChange={this.updateColor} onClose={onClose} />, {
-      initOpen: true
-    })
-  }
-
-  updateNewPosition(route: { features: Array<SMMMissionUserPointTimeGeoJSON> }) {
-    for (const feature of route.features) {
-      const lon = feature.geometry.coordinates[0]
-      const lat = feature.geometry.coordinates[1]
-      this.path.push(L.latLng(lat, lon))
-      this.lastUpdate = feature.properties.created_at
-    }
-    this.polyline.setLatLngs(this.path)
-    this.updating = false
-  }
-
-  updateError() {
-    this.updating = false
-  }
-
-  update() {
-    if (this.updating) {
-      return
-    }
-    this.updating = true
-
-    const userUrl = `/mission/${this.missionId}/data/user/${this.userName}/position/history/`
-    const params: Record<string, string | undefined> = { oldest: 'last' }
-    if (this.lastUpdate != null) {
-      params.from = this.lastUpdate
-    }
-
-    smmGetJSON<{ features: Array<SMMMissionUserPointTimeGeoJSON> }>(userUrl, params).then(this.updateNewPosition).catch(this.updateError)
+  protected historyUrl() {
+    return `/mission/${this.missionId}/data/user/${this.userName}/position/history/`
   }
 }
 


### PR DESCRIPTION
## Description

SMMAsset and SMMUserPosition were near-identical: accumulated path, track colour with its persisted cookie/swatch, the colour-picker dialog, and the in-flight-guarded incremental history fetch were duplicated, the only differences being the colour cookie key and the history endpoint.

Pull the shared behaviour into TrackedPath (components/TrackedPath.tsx) with two abstract hooks - colorCookieKey() and historyUrl() - and have both classes extend it. SMMUserPosition keeps its own popup field. Pure refactor; behaviour is unchanged (the `from` guard is normalised to the already-equivalent `!= null`).

## Summary by Sourcery

Extract shared tracked-path behaviour for asset and user maps into a reusable base class.

Enhancements:
- Introduce a TrackedPath base class encapsulating shared path rendering, colour persistence, and incremental history fetching for tracked entities.
- Refactor SMMAsset and SMMUserPosition to extend TrackedPath, keeping existing behaviour while reducing duplication.