### PR TITLE
Add unit tests for core utilities

### DIFF
--- a/frontend/ajax.test.ts
+++ b/frontend/ajax.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+
+vi.mock('./cookies', () => ({
+  cookieJar: { get: vi.fn(() => 'test-token') },
+  PREFERENCE_COOKIE_OPTS: {}
+}))
+
+import { cookieJar } from './cookies'
+import { smmGet, smmGetJSON, smmPost, smmPatch, smmDelete } from './ajax'
+
+interface ResponseInit {
+  ok: boolean
+  status?: number
+  json?: unknown
+  text?: string
+}
+
+function mockResponse({ ok, status, json, text }: ResponseInit): Response {
+  return {
+    ok,
+    status: status ?? (ok ? 200 : 500),
+    json: async () => json,
+    text: async () => text ?? ''
+  } as unknown as Response
+}
+
+const fetchMock = vi.fn()
+
+function lastCall() {
+  return fetchMock.mock.calls[fetchMock.mock.calls.length - 1]
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  ;(cookieJar.get as Mock).mockReturnValue('test-token')
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('smmGetJSON / smmGet', () => {
+  it('appends a query string and parses JSON, invoking success', async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, json: { hello: 'world' } }))
+    const success = vi.fn()
+
+    const data = await smmGetJSON<{ hello: string }>('/api/thing/', { a: 1, b: 'x' }, success)
+
+    const [url, options] = lastCall()
+    expect(url).toBe('/api/thing/?a=1&b=x')
+    expect(options.headers).toMatchObject({ Accept: 'application/json' })
+    expect(data).toEqual({ hello: 'world' })
+    expect(success).toHaveBeenCalledWith({ hello: 'world' })
+  })
+
+  it('omits null and undefined query parameters', async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, text: 'ok' }))
+
+    await smmGet('/api/thing/', { keep: 'yes', drop: null, gone: undefined })
+
+    const [url] = lastCall()
+    expect(url).toBe('/api/thing/?keep=yes')
+  })
+
+  it('appends with & when the url already has a query string', async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, text: 'ok' }))
+
+    await smmGet('/api/thing/?existing=1', { more: 2 })
+
+    expect(lastCall()[0]).toBe('/api/thing/?existing=1&more=2')
+  })
+
+  it('calls error with the parsed body and rejects on a non-ok response', async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: false, status: 403, json: { detail: 'nope' } }))
+    const success = vi.fn()
+    const error = vi.fn()
+
+    await expect(smmGetJSON('/api/thing/', {}, success, error)).rejects.toThrow('HTTP 403')
+    expect(error).toHaveBeenCalledWith({ detail: 'nope' })
+    expect(success).not.toHaveBeenCalled()
+  })
+
+  it('calls error with no body and rejects when fetch itself fails', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    const error = vi.fn()
+
+    await expect(smmGet('/api/thing/', {}, undefined, error)).rejects.toThrow('network down')
+    expect(error).toHaveBeenCalledWith()
+  })
+
+  it('swallows a throwing success handler and still resolves with the data', async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, json: { ok: 1 } }))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const success = vi.fn(() => {
+      throw new Error('handler boom')
+    })
+
+    await expect(smmGetJSON('/api/thing/', {}, success)).resolves.toEqual({ ok: 1 })
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+})
+
+describe('smmPost', () => {
+  it('sends a CSRF header and a form-urlencoded body for a flat object', async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, text: 'ok' }))
+
+    await smmPost('/api/thing/', { name: 'a', count: 2 })
+
+    const [url, options] = lastCall()
+    expect(url).toBe('/api/thing/')
+    expect(options.method).toBe('POST')
+    expect(options.headers).toMatchObject({ 'X-CSRFToken': 'test-token' })
+    expect(options.body).toBeInstanceOf(URLSearchParams)
+    expect(options.body.toString()).toBe('name=a&count=2')
+  })
+
+  it('passes a FormData body through verbatim', async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, text: 'ok' }))
+    const fd = new FormData()
+    fd.append('file', 'contents')
+
+    await smmPost('/api/upload/', fd)
+
+    expect(lastCall()[1].body).toBe(fd)
+  })
+
+  it('sends an empty CSRF header when the token cookie is missing', async () => {
+    ;(cookieJar.get as Mock).mockReturnValue(undefined)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, text: 'ok' }))
+
+    await smmPost('/api/thing/', { a: 1 })
+
+    expect(lastCall()[1].headers).toMatchObject({ 'X-CSRFToken': '' })
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+})
+
+describe('smmPatch', () => {
+  it('sends a JSON body with the content-type and CSRF headers', async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, text: 'ok' }))
+
+    await smmPatch('/api/thing/1/', { admin: true })
+
+    const [, options] = lastCall()
+    expect(options.method).toBe('PATCH')
+    expect(options.headers).toMatchObject({ 'Content-Type': 'application/json', 'X-CSRFToken': 'test-token' })
+    expect(options.body).toBe(JSON.stringify({ admin: true }))
+  })
+})
+
+describe('smmDelete', () => {
+  it('sends DELETE with the CSRF header and resolves void, invoking success', async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, text: '' }))
+    const success = vi.fn()
+
+    await smmDelete('/api/thing/1/', success)
+
+    const [, options] = lastCall()
+    expect(options.method).toBe('DELETE')
+    expect(options.headers).toMatchObject({ 'X-CSRFToken': 'test-token' })
+    expect(success).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/components/flattenPoints.test.ts
+++ b/frontend/components/flattenPoints.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import L from 'leaflet'
+
+import { flattenPoints } from './flattenPoints'
+
+describe('flattenPoints', () => {
+  it('flattens an empty list to just the count', () => {
+    expect(flattenPoints([])).toEqual({ points: 0 })
+  })
+
+  it('emits count plus per-point lat/lng keyed by index', () => {
+    const points = [L.latLng(1.5, 2.5), L.latLng(-3, 4)]
+
+    expect(flattenPoints(points)).toEqual({
+      points: 2,
+      point0_lat: 1.5,
+      point0_lng: 2.5,
+      point1_lat: -3,
+      point1_lng: 4
+    })
+  })
+})

--- a/frontend/components/swatchLabel.test.ts
+++ b/frontend/components/swatchLabel.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildSwatchLabel } from './swatchLabel'
+
+function makeOwner(color = '#3388ff') {
+  return { color, colorPicker: vi.fn(), swatch: undefined as HTMLElement | undefined }
+}
+
+describe('buildSwatchLabel', () => {
+  it('renders the name as text and appends a coloured swatch stored on the owner', () => {
+    const owner = makeOwner('red')
+    const label = buildSwatchLabel('Rescue 1', owner)
+
+    expect(label.textContent).toContain('Rescue 1')
+    expect(owner.swatch).toBeDefined()
+    expect(label.contains(owner.swatch!)).toBe(true)
+    expect(owner.swatch!.style.backgroundColor).not.toBe('')
+  })
+
+  it('treats the name as text, not markup (no HTML injection)', () => {
+    const owner = makeOwner()
+    const label = buildSwatchLabel('<img src=x onerror=alert(1)>', owner)
+
+    expect(label.querySelector('img')).toBeNull()
+    expect(label.textContent).toContain('<img src=x onerror=alert(1)>')
+  })
+
+  it('invokes the owner colorPicker when the swatch is clicked', () => {
+    const owner = makeOwner()
+    buildSwatchLabel('Rescue 1', owner)
+
+    owner.swatch!.dispatchEvent(new MouseEvent('click'))
+
+    expect(owner.colorPicker).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/geometry/details.test.tsx
+++ b/frontend/geometry/details.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { coordinateToLatLng, mapCoordinates } from './details'
+
+describe('coordinateToLatLng', () => {
+  it('maps GeoJSON [lon, lat] order to a {lat, lng} point', () => {
+    expect(coordinateToLatLng([174.7, -41.3])).toEqual({ lat: -41.3, lng: 174.7 })
+  })
+})
+
+describe('mapCoordinates', () => {
+  it('converts a list of [lon, lat] pairs preserving order', () => {
+    expect(
+      mapCoordinates([
+        [1, 2],
+        [3, 4]
+      ])
+    ).toEqual([
+      { lat: 2, lng: 1 },
+      { lat: 4, lng: 3 }
+    ])
+  })
+})

--- a/frontend/mission/MissionId.test.ts
+++ b/frontend/mission/MissionId.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSpecificMission } from './MissionId'
+
+describe('isSpecificMission', () => {
+  it('is true for a numeric mission id', () => {
+    expect(isSpecificMission(0)).toBe(true)
+    expect(isSpecificMission(42)).toBe(true)
+  })
+
+  it('is false for the aggregate sentinels', () => {
+    expect(isSpecificMission('current')).toBe(false)
+    expect(isSpecificMission('all')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description

Cover the pure helpers that the rest of the frontend leans on:

- ajax.ts: query-string build (incl. null/undefined omission and &-joining), JSON parse + success callback, non-ok -> error(body) + reject, network failure -> error() + reject, throwing success handler swallowed, and CSRF/body shape for POST (form vs FormData), PATCH, and DELETE. fetch and the cookie jar are mocked.
- flattenPoints, swatchLabel (incl. HTML-injection safety and the swatch click -> colorPicker wiring), isSpecificMission, and the geometry [lon,lat] -> {lat,lng} converters.

## Summary by Sourcery

Add unit tests to cover core frontend utility helpers and components.

Tests:
- Add comprehensive tests for AJAX helper functions including query building, JSON responses, error handling, and CSRF behavior for GET/POST/PATCH/DELETE requests.
- Add tests for the swatch label component to verify text rendering, HTML-injection safety, and color picker wiring.
- Introduce test files for geometry utilities, mission ID helpers, and point-flattening logic to expand baseline coverage of shared frontend utilities.