### PR TITLE
Update stale Django 2.1 doc links to /en/stable/

### DIFF
--- a/smm/local_settings.py.template
+++ b/smm/local_settings.py.template
@@ -14,7 +14,7 @@ LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 
 # Database
-# https://docs.djangoproject.com/en/2.1/ref/settings/#databases
+# https://docs.djangoproject.com/en/stable/ref/settings/#databases
 
 DATABASES = {
     'default': {

--- a/smm/urls.py
+++ b/smm/urls.py
@@ -1,7 +1,7 @@
 """smm URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/2.1/topics/http/urls/
+    https://docs.djangoproject.com/en/stable/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views

--- a/smm/wsgi.py
+++ b/smm/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for smm project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/2.1/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/stable/howto/deployment/wsgi/
 """
 
 import os


### PR DESCRIPTION
## Description

The remaining /en/2.1/ documentation links in the settings template, URL conf, and WSGI config predate the Django 6 upgrade. Point them at /en/stable/ so they track the supported version.

## Summary by Sourcery

Documentation:
- Refresh Django URL configuration documentation link to use the /en/stable/ version of the docs.