### PR TITLE
Pin remaining top-level Python dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 # Code checking
-pycodestyle
+pycodestyle==2.14.0
 pylint==4.0.*
 pylint-django==2.7.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
 django==6.0.6
 
 # Timezone support
-pytz
+pytz==2026.2
 
 # Database
 psycopg[binary,pool]==3.3.4
 
 # Numerical
 numpy==2.4.5
-haversine
+haversine==2.9.0
 
 # uwsgi
-uwsgi
+uwsgi==2.0.31
 
 # static file serving
-whitenoise
+whitenoise==6.12.0
 
 # image support
-image
+image==1.5.33


### PR DESCRIPTION
## Description

There is no lockfile, so unpinned packages resolve to the latest release on every fresh venv, which is how the NumPy 2.0 cross-product removal slipped into CI. Pin the remaining top-level deps to their known-good installed versions:

- pytz, haversine, uwsgi, whitenoise, image (runtime)
- pycodestyle (gates the check-code CI job)

## Summary by Sourcery

Build:
- Pin pytz, haversine, uwsgi, whitenoise, and image runtime dependencies to specific versions in requirements.txt.