### PR TITLE
Document Docker env vars and refresh README deploy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,28 @@ docker-compose up
 docker-compose run app ./docker/app/test.sh
 ```
 
+#### Configuration
+
+The container generates `smm/local_settings.py` from the template at startup and
+reads its configuration from environment variables (see `docker-compose.yaml`
+for a working example):
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `DB_HOST` | PostGIS host | (from template) |
+| `DB_NAME` | Database name | (from template) |
+| `DB_USER` | Database user | (from template) |
+| `DB_PASS` | Database password | (from template) |
+| `ALLOWED_HOSTS` | Comma-separated allowed hosts | `localhost` |
+| `CSRF_TRUSTED_ORIGINS` | Comma-separated trusted origins | `http://localhost:8080` |
+| `DJANGO_SUPERUSER_USERNAME` | Superuser created on first start, if set | (unset) |
+| `DJANGO_SUPERUSER_PASSWORD` | Password for that superuser | (unset) |
+| `DJANGO_SUPERUSER_EMAIL` | Email for that superuser | (unset) |
+
 ## Deploying
-[Refer to Django mod_wsgi documentation](https://docs.djangoproject.com/en/2.1/howto/deployment/wsgi/)
+
+The container runs under uWSGI. For other deployment options, refer to the
+[Django WSGI deployment documentation](https://docs.djangoproject.com/en/stable/howto/deployment/wsgi/).
 
 ## Authors
 See the list of [contributors](https://github.com/canterbury-air-patrol/search-management-map/contributors).


### PR DESCRIPTION
## Description

The README's deployment notes still linked to Django 2.1 mod_wsgi docs and documented none of the environment variables the container reads. Add a Configuration table covering the DB_*, ALLOWED_HOSTS, CSRF_TRUSTED_ORIGINS, and DJANGO_SUPERUSER_* vars, and note that the container runs under uWSGI with the deployment link pointed at /en/stable/.

## Summary by Sourcery

Document Docker environment-based configuration and clarify container deployment under uWSGI.

Documentation:
- Add a configuration section to the README documenting Docker environment variables used by the app container.
- Update README deployment notes to reference current Django WSGI deployment documentation and note uWSGI usage.