### PR TITLE
Guard first-option select seeding for strict index access

### DIFF
--- a/frontend/Admin/AssetCommandDialog.tsx
+++ b/frontend/Admin/AssetCommandDialog.tsx
@@ -35,8 +35,10 @@ export function AssetCommandDialog({ map, missionId, onClose }: Props) {
       setAssets(data.assets)
       setCommands(data.commands)
       setRequiresPosition(data.requires_position)
-      if (data.assets.length > 0) setAssetId(String(data.assets[0].id))
-      if (data.commands.length > 0) setCommand(data.commands[0].value)
+      const firstAsset = data.assets[0]
+      if (firstAsset) setAssetId(String(firstAsset.id))
+      const firstCommand = data.commands[0]
+      if (firstCommand) setCommand(firstCommand.value)
     })
     return () => {
       cancelled = true

--- a/frontend/SearchAdder/SearchAdderDialog.tsx
+++ b/frontend/SearchAdder/SearchAdderDialog.tsx
@@ -54,7 +54,8 @@ export function SearchAdderDialog({ map, objectType, objectID, onClose }: Props)
     smmGetJSON<{ asset_types: AssetType[] }>('/assets/assettypes/', {}).then((data) => {
       const types = data.asset_types ?? []
       setAssetTypes(types)
-      if (types.length > 0) setAssetTypeId(String(types[0].id))
+      const firstType = types[0]
+      if (firstType) setAssetTypeId(String(firstType.id))
     })
     return () => {
       previewRef.current?.remove()

--- a/frontend/asset/ui.tsx
+++ b/frontend/asset/ui.tsx
@@ -371,7 +371,7 @@ function AssetStatus({ asset, details }: AssetStatusProps) {
   usePolling(async () => {
     const data = await smmGetJSON<{ values: AssetStatusValueData[] }>('/assets/status/values/', {})
     setStatusValues(data.values)
-    setSelectedValueId((prev) => (prev === undefined && data.values.length > 0 ? data.values[0].id : prev))
+    setSelectedValueId((prev) => prev ?? data.values[0]?.id)
   }, 10000)
 
   async function setStatus() {

--- a/frontend/mission/asset/status.tsx
+++ b/frontend/mission/asset/status.tsx
@@ -33,7 +33,7 @@ function MissionAssetStatusForm({ asset, mission }: MissionAssetStatusFormProps)
   usePolling(async () => {
     const data = await smmGetJSON<{ values: MissionAssetStatusValue[] }>('/mission/asset/status/values/', {})
     setStatusValues(data.values)
-    setSelectedValueId((prev) => (prev === undefined && data.values.length > 0 ? data.values[0].id : prev))
+    setSelectedValueId((prev) => prev ?? data.values[0]?.id)
   }, 10000)
 
   async function setStatus() {

--- a/frontend/mission/details.tsx
+++ b/frontend/mission/details.tsx
@@ -296,7 +296,7 @@ function MissionDetailsOrganizationAdd({ mission }: { mission: number }) {
   usePolling(async () => {
     const data = await smmGetJSON<{ organizations: OrganizationData[] }>(`/mission/${mission}/organizations/?not_included=True`, {})
     setOrgs(data.organizations)
-    setSelectedOrg((prev) => (prev === undefined && data.organizations.length > 0 ? data.organizations[0].id : prev))
+    setSelectedOrg((prev) => prev ?? data.organizations[0]?.id)
   }, 10000)
 
   function add() {
@@ -427,7 +427,7 @@ function MissionDetailsUserAdd({ mission }: { mission: number }) {
   usePolling(async () => {
     const data = await smmGetJSON<{ users: Array<{ id: number; username: string }> }>(`/mission/${mission}/users/?not_included=True`, {})
     setUsers(data.users)
-    setSelectedUser((prev) => (prev === undefined && data.users.length > 0 ? data.users[0].id : prev))
+    setSelectedUser((prev) => prev ?? data.users[0]?.id)
   }, 10000)
 
   function add() {
@@ -533,7 +533,7 @@ function MissionDetailsAssetAdd({ mission }: { mission: number }) {
   usePolling(async () => {
     const data = await smmGetJSON<{ assets: AssetData[] }>(`/mission/${mission}/assets/?not_included=True`, {})
     setAssets(data.assets)
-    setSelectedAsset((prev) => (prev === undefined && data.assets.length > 0 ? data.assets[0].id : prev))
+    setSelectedAsset((prev) => prev ?? data.assets[0]?.id)
   }, 10000)
 
   function add() {

--- a/frontend/organization/details.tsx
+++ b/frontend/organization/details.tsx
@@ -132,7 +132,7 @@ function OrganizationMemberAdd({ organizationId }: { organizationId: number }) {
   usePolling(async () => {
     const data = await smmGetJSON<{ users: { id: number; username: string }[] }>(`/organization/${organizationId}/users/notmember/`, {})
     setUserList(data.users)
-    setUserId((prev) => (prev === undefined && data.users.length > 0 ? data.users[0].id : prev))
+    setUserId((prev) => prev ?? data.users[0]?.id)
   }, 10000)
 
   async function addOrganizationMember() {
@@ -208,7 +208,7 @@ export function OrganizationAssetAdd({ organizationId }: { organizationId: numbe
   usePolling(async () => {
     const data = await smmGetJSON<{ assets: AssetData[] }>('/assets/', {})
     setAssetList(data.assets)
-    setAssetId((prev) => (prev === undefined && data.assets.length > 0 ? data.assets[0].id : prev))
+    setAssetId((prev) => prev ?? data.assets[0]?.id)
   }, 10000)
 
   async function addOrganizationAsset() {

--- a/frontend/search/SearchQueueDialog.tsx
+++ b/frontend/search/SearchQueueDialog.tsx
@@ -23,7 +23,8 @@ export function SearchQueueDialog({ searchPk, missionId, createdFor, onClose }: 
       if (cancelled) return
       const filtered = d.assets.filter((a) => a.type_name === createdFor)
       setAssets(filtered)
-      if (filtered.length > 0) setSelectedAssetId(String(filtered[0].id))
+      const firstAsset = filtered[0]
+      if (firstAsset) setSelectedAssetId(String(firstAsset.id))
     })
     return () => {
       cancelled = true


### PR DESCRIPTION
## Description

In preparation for noUncheckedIndexedAccess, stop indexing the fetched list at [0] without accounting for undefined. The poller seeding pattern `prev === undefined && list.length > 0 ? list[0].id : prev` becomes the equivalent `prev ?? list[0]?.id`, and the dialog forms bind the first element and null-check it before use. Behaviour is unchanged.

## Summary by Sourcery

Guard initial select values and first-item accessors against undefined results while preserving existing behavior.

Enhancements:
- Update poller seeding logic to use nullish coalescing and optional chaining when deriving initial selected IDs from fetched lists.
- Adjust dialog and form components to safely read the first element of fetched collections before binding initial selection values.