### PR TITLE
Use form.cleaned_data['file'] instead of request.FILES['file'] after validation

### DIFF
--- a/images/views.py
+++ b/images/views.py
@@ -37,7 +37,7 @@ class ImageUploadView(View):
                 point = Point(float(longitude), float(latitude))
             except (ValueError, TypeError):
                 return HttpResponseBadRequest('Invalid lat/long')
-            upload_image_file(mission_user, form.cleaned_data['description'], point, request.FILES['file'])
+            upload_image_file(mission_user, form.cleaned_data['description'], point, form.cleaned_data['file'])
             return HttpResponseRedirect(f'/mission/{mission_user.mission.pk}/map/')
         return HttpResponseBadRequest()
 


### PR DESCRIPTION
## Description

After form.is_valid(), the file should be taken from form.cleaned_data so it goes through whatever cleaning the form field applies, rather than bypassing it.

## Summary by Sourcery

Bug Fixes:
- Ensure image uploads use the cleaned file field from the validated form rather than bypassing form cleaning via direct access to request.FILES.