### PR TITLE
Add HTTPS security settings with a dev/HTTP override

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,9 @@ services:
       - DB_PASS=password
       - ALLOWED_HOSTS=localhost
       - CSRF_TRUSTED_ORIGINS=http://localhost:8080
+      # This demo serves plain HTTP on :8080; real deployments behind TLS should
+      # drop this so cookies/redirects default to HTTPS-only.
+      - SECURE_SSL=False
       - DJANGO_SUPERUSER_USERNAME=admin
       - DJANGO_SUPERUSER_PASSWORD=administrator
       - DJANGO_SUPERUSER_EMAIL=me@example.com

--- a/smm/settings.py
+++ b/smm/settings.py
@@ -4,6 +4,8 @@ Django settings for smm project.
 
 import os
 
+from django.core.exceptions import ImproperlyConfigured
+
 # Import other settings
 from smm.local_settings import *
 
@@ -132,6 +134,10 @@ if SECURE_SSL:
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     # HSTS is opt-in and off by default: it is hard to undo, so operators should
     # set SECURE_HSTS_SECONDS (e.g. 31536000) only once HTTPS-only is confirmed.
-    SECURE_HSTS_SECONDS = int(os.environ.get('SECURE_HSTS_SECONDS', '0'))
+    # Fail loudly on a non-integer value rather than silently disabling HSTS.
+    try:
+        SECURE_HSTS_SECONDS = int(os.environ.get('SECURE_HSTS_SECONDS', '0'))
+    except ValueError as exc:
+        raise ImproperlyConfigured('SECURE_HSTS_SECONDS must be an integer number of seconds') from exc
     SECURE_HSTS_INCLUDE_SUBDOMAINS = SECURE_HSTS_SECONDS > 0
     SECURE_HSTS_PRELOAD = SECURE_HSTS_SECONDS > 0

--- a/smm/settings.py
+++ b/smm/settings.py
@@ -121,7 +121,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 # so local development runs over plain HTTP with no extra setup. Override either
 # way with the SECURE_SSL env var (set SECURE_SSL=False for HTTP-only
 # deployments, e.g. the bundled docker-compose demo).
-SECURE_SSL = os.environ.get('SECURE_SSL', 'False' if globals().get('DEBUG', False) else 'True') == 'True'
+SECURE_SSL = os.environ.get('SECURE_SSL', 'False' if globals().get('DEBUG', False) else 'True').strip().lower() in ('true', '1', 'yes', 'on')
 
 SESSION_COOKIE_SECURE = SECURE_SSL
 CSRF_COOKIE_SECURE = SECURE_SSL

--- a/smm/settings.py
+++ b/smm/settings.py
@@ -112,3 +112,26 @@ STORAGES = {
 LOGIN_REDIRECT_URL = '/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+
+# Security: HTTPS-only cookies and SSL redirect.
+# https://docs.djangoproject.com/en/stable/topics/security/
+#
+# Enabled by default in production and disabled automatically when DEBUG is on,
+# so local development runs over plain HTTP with no extra setup. Override either
+# way with the SECURE_SSL env var (set SECURE_SSL=False for HTTP-only
+# deployments, e.g. the bundled docker-compose demo).
+SECURE_SSL = os.environ.get('SECURE_SSL', 'False' if globals().get('DEBUG', False) else 'True') == 'True'
+
+SESSION_COOKIE_SECURE = SECURE_SSL
+CSRF_COOKIE_SECURE = SECURE_SSL
+SECURE_SSL_REDIRECT = SECURE_SSL
+
+if SECURE_SSL:
+    # TLS is terminated at the reverse proxy / load balancer in front of uWSGI.
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+    # HSTS is opt-in and off by default: it is hard to undo, so operators should
+    # set SECURE_HSTS_SECONDS (e.g. 31536000) only once HTTPS-only is confirmed.
+    SECURE_HSTS_SECONDS = int(os.environ.get('SECURE_HSTS_SECONDS', '0'))
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = SECURE_HSTS_SECONDS > 0
+    SECURE_HSTS_PRELOAD = SECURE_HSTS_SECONDS > 0

--- a/test-venv.sh
+++ b/test-venv.sh
@@ -2,6 +2,10 @@
 
 source venv/bin/activate
 
+# The Django test client speaks plain HTTP, so disable HTTPS-only redirects
+# (which default on when DEBUG is False) to stop every request 301'ing.
+export SECURE_SSL=False
+
 coverage run --source=. ./manage.py test
 RES=$?
 


### PR DESCRIPTION
## Description

Set SESSION_COOKIE_SECURE, CSRF_COOKIE_SECURE, and SECURE_SSL_REDIRECT (plus an opt-in HSTS and the proxy SSL header) so production serves cookies and redirects over HTTPS only. These clear the security.W008/W012/W016 deploy-check warnings.

The toggle defaults to off when DEBUG is on, so local development still runs over plain HTTP with no setup, and can be forced either way with the SECURE_SSL env var. The bundled docker-compose demo serves plain HTTP on :8080, so it sets SECURE_SSL=False; real TLS deployments drop that to get the secure default. HSTS stays off unless SECURE_HSTS_SECONDS is set, since it is hard to undo.

## Summary by Sourcery

Configure HTTPS-related security settings with an environment-driven toggle that defaults to secure behavior in production while preserving HTTP-based local development.

New Features:
- Add environment-controlled SECURE_SSL toggle to enable or disable HTTPS-only behavior across cookies and redirects.
- Introduce optional HSTS configuration based on SECURE_HSTS_SECONDS for deployments that want strict HTTPS enforcement.

Enhancements:
- Align Django security settings (secure cookies, SSL redirect, proxy SSL header) with production HTTPS deployments while avoiding friction for local development.
- Update the demo docker-compose configuration to explicitly run over plain HTTP by disabling the SECURE_SSL toggle.