### PR TITLE
Align assetLayer marker title fallback with the other paths

### DIFF
--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -111,7 +111,7 @@ class SMMAssets extends SMMRealtime {
 
   assetLayer(asset: { properties: { asset: number } }, latlng: L.LatLng) {
     const iconUrl = this.getAssetIcon(asset.properties.asset)
-    const title = this.assetNameMap[asset.properties.asset]
+    const title = this.assetNameMap[asset.properties.asset] ?? String(asset.properties.asset)
     return L.marker(latlng, iconUrl ? { title, icon: customAssetIcon(iconUrl) } : { title })
   }
 


### PR DESCRIPTION
## Description

assetLayer left the marker tooltip undefined when the name map hadn't loaded yet, while createPopup and assetUpdate fall back to String(assetId). Use the same fallback so a marker created before the first name-map poll shows the id rather than no tooltip until the next update.

## Summary by Sourcery

Bug Fixes:
- Ensure asset markers fall back to showing the asset ID in the tooltip when the asset name map has not yet loaded.