### PR TITLE
Harden test-file indexing for strict index access

### DIFF
--- a/frontend/ajax.test.ts
+++ b/frontend/ajax.test.ts
@@ -28,7 +28,10 @@ function mockResponse({ ok, status, json, text }: ResponseInit): Response {
 const fetchMock = vi.fn()
 
 function lastCall() {
-  return fetchMock.mock.calls[fetchMock.mock.calls.length - 1]
+  const { calls } = fetchMock.mock
+  const call = calls[calls.length - 1]
+  if (!call) throw new Error('fetch was not called')
+  return call
 }
 
 beforeEach(() => {

--- a/frontend/mission/details.test.tsx
+++ b/frontend/mission/details.test.tsx
@@ -86,7 +86,7 @@ describe('MissionDetailPage external references', () => {
     await screen.findByText('ABC')
 
     // The code changes server-side while the field is closed.
-    detailsState = { ...detailsState, external_references: [{ ...detailsState.external_references[0], code: 'XYZ' }] }
+    detailsState = { ...detailsState, external_references: [{ id: 50, mission: 1, name: 'IRD', code: 'XYZ', url: 'http://example/x', notes: 'note' }] }
     triggerRepoll()
     await screen.findByText('XYZ')
 
@@ -101,7 +101,7 @@ describe('MissionDetailPage external references', () => {
     await screen.findByText('ABC')
 
     // Code is updated by a background poll; the user never touches it.
-    detailsState = { ...detailsState, external_references: [{ ...detailsState.external_references[0], code: 'XYZ' }] }
+    detailsState = { ...detailsState, external_references: [{ id: 50, mission: 1, name: 'IRD', code: 'XYZ', url: 'http://example/x', notes: 'note' }] }
     triggerRepoll()
     await screen.findByText('XYZ')
 


### PR DESCRIPTION
## Description

lastCall() now binds the last fetch invocation and throws a clear error if fetch wasn't called, instead of returning a possibly-undefined args array. The external-reference re-poll fixtures use an explicit object literal rather than spreading a possibly-undefined array element.

## Summary by Sourcery

Harden tests around fetch usage and mission external-reference updates to avoid accessing undefined array elements.

Bug Fixes:
- Ensure test helper lastCall() throws a clear error when fetch was never called instead of returning an undefined call.
- Avoid spreading from a potentially undefined external_references[0] element in mission detail tests by using an explicit fixture object.

Tests:
- Strengthen ajax and mission detail page tests to rely on explicit, well-defined fetch calls and external reference fixtures.