### PR TITLE
search: require POST for search state changes

### DIFF
--- a/search/tests.py
+++ b/search/tests.py
@@ -448,3 +448,65 @@ class SearchTestCase(TestCase):
             'asset_id': self.asset1.pk,
         })
         self.assertEqual(response.status_code, 405)
+
+    def test_1100_queue_rejects_get(self):
+        """
+        Queueing a search mutates state, so GET must be rejected (CSRF safe method).
+        """
+        poi = self.create_poi(-43.5, 172.5)
+        search = self.searches.create_sector(poi, 200, self.asset_type1)
+        response = self.smm.client1.get(f'/search/{search.search_id}/queue/')
+        self.assertEqual(response.status_code, 405)
+        self.assertIsNone(search.as_object().queued_at)
+
+    def test_1101_queue_via_post(self):
+        """
+        Queueing a search via POST still works.
+        """
+        poi = self.create_poi(-43.5, 172.5)
+        search = self.searches.create_sector(poi, 200, self.asset_type1)
+        response = self.smm.client1.post(f'/search/{search.search_id}/queue/', data={})
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(search.as_object().queued_at)
+
+    def test_1102_begin_rejects_get(self):
+        """
+        Beginning a search mutates state, so GET must be rejected.
+        """
+        poi = self.create_poi(-43.5, 172.5)
+        search = self.searches.create_sector(poi, 200, self.asset_type1)
+        response = self.smm.client1.get(f'/search/{search.search_id}/begin/', data={'asset_id': self.asset1.pk})
+        self.assertEqual(response.status_code, 405)
+        self.assertIsNone(search.as_object().inprogress_by)
+
+    def test_1103_begin_via_post(self):
+        """
+        Beginning a search via POST still works.
+        """
+        poi = self.create_poi(-43.5, 172.5)
+        search = self.searches.create_sector(poi, 200, self.asset_type1)
+        response = self.smm.client1.post(f'/search/{search.search_id}/begin/', data={'asset_id': self.asset1.pk})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(search.as_object().inprogress_by, self.asset1)
+
+    def test_1104_finished_rejects_get(self):
+        """
+        Finishing a search mutates state, so GET must be rejected.
+        """
+        poi = self.create_poi(-43.5, 172.5)
+        search = self.searches.create_sector(poi, 200, self.asset_type1)
+        self.smm.client1.post(f'/search/{search.search_id}/begin/', data={'asset_id': self.asset1.pk})
+        response = self.smm.client1.get(f'/search/{search.search_id}/finished/', data={'asset_id': self.asset1.pk})
+        self.assertEqual(response.status_code, 405)
+        self.assertIsNone(search.as_object().completed_at)
+
+    def test_1105_finished_via_post(self):
+        """
+        Finishing a search via POST still works.
+        """
+        poi = self.create_poi(-43.5, 172.5)
+        search = self.searches.create_sector(poi, 200, self.asset_type1)
+        self.smm.client1.post(f'/search/{search.search_id}/begin/', data={'asset_id': self.asset1.pk})
+        response = self.smm.client1.post(f'/search/{search.search_id}/finished/', data={'asset_id': self.asset1.pk})
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(search.as_object().completed_at)

--- a/search/views.py
+++ b/search/views.py
@@ -19,6 +19,7 @@ from django.contrib.gis.geos import Point
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views import View
+from django.views.decorators.http import require_POST
 
 from assets.models import AssetType, Asset
 from organization.decorators import asset_id_in_get_post, asset_is_operator
@@ -131,6 +132,7 @@ def check_search_state(search, action, asset):
     return None
 
 
+@require_POST
 @login_required
 @asset_id_in_get_post
 @mission_asset_get_mission
@@ -156,6 +158,7 @@ def search_begin(request, search_id, object_class, asset, mission):
     return error if error is not None else HttpResponseNotFound('Try Again')
 
 
+@require_POST
 @login_required
 @asset_id_in_get_post
 @mission_asset_get_mission
@@ -177,6 +180,7 @@ def search_finished(request, search_id, object_class, asset, mission):
     return HttpResponse("Completed")
 
 
+@require_POST
 @login_required
 @search_from_id
 @data_get_mission_id(arg_name='search')
@@ -190,7 +194,7 @@ def search_queue(request, search, mission_user):
         return HttpResponseForbidden(f"This search is already queued for {search.get_match()}")
 
     asset = None
-    if request.method == "POST" and 'asset' in request.POST:
+    if 'asset' in request.POST:
         asset = get_object_or_404(Asset, pk=request.POST['asset'])
         # Make sure this asset is a member of this mission
         get_object_or_404(MissionAsset, mission=mission_user.mission, asset=asset, removed__isnull=True)


### PR DESCRIPTION
## Description

search_begin, search_finished, and search_queue mutate search state but accepted GET requests, which Django's CSRF middleware does not protect. A logged-in user visiting a malicious page could be made to queue, begin, or finish a search via a simple GET.

Restrict all three to POST with @require_POST. The frontend (smmPost) and the smm-python client already POST these endpoints, so no client change is needed. The now-redundant request.method == "POST" guard inside search_queue is dropped.

Add tests that GET returns 405 without mutating state and that the POST path still works for each endpoint.

## Summary by Sourcery

Enforce POST-only access for search state mutation endpoints and validate the behavior with tests.

Bug Fixes:
- Prevent CSRF-vulnerable GET requests from mutating search state on the queue, begin, and finished endpoints.

Tests:
- Add tests ensuring search queue, begin, and finished endpoints reject GET with 405 and do not change state, while POST requests still perform the expected state transitions.