### PR TITLE
Align the frontend build image with the Dockerfile (node 26)

### DIFF
--- a/build-frontend-docker.sh
+++ b/build-frontend-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker run --mount type=bind,source=$(pwd),target=/usr/src node:24-slim /bin/bash -c "cd /usr/src; USERID=$(id -u) GROUPID=$(id -g) ./build-frontend.sh"
+docker run --mount type=bind,source=$(pwd),target=/usr/src node:26-slim /bin/bash -c "cd /usr/src; USERID=$(id -u) GROUPID=$(id -g) ./build-frontend.sh"


### PR DESCRIPTION
## Description

build-frontend-docker.sh built with node:24-slim while the Dockerfile's frontend stage uses node:26-slim, so the local/CI build ran on a different Node than the deployment image. Bump the script to node:26-slim so both paths (and local dev, also on Node 26) agree.

## Summary by Sourcery

Build:
- Update build-frontend-docker.sh to use the node:26-slim image instead of node:24-slim for frontend builds.