### PR TITLE
Guard geometry coordinate indexing for strict index access

### DIFF
--- a/frontend/geomap.tsx
+++ b/frontend/geomap.tsx
@@ -20,13 +20,13 @@ function GeoJsonMap({ geometry }: GeoJsonMapProps) {
   switch (geometry.type) {
     case 'LineString': {
       const coordinates = mapCoordinates(geometry.coordinates)
-      firstPoint = coordinates[0]
+      firstPoint = coordinates[0] ?? firstPoint
       objects.push(<Polyline key="linestring" positions={coordinates} />)
       break
     }
     case 'Polygon': {
-      const coordinates = mapCoordinates(geometry.coordinates[0])
-      firstPoint = coordinates[0]
+      const coordinates = mapCoordinates(geometry.coordinates[0] ?? [])
+      firstPoint = coordinates[0] ?? firstPoint
       objects.push(<Polygon key="polygon" positions={coordinates} />)
       break
     }

--- a/frontend/geometry/details.tsx
+++ b/frontend/geometry/details.tsx
@@ -17,8 +17,8 @@ export type GeometryJSON =
 
 function coordinateToLatLng(point: number[]): Point {
   return {
-    lat: point[1],
-    lng: point[0]
+    lat: point[1] ?? 0,
+    lng: point[0] ?? 0
   }
 }
 
@@ -36,8 +36,10 @@ function pointsFromGeometry(geometry: GeometryJSON): Point[] {
       return [coordinateToLatLng(geometry.coordinates)]
     case 'LineString':
       return mapCoordinates(geometry.coordinates)
-    case 'Polygon':
-      return mapCoordinates(geometry.coordinates[0])
+    case 'Polygon': {
+      const ring = geometry.coordinates[0]
+      return ring ? mapCoordinates(ring) : []
+    }
   }
 }
 


### PR DESCRIPTION
## Description

coordinateToLatLng falls back to 0 for a missing lon/lat component (well-formed GeoJSON always has both; a real 0 is preserved since ?? only catches undefined). The polygon ring and the map's first-point lookups guard the array index so an empty coordinate list yields an empty result / the default centre rather than undefined.

## Summary by Sourcery

Guard geometry coordinate and first-point lookups against missing indices to avoid undefined values when rendering maps.

Bug Fixes:
- Ensure coordinate-to-lat/lng conversion falls back to 0 when a longitude or latitude component is missing.
- Prevent empty polygon rings and line strings from producing undefined first points by falling back to existing defaults or empty arrays.