### PR TITLE
Harden Leaflet cache and track indexing for strict index access

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -80,14 +80,15 @@ class SMMAssets extends SMMRealtime {
   }
 
   createAsset(assetId: number) {
-    if (!(assetId in this.assetNameMap)) {
+    const assetName = this.assetNameMap[assetId]
+    if (assetName === undefined) {
       return null
     }
     if (!(assetId in this.assetObjects)) {
       const color = cookieJar.get(`asset_${assetId}_track_color`)
-      const assetObject = new SMMAsset(this.map, this.missionId, assetId, this.assetNameMap[assetId], color !== undefined ? color : this.color)
+      const assetObject = new SMMAsset(this.map, this.missionId, assetId, assetName, color !== undefined ? color : this.color)
       this.assetObjects[assetId] = assetObject
-      this.overlayAdd(buildSwatchLabel(this.assetNameMap[assetId], assetObject), assetObject.overlay())
+      this.overlayAdd(buildSwatchLabel(assetName, assetObject), assetObject.overlay())
     }
     return this.assetObjects[assetId]
   }
@@ -124,27 +125,19 @@ class SMMAssets extends SMMRealtime {
 
     const coords = asset.geometry.coordinates as [number, number]
     const { alt, heading, fix } = asset.properties
+    const assetName = this.assetNameMap[assetId] ?? String(assetId)
     this.popups[assetId]?.rerender(
-      <AssetPopup
-        assetName={this.assetNameMap[assetId]}
-        coords={coords}
-        alt={alt}
-        heading={heading}
-        fix={fix}
-        status={assetId in this.assetStatusMap ? this.assetStatusMap[assetId] : undefined}
-      />
+      <AssetPopup assetName={assetName} coords={coords} alt={alt} heading={heading} fix={fix} status={assetId in this.assetStatusMap ? this.assetStatusMap[assetId] : undefined} />
     )
 
     if (asset.geometry.type === 'Point') {
-      const c = asset.geometry.coordinates
-      oldLayer.setLatLng([c[1], c[0]])
+      oldLayer.setLatLng([coords[1], coords[0]])
 
-      const newTitle = this.assetNameMap[assetId]
       const iconEl = oldLayer.getElement()
-      if (iconEl && iconEl.title !== newTitle) {
-        iconEl.title = newTitle
+      if (iconEl && iconEl.title !== assetName) {
+        iconEl.title = assetName
       }
-      oldLayer.options.title = newTitle
+      oldLayer.options.title = assetName
 
       const desiredIconUrl = this.assetIconMap[assetId] // undefined when the asset has no custom icon
       const currentIconUrl = oldLayer.getIcon().options.iconUrl

--- a/frontend/components/TrackedPath.tsx
+++ b/frontend/components/TrackedPath.tsx
@@ -10,7 +10,7 @@ import { renderInLeafletDialog } from './renderInLeafletDialog'
  *  [lon, lat] order, each carrying the time it was recorded. Both the
  *  asset and user position-history responses are supersets of this. */
 interface PositionHistory {
-  features: Array<{ geometry: { coordinates: number[] }; properties: { created_at: string } }>
+  features: Array<{ geometry: { coordinates: [number, number] }; properties: { created_at: string } }>
 }
 
 /**

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -80,11 +80,12 @@ abstract class SMMSearches extends SMMRealtime {
   abstract searchStatus(search: SMMSearchObjectDetailsData): string
 
   getObject(pk: number, search: SMMSearchObjectDetailsData) {
-    if (!(pk in this.searchObjects)) {
-      const searchObject = new SMMSearch(this, search)
+    let searchObject = this.searchObjects[pk]
+    if (!searchObject) {
+      searchObject = new SMMSearch(this, search)
       this.searchObjects[pk] = searchObject
     }
-    return this.searchObjects[pk]
+    return searchObject
   }
 
   createPopup(search: { properties: SMMSearchObjectDetailsData }, layer: L.Layer) {

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -51,13 +51,14 @@ class SMMUserPositions extends SMMRealtime {
   }
 
   createUser(userName: string) {
-    if (!(userName in this.userObjects)) {
+    let userObject = this.userObjects[userName]
+    if (!userObject) {
       const color = cookieJar.get(`user_${userName}_track_color`)
-      const userObject = new SMMUserPosition(this.map, this.missionId, userName, color !== undefined ? color : this.color)
+      userObject = new SMMUserPosition(this.map, this.missionId, userName, color !== undefined ? color : this.color)
       this.userObjects[userName] = userObject
       this.overlayAdd(buildSwatchLabel(userName, userObject), userObject.overlay())
     }
-    return this.userObjects[userName]
+    return userObject
   }
 
   createPopup(user: SMMMissionUserPointTimeGeoJSON, layer: L.Layer) {

--- a/frontend/usergeo/base.tsx
+++ b/frontend/usergeo/base.tsx
@@ -60,10 +60,12 @@ abstract class SMMUserGeoCollection<TGeoJSON extends { properties: SMMUserGeoLab
   abstract createObject(feature: TGeoJSON): TLayer
 
   getObject(pk: number, feature: TGeoJSON): TLayer {
-    if (!(pk in this.objects)) {
-      this.objects[pk] = this.createObject(feature)
+    let obj = this.objects[pk]
+    if (!obj) {
+      obj = this.createObject(feature)
+      this.objects[pk] = obj
     }
-    return this.objects[pk]
+    return obj
   }
 
   createPopup(feature: TGeoJSON, layer: L.Layer) {

--- a/frontend/usergeo/polygon.tsx
+++ b/frontend/usergeo/polygon.tsx
@@ -16,10 +16,11 @@ class SMMPolygon extends SMMUserGeoLayer {
   }
 
   editCallback() {
+    const ring = this.coords[0] ?? []
     PolygonAdder(
       this.map,
       this.missionId,
-      this.coords[0].map((x) => L.latLng(x[1], x[0])),
+      ring.map((x) => L.latLng(x[1], x[0])),
       this.data.pk,
       this.data.label
     )


### PR DESCRIPTION
## Description

Make the object caches return a definite value instead of an unchecked index lookup: createAsset resolves the name once (and bails when absent), createUser and the usergeo/search getObject helpers build-or-return a local. assetUpdate reuses the tuple-cast coords and a resolved name for setLatLng/title/popup, the position-history coordinates are typed as a [lon, lat] tuple, and the polygon edit guards its first ring. No behaviour change.

## Summary by Sourcery

Harden Leaflet-related caches and geometry handling to avoid unsafe index lookups while preserving existing behavior.

Enhancements:
- Resolve and reuse asset names and coordinates before accessing asset-related caches to avoid unchecked map indexing.
- Reuse locally cached user, user-geo, and search objects when available, initializing them lazily when missing instead of relying on raw index access.
- Guard polygon editing against missing first rings when mapping coordinates into Leaflet lat/lng objects.
- Tighten typing of position history geometry coordinates to a fixed [lon, lat] tuple for clearer and safer usage.