### PR TITLE
Pin numpy to 2.4.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytz
 psycopg[binary,pool]==3.3.4
 
 # Numerical
-numpy
+numpy==2.4.5
 haversine
 
 # uwsgi


### PR DESCRIPTION
## Description

Pin numpy to a known-good version to avoid surprise breakages from NumPy API removals during deployment, matching the existing == pins for django and psycopg.