### PR TITLE
Harden usePolling tests per review

### DIFF
--- a/frontend/hooks/usePolling.test.ts
+++ b/frontend/hooks/usePolling.test.ts
@@ -55,10 +55,12 @@ describe('usePolling', () => {
     await vi.advanceTimersByTimeAsync(1000)
     expect(fn).toHaveBeenCalledTimes(1)
 
-    // Once it settles, the next tick runs again.
+    // Once it settles, the next tick runs again. Awaiting the promise then
+    // advancing drains the .catch().finally() that clears the in-flight flag
+    // (advanceTimersByTimeAsync flushes microtasks before firing the timer),
+    // so this doesn't depend on the exact length of the implementation chain.
     first.resolve()
-    await Promise.resolve()
-    await Promise.resolve()
+    await first.promise
     await vi.advanceTimersByTimeAsync(1000)
     expect(fn).toHaveBeenCalledTimes(2)
   })
@@ -99,8 +101,8 @@ describe('usePolling', () => {
     await vi.advanceTimersByTimeAsync(3000)
     expect(fn).toHaveBeenCalledTimes(1)
 
-    // A visibility change after unmount must not restart polling.
-    setVisibility('visible')
+    // A visibility change after unmount must not restart polling (the
+    // listener was removed). The tab is already visible here.
     document.dispatchEvent(new Event('visibilitychange'))
     expect(fn).toHaveBeenCalledTimes(1)
   })
@@ -112,7 +114,7 @@ describe('usePolling', () => {
 
     await vi.advanceTimersByTimeAsync(1000)
     expect(fn).toHaveBeenCalledTimes(2)
-    expect(consoleError).toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalledWith('usePolling callback rejected', expect.any(Error))
   })
 
   it('logs and keeps polling when a synchronous callback throws', async () => {
@@ -122,7 +124,7 @@ describe('usePolling', () => {
     })
     renderHook(() => usePolling(fn, 1000))
     expect(fn).toHaveBeenCalledTimes(1)
-    expect(consoleError).toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalledWith('usePolling callback threw', expect.any(Error))
 
     await vi.advanceTimersByTimeAsync(1000)
     expect(fn).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
## Description

Make the in-flight test independent of the implementation's microtask chain depth (await the promise, then let advanceTimersByTimeAsync drain the finally), assert the exact console.error messages so an unrelated warning can't satisfy the error-path tests, and drop a misleading no-op setVisibility in the unmount test.

## Summary by Sourcery

Harden usePolling hook tests to be more deterministic and precise about error handling and visibility behavior.

Tests:
- Make the in-flight polling test independent of microtask chain depth by awaiting the promise before advancing timers.
- Clarify the unmount visibility test to rely on the existing visible state instead of toggling visibility.
- Assert exact console.error messages for rejected and throwing callbacks to ensure only the expected errors satisfy the tests.