### PR TITLE
Add regression tests for the frontend fixes

### DIFF
--- a/frontend/asset/AssetPopup.test.tsx
+++ b/frontend/asset/AssetPopup.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { AssetPopup } from './AssetPopup'
+
+function valueFor(label: string): string | null | undefined {
+  // PopupDataList renders each item as <dl><dt>label</dt><dd>value</dd></dl>.
+  return screen.getByText(label).nextElementSibling?.textContent
+}
+
+describe('AssetPopup', () => {
+  it('always shows the asset name and coordinates', () => {
+    render(<AssetPopup assetName="Rescue 1" coords={[174.7, -41.3]} />)
+    expect(valueFor('Asset')).toBe('Rescue 1')
+    expect(screen.getByText('Lat')).toBeInTheDocument()
+    expect(screen.getByText('Long')).toBeInTheDocument()
+  })
+
+  it('shows altitude 0 and heading 0 instead of hiding them as falsy', () => {
+    render(<AssetPopup assetName="Rescue 1" coords={[174.7, -41.3]} alt={0} heading={0} />)
+    expect(screen.getByText('Altitude')).toBeInTheDocument()
+    expect(valueFor('Altitude')).toBe('0')
+    expect(screen.getByText('Heading')).toBeInTheDocument()
+    expect(valueFor('Heading')).toBe('0')
+  })
+
+  it('omits altitude and heading when they are not provided', () => {
+    render(<AssetPopup assetName="Rescue 1" coords={[174.7, -41.3]} />)
+    expect(screen.queryByText('Altitude')).toBeNull()
+    expect(screen.queryByText('Heading')).toBeNull()
+  })
+
+  it('shows status and only shows status notes when non-empty', () => {
+    const { rerender } = render(<AssetPopup assetName="Rescue 1" coords={[1, 2]} status={{ status: 'Available', notes: '' }} />)
+    expect(valueFor('Status')).toBe('Available')
+    expect(screen.queryByText('Status Notes')).toBeNull()
+
+    rerender(<AssetPopup assetName="Rescue 1" coords={[1, 2]} status={{ status: 'Available', notes: 'fuelling' }} />)
+    expect(valueFor('Status Notes')).toBe('fuelling')
+  })
+})

--- a/frontend/asset/ui.test.tsx
+++ b/frontend/asset/ui.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../page-shell', () => ({}))
+vi.mock('../ajax', () => ({
+  smmGet: vi.fn(() => Promise.resolve('')),
+  smmGetJSON: vi.fn(() => Promise.resolve({})),
+  smmPost: vi.fn(() => Promise.resolve('')),
+  smmPatch: vi.fn(() => Promise.resolve('')),
+  smmDelete: vi.fn(() => Promise.resolve())
+}))
+
+import { smmPost } from '../ajax'
+import { AssetCommandView, AssetMissionDetails } from './ui'
+import type { AssetCommandData, AssetFullStatusData } from './types'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+const missionDetails = {
+  asset_id: 5,
+  mission_id: 10,
+  mission_name: 'Op Kahu',
+  queued_search_id: 99
+}
+
+describe('AssetMissionDetails - begin search gating', () => {
+  it('offers Begin Search when a search is queued and current_search_id is null', () => {
+    render(<AssetMissionDetails details={{ ...missionDetails, current_search_id: null } as unknown as AssetFullStatusData} />)
+    expect(screen.getByRole('button', { name: 'Begin Search' })).toBeInTheDocument()
+  })
+
+  it('hides Begin Search while a current search is in progress', () => {
+    render(<AssetMissionDetails details={{ ...missionDetails, current_search_id: 7 } as unknown as AssetFullStatusData} />)
+    expect(screen.queryByRole('button', { name: 'Begin Search' })).toBeNull()
+  })
+
+  it('begins the queued search via POST and notifies the parent', async () => {
+    const onAction = vi.fn()
+    render(<AssetMissionDetails details={{ ...missionDetails, current_search_id: null } as unknown as AssetFullStatusData} onAction={onAction} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Begin Search' }))
+
+    expect(smmPost).toHaveBeenCalledWith('/search/99/begin/', { asset_id: 5 })
+    expect(onAction).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('AssetCommandView - response type select', () => {
+  const lastCommand = {
+    id: 3,
+    action_txt: 'Goto',
+    issued: null,
+    issued_by: 'controller',
+    reason: 'proceed',
+    response: { set: null }
+  } as unknown as AssetCommandData
+
+  it('is controlled: the chosen response type is reflected and submitted', async () => {
+    render(<AssetCommandView asset={5} lastCommand={lastCommand} />)
+
+    const select = screen.getByRole('combobox') as HTMLSelectElement
+    expect(select.value).toBe('Accepted')
+
+    await userEvent.selectOptions(select, 'Unable')
+    expect(select.value).toBe('Unable')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Respond' }))
+    expect(smmPost).toHaveBeenCalledWith('/assets/5/command/', { command_id: 3, message: '', type: 'Unable' })
+  })
+})

--- a/frontend/mission/details.test.tsx
+++ b/frontend/mission/details.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { Mock } from 'vitest'
+
+vi.mock('../page-shell', () => ({}))
+vi.mock('../ajax', () => ({
+  smmGetJSON: vi.fn(),
+  smmPost: vi.fn(),
+  smmPatch: vi.fn(() => Promise.resolve('')),
+  smmDelete: vi.fn(() => Promise.resolve(''))
+}))
+
+import { smmGetJSON, smmPost } from '../ajax'
+import { MissionDetailPage } from './details'
+
+function makeDetails() {
+  return {
+    mission: { id: 1, name: 'Op Kahu', started: '2024-01-01T00:00:00Z', creator: 'controller', description: 'desc', closed: null, closed_by: null },
+    external_references: [{ id: 50, mission: 1, name: 'IRD', code: 'ABC', url: 'http://example/x', notes: 'note' }],
+    mission_organizations: [],
+    mission_users: [],
+    mission_assets: [],
+    admin: false,
+    me: 'controller',
+    can_add_organizations: false,
+    can_add_users: false
+  }
+}
+
+beforeEach(() => {
+  const details = makeDetails()
+  ;(smmGetJSON as Mock).mockImplementation((url: string, _data: unknown, success?: (d: unknown) => void) => {
+    let data: unknown = {}
+    if (url.includes('/details/')) data = details
+    else if (url.includes('not_included')) data = { assets: [], organizations: [], users: [] }
+    success?.(data)
+    return Promise.resolve(data)
+  })
+  ;(smmPost as Mock).mockImplementation((_url: string, _data: unknown, success?: (d: unknown) => void) => {
+    success?.('')
+    return Promise.resolve('')
+  })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('MissionDetailPage external references', () => {
+  it('seeds the edit input from the current value when a field is opened', async () => {
+    render(<MissionDetailPage missionId={1} />)
+    await userEvent.click(await screen.findByText('IRD'))
+    expect(screen.getByDisplayValue('IRD')).toBeInTheDocument()
+  })
+
+  it('saves only edited fields over the latest props and leaves edit mode on success', async () => {
+    render(<MissionDetailPage missionId={1} />)
+
+    await userEvent.click(await screen.findByText('IRD'))
+    const input = screen.getByDisplayValue('IRD')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'NewName')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    // Untouched fields carry their current prop values, not a blank/stale snapshot.
+    expect(smmPost).toHaveBeenCalledWith('/mission/1/externalreferences/50/', { name: 'NewName', code: 'ABC', url: 'http://example/x', notes: 'note' }, expect.any(Function))
+
+    // Editing ends on success: the input is gone and the row is back to its
+    // display state (Delete button shown instead of Update/Cancel).
+    expect(screen.queryByDisplayValue('NewName')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+  })
+
+  it('cancel discards the edit without posting', async () => {
+    render(<MissionDetailPage missionId={1} />)
+
+    await userEvent.click(await screen.findByText('IRD'))
+    const input = screen.getByDisplayValue('IRD')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Discarded')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(smmPost).not.toHaveBeenCalled()
+    expect(screen.queryByDisplayValue('Discarded')).toBeNull()
+    expect(screen.getByText('IRD')).toBeInTheDocument()
+  })
+})

--- a/frontend/test-setup.ts
+++ b/frontend/test-setup.ts
@@ -1,3 +1,12 @@
 // Registers @testing-library/jest-dom matchers (toBeInTheDocument, etc.)
 // with Vitest's expect, and their type augmentation across the suite.
 import '@testing-library/jest-dom/vitest'
+
+// With globals disabled, Testing Library can't auto-register its cleanup,
+// so unmount each render after every test to keep the jsdom DOM isolated.
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})


### PR DESCRIPTION
## Description

Component tests (RTL + jsdom, ajax mocked) that lock in the behaviour corrected earlier:

- AssetPopup: altitude 0 and heading 0 are shown (not hidden as falsy); absent values are omitted; status notes only when non-empty.
- AssetMissionDetails: Begin Search appears when a search is queued and current_search_id is null, hides while a current search is in progress, and begins via the expected POST.
- AssetCommandView: the response-type select is controlled - the choice is reflected and submitted.
- MissionDetailPage external references: opening a field seeds the input from the current value; saving posts only the edited field over the latest props (untouched fields keep their values) and leaves edit mode on success; cancel discards without posting.

Also register Testing Library's cleanup in test-setup.ts, since with Vitest globals disabled it isn't auto-registered, keeping each render's DOM isolated.

## Summary by Sourcery

Add regression coverage for key frontend asset and mission detail behaviours while improving test environment cleanup.

Enhancements:
- Register Testing Library cleanup in the shared Vitest setup to ensure DOM isolation between tests.

Tests:
- Add regression tests for AssetPopup display of coordinates, altitude/heading, and conditional status notes.
- Add regression tests for AssetMissionDetails begin-search gating and POST behaviour with parent notification.
- Add regression tests for AssetCommandView to verify the response-type select is controlled and submitted correctly.
- Add regression tests for MissionDetailPage external references editing, ensuring proper seeding, partial updates, and cancel behaviour without posting.