### PR TITLE
Add regression tests for the org-asset-add guard and select

### DIFF
--- a/frontend/organization/details.test.tsx
+++ b/frontend/organization/details.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { Mock } from 'vitest'
+
+vi.mock('../page-shell', () => ({}))
+vi.mock('../ajax', () => ({
+  smmGetJSON: vi.fn(),
+  smmPost: vi.fn(() => Promise.resolve('')),
+  smmDelete: vi.fn(() => Promise.resolve(''))
+}))
+
+import { smmGetJSON, smmPost } from '../ajax'
+import { OrganizationAssetAdd } from './details'
+
+function mockAssets(assets: Array<{ id: number; name: string }>) {
+  ;(smmGetJSON as Mock).mockResolvedValue({ assets })
+}
+
+beforeEach(() => {
+  mockAssets([])
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('OrganizationAssetAdd', () => {
+  it('does not POST when no asset is selected (empty list)', async () => {
+    render(<OrganizationAssetAdd organizationId={3} />)
+    // Let the mount poll settle (it resolves to an empty asset list).
+    await Promise.resolve()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(smmPost).not.toHaveBeenCalled()
+  })
+
+  it('seeds the select with the first asset and POSTs it on Add', async () => {
+    mockAssets([
+      { id: 7, name: 'Boat' },
+      { id: 8, name: 'RHIB' }
+    ])
+    render(<OrganizationAssetAdd organizationId={3} />)
+
+    const select = (await screen.findByRole('combobox')) as HTMLSelectElement
+    await screen.findByRole('option', { name: 'Boat' })
+    expect(select.value).toBe('7')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(smmPost).toHaveBeenCalledWith('/organization/3/assets/7/', {})
+  })
+
+  it('is controlled: changing the selection updates the value and what is POSTed', async () => {
+    mockAssets([
+      { id: 7, name: 'Boat' },
+      { id: 8, name: 'RHIB' }
+    ])
+    render(<OrganizationAssetAdd organizationId={3} />)
+
+    const select = (await screen.findByRole('combobox')) as HTMLSelectElement
+    await screen.findByRole('option', { name: 'RHIB' })
+
+    await userEvent.selectOptions(select, '8')
+    expect(select.value).toBe('8')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(smmPost).toHaveBeenCalledWith('/organization/3/assets/8/', {})
+  })
+})

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -201,7 +201,7 @@ function OrganizationAssetList({ organizationId, assets }: OrganizationAssetList
   )
 }
 
-function OrganizationAssetAdd({ organizationId }: { organizationId: number }) {
+export function OrganizationAssetAdd({ organizationId }: { organizationId: number }) {
   const [assetList, setAssetList] = useState<AssetData[]>([])
   const [assetId, setAssetId] = useState<number | undefined>(undefined)
 


### PR DESCRIPTION
## Description

Export OrganizationAssetAdd and cover: Add is a no-op when no asset is selected (empty list -> assetId undefined, the guard added earlier), the select is seeded with the first asset and POSTs it, and the select is controlled so changing the selection changes what gets POSTed.

## Summary by Sourcery

Add test coverage for the organization asset add flow and export the component for use in tests.

Enhancements:
- Export OrganizationAssetAdd from the organization details module so it can be imported externally.

Tests:
- Add regression tests for OrganizationAssetAdd to verify no POST occurs with no assets, the first asset is selected and posted by default, and selection changes control which asset is posted.