### PR TITLE
Validate boolean JSON fields strictly instead of using bool()

### DIFF
--- a/images/views.py
+++ b/images/views.py
@@ -117,9 +117,11 @@ class ImagePriorityView(View):
         """Update image priority from JSON body {"priority": true/false}."""
         try:
             body = json.loads(request.body)
-            priority = bool(body.get('priority'))
-        except (ValueError, KeyError):
+        except ValueError:
             return HttpResponseBadRequest('Expected JSON body with {"priority": true/false}')
+        priority = body.get('priority')
+        if not isinstance(priority, bool):
+            return HttpResponseBadRequest('priority must be a boolean')
         image.priority = priority
         image.save()
         timeline_record_image_priority_changed(mission_user.mission, mission_user.user, image)

--- a/mission/views.py
+++ b/mission/views.py
@@ -452,14 +452,17 @@ class MissionUserView(View):
         add_organization = body.get('add_organization', None)
         add_user = body.get('add_user', None)
 
+        if any(v is not None and not isinstance(v, bool) for v in (admin, add_organization, add_user)):
+            return HttpResponseBadRequest('admin, add_organization and add_user must be booleans')
+
         if admin is not None or add_organization is not None or add_user is not None:
             target_mission_user = get_object_or_404(MissionUser, mission=mission_user.mission, user=user)
             if admin is not None:
-                self._update_user_permissions(mission_user, target_mission_user, 'admin', bool(admin))
+                self._update_user_permissions(mission_user, target_mission_user, 'admin', admin)
             if add_organization is not None:
-                self._update_user_permissions(mission_user, target_mission_user, 'organization_add', bool(add_organization))
+                self._update_user_permissions(mission_user, target_mission_user, 'organization_add', add_organization)
             if add_user is not None:
-                self._update_user_permissions(mission_user, target_mission_user, 'user_add', bool(add_user))
+                self._update_user_permissions(mission_user, target_mission_user, 'user_add', add_user)
             target_mission_user.save()
         return HttpResponse('')
 


### PR DESCRIPTION
## Description

bool() silently accepts any truthy value — "false" evaluates to True, a non-zero int is also True, etc. Validate that priority/admin/add_organization/ add_user are actual JSON booleans and return 400 if not.

## Summary by Sourcery

Enforce strict boolean handling for selected JSON request fields and return validation errors when non-boolean values are provided.

Bug Fixes:
- Validate mission user admin/add_organization/add_user flags as JSON booleans instead of coercing arbitrary truthy values.
- Validate image priority in patch requests as a JSON boolean and reject non-boolean values with a 400 response.