### PR TITLE
Replace per-item asset.pk deref with a values() subquery in search form

### DIFF
--- a/search/forms.py
+++ b/search/forms.py
@@ -16,8 +16,9 @@ class AssetSearchQueueEntryForm(ModelForm):
     def __init__(self, *args, **kwargs):
         self.mission = kwargs.pop('mission')
         super().__init__(*args, **kwargs)
-        mission_assets = MissionAsset.objects.filter(mission=self.mission, removed__isnull=True)
-        self.fields['queued_for_asset'].queryset = Asset.objects.filter(pk__in=[mission_asset.asset.pk for mission_asset in mission_assets])
+        self.fields['queued_for_asset'].queryset = Asset.objects.filter(
+            pk__in=MissionAsset.objects.filter(mission=self.mission, removed__isnull=True).values('asset')
+        )
 
     class Meta:
         model = Search

--- a/search/forms.py
+++ b/search/forms.py
@@ -16,8 +16,9 @@ class AssetSearchQueueEntryForm(ModelForm):
     def __init__(self, *args, **kwargs):
         self.mission = kwargs.pop('mission')
         super().__init__(*args, **kwargs)
+        mission_assets = MissionAsset.objects.filter(mission=self.mission, removed__isnull=True)
         self.fields['queued_for_asset'].queryset = Asset.objects.filter(
-            pk__in=MissionAsset.objects.filter(mission=self.mission, removed__isnull=True).values('asset')
+            pk__in=mission_assets.values_list('asset', flat=True)
         )
 
     class Meta:


### PR DESCRIPTION
## Description

The list comprehension accessed mission_asset.asset.pk in a loop, hitting the DB once per MissionAsset to dereference the FK. Replace with a single values('asset') subquery.

## Summary by Sourcery

Enhancements:
- Improve AssetSearchQueueEntryForm performance by replacing per-mission-asset FK lookups with a single subquery-based Asset queryset filter.