### PR TITLE
Move AssetMissionView to search app to break mission<->search import cycle

### DIFF
--- a/mission/urls.py
+++ b/mission/urls.py
@@ -26,5 +26,4 @@ urlpatterns = [
     re_path(r'^$', views.mission_list, name='mission_list'),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/command/set/$', views.AssetCommandSetView.as_view(), name='asset_command_set'),
     re_path(r'^assets/(?P<asset_id>\d+)/command/$', views.AssetCommandView.as_view(), name='assets_command'),
-    re_path(r'^assets/(?P<asset_id>\d+)/mission/$', views.AssetMissionView.as_view(), name='asset_mission_view'),
 ]

--- a/mission/views.py
+++ b/mission/views.py
@@ -20,8 +20,6 @@ from assets.models import Asset, AssetStatus
 from mission.helpers import get_my_assets_not_in_mission
 from organization.decorators import asset_is_operator, get_organization_from_id
 from organization.models import Organization, OrganizationMember, OrganizationAsset
-from search.models import Search
-from search.view_helpers import check_searches_in_progress
 from timeline.models import TimeLineEntry
 from timeline.helpers import timeline_record_create, \
     timeline_record_external_reference_add, timeline_record_external_reference_remove, timeline_record_external_reference_update, \
@@ -31,7 +29,7 @@ from timeline.helpers import timeline_record_create, \
 
 from .models import Mission, MissionExternalReference, MissionUser, MissionAsset, MissionAssetType, MissionOrganization, MissionAssetStatus, MissionAssetStatusValue, AssetCommand
 from .forms import AssetCommandForm, MissionForm, MissionUserForm, MissionAssetForm, MissionOrganizationForm
-from .decorators import get_user_from_id, mission_asset_get, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin
+from .decorators import get_user_from_id, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin
 
 
 @method_decorator(login_required, name="dispatch")
@@ -714,34 +712,6 @@ class MissionExternalReferenceView(View):
         extref.save()
         timeline_record_external_reference_remove(mission=mission_user.mission, user=mission_user.user, external_reference=extref)
         return HttpResponse("Done")
-
-
-@method_decorator(login_required, name="dispatch")
-@method_decorator(asset_is_operator, name="dispatch")
-class AssetMissionView(View):
-    """
-    Mission/search context for an asset: last command, active mission, and searches.
-    """
-    def get(self, request, asset):
-        """
-        Return mission/search context for this asset as JSON.
-        """
-        data = {
-            'last_command': AssetCommand.last_command_for_asset_to_json(asset),
-        }
-        mission_asset = mission_asset_get(asset)
-        if mission_asset is not None:
-            data['mission_id'] = mission_asset.mission.pk
-            data['mission_name'] = mission_asset.mission.mission_name
-
-            current_search = check_searches_in_progress(mission_asset.mission, asset)
-            if current_search is not None:
-                data['current_search_id'] = current_search.pk
-            queued_search = Search.oldest_queued_for_asset(mission_asset.mission, asset)
-            if queued_search is not None:
-                data['queued_search_id'] = queued_search.pk
-
-        return JsonResponse(data)
 
 
 @method_decorator(login_required, name='dispatch')

--- a/search/urls.py
+++ b/search/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     re_path(r'^search/creepingline/create/track/$', views.TrackCreepingLineSearchCreateView.as_view(), name='track_creeping_line_search_create'),
     re_path(r'^search/creepingline/create/polygon/$', views.PolygonCreepingLineSearchCreateView.as_view(), name='polygon_creeping_line_search_create'),
     re_path(r'^search/find/closest/$', views.find_next_search, name='find_next_search'),
+    re_path(r'^assets/(?P<asset_id>\d+)/mission/$', views.AssetMissionView.as_view(), name='asset_mission_view'),
 
     re_path(r'^mission/all/search/notstarted/$', views.search_notstarted_user, {'search_class': Search, 'current_only': False}),
     re_path(r'^mission/all/search/inprogress/$', views.search_inprogress_user, {'search_class': Search, 'current_only': False}),

--- a/search/views.py
+++ b/search/views.py
@@ -21,12 +21,12 @@ from django.utils.decorators import method_decorator
 from django.views import View
 
 from assets.models import AssetType, Asset
-from organization.decorators import asset_id_in_get_post
+from organization.decorators import asset_id_in_get_post, asset_is_operator
 from data.decorators import data_get_mission_id
 from data.models import GeoTimeLabel
 from data.view_helpers import to_kml, to_geojson
-from mission.models import Mission, MissionAsset
-from mission.decorators import mission_is_member, mission_asset_get_mission
+from mission.models import Mission, MissionAsset, AssetCommand
+from mission.decorators import mission_is_member, mission_asset_get_mission, mission_asset_get
 from timeline.helpers import timeline_record_search_finished
 from .decorators import search_from_id
 from .models import Search, SearchParams, ExpandingBoxSearchParams, TrackLineCreepingSearchParams
@@ -425,3 +425,31 @@ class SearchView(View):
             return HttpResponse('Success')
 
         return HttpResponseNotFound('Unable')
+
+
+@method_decorator(login_required, name="dispatch")
+@method_decorator(asset_is_operator, name="dispatch")
+class AssetMissionView(View):
+    """
+    Mission/search context for an asset: last command, active mission, and searches.
+    """
+    def get(self, request, asset):
+        """
+        Return mission/search context for this asset as JSON.
+        """
+        data = {
+            'last_command': AssetCommand.last_command_for_asset_to_json(asset),
+        }
+        mission_asset = mission_asset_get(asset)
+        if mission_asset is not None:
+            data['mission_id'] = mission_asset.mission.pk
+            data['mission_name'] = mission_asset.mission.mission_name
+
+            current_search = check_searches_in_progress(mission_asset.mission, asset)
+            if current_search is not None:
+                data['current_search_id'] = current_search.pk
+            queued_search = Search.oldest_queued_for_asset(mission_asset.mission, asset)
+            if queued_search is not None:
+                data['queued_search_id'] = queued_search.pk
+
+        return JsonResponse(data)


### PR DESCRIPTION
## Description

The AssetMissionView endpoint (asset mission/search context) lived in mission/views.py but reached up into the search app for the asset's current/queued search, creating a mission<->search import cycle (and a data->mission->search->data loop).

Move the view and its route into the search app, which already depends on mission. The URL (assets/<id>/mission/, name asset_mission_view) is unchanged since all app URLConfs mount at the root prefix, so the frontend is unaffected. Also drop the now-unused mission_asset_get import from mission/views.py.

## Summary by Sourcery

Move the asset mission context view and route from the mission app into the search app to resolve an import dependency cycle while preserving the existing API endpoint.

Enhancements:
- Relocate AssetMissionView from mission/views.py to search/views.py without changing its behavior or response format.
- Update URL routing so the asset mission endpoint is now served from the search app while keeping the URL path and name unchanged.