### PR TITLE
mission: require POST to close a mission

### DIFF
--- a/frontend/mission/list.test.tsx
+++ b/frontend/mission/list.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../page-shell', () => ({}))
+vi.mock('../ajax', () => ({
+  smmGetJSON: vi.fn(() => Promise.resolve({ missions: [] })),
+  smmPost: vi.fn((_url: string, _data: unknown, success?: (data: unknown) => void) => {
+    success?.('')
+    return Promise.resolve('')
+  })
+}))
+
+import { smmPost } from '../ajax'
+import { MissionListRow } from './list'
+import type { MissionData } from './types'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+const activeMission = {
+  id: 7,
+  name: 'Op Kahu',
+  started: '2024-01-01T00:00:00Z',
+  creator: 'controller',
+  admin: true
+} as unknown as MissionData
+
+function renderRow(mission: MissionData, onChanged?: () => void) {
+  return render(
+    <table>
+      <tbody>
+        <MissionListRow mission={mission} showButtons={true} showClosed={false} onChanged={onChanged} />
+      </tbody>
+    </table>
+  )
+}
+
+describe('MissionListRow - close button', () => {
+  it('closes the mission via POST and refreshes the list', async () => {
+    const onChanged = vi.fn()
+    renderRow(activeMission, onChanged)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(smmPost).toHaveBeenCalledWith('/mission/7/close/', {}, expect.any(Function))
+    expect(onChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not offer Close to non-admins', () => {
+    renderRow({ ...activeMission, admin: false })
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+  })
+
+  it('does not offer Close on an already-closed mission', () => {
+    renderRow({ ...activeMission, closed: '2024-02-01T00:00:00Z' } as unknown as MissionData)
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+  })
+})

--- a/frontend/mission/list.tsx
+++ b/frontend/mission/list.tsx
@@ -1,10 +1,10 @@
 import '../page-shell'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { Table, Button, ButtonGroup } from 'react-bootstrap'
 
 import { formatLocalDateTime } from '../format'
-import { smmGetJSON } from '../ajax'
+import { smmGetJSON, smmPost } from '../ajax'
 import { SMMTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
 import { Loading, LoadFailed } from '../components/Loading'
@@ -14,9 +14,10 @@ interface MissionListRowProps {
   mission: MissionData
   showClosed: boolean
   showButtons: boolean
+  onChanged?: () => void
 }
 
-function MissionListRow({ mission, showClosed, showButtons }: MissionListRowProps) {
+function MissionListRow({ mission, showClosed, showButtons, onChanged }: MissionListRowProps) {
   const dataFields = [<td key="name">{mission.name}</td>, <td key="opened">{formatLocalDateTime(mission.started)}</td>, <td key="creator">{mission.creator}</td>]
 
   if (showClosed) {
@@ -37,8 +38,11 @@ function MissionListRow({ mission, showClosed, showButtons }: MissionListRowProp
       </Button>
     ]
     if (!mission.closed && mission.admin) {
+      const closeMission = () => {
+        smmPost(`/mission/${mission.id}/close/`, {}, () => onChanged?.())
+      }
       buttons.push(
-        <Button key="close" className="btn-danger" href={`/mission/${mission.id}/close/`}>
+        <Button key="close" className="btn-danger" onClick={closeMission}>
           Close
         </Button>
       )
@@ -52,7 +56,7 @@ function MissionListRow({ mission, showClosed, showButtons }: MissionListRowProp
   return <tr key={mission.id}>{dataFields}</tr>
 }
 
-function ActiveMissionList({ missions }: { missions: MissionData[] }) {
+function ActiveMissionList({ missions, onChanged }: { missions: MissionData[]; onChanged: () => void }) {
   return (
     <Table responsive>
       <thead>
@@ -70,7 +74,7 @@ function ActiveMissionList({ missions }: { missions: MissionData[] }) {
       </thead>
       <tbody>
         {missions.map((mission) => (
-          <MissionListRow key={mission.id} mission={mission} showButtons={true} showClosed={false} />
+          <MissionListRow key={mission.id} mission={mission} showButtons={true} showClosed={false} onChanged={onChanged} />
         ))}
       </tbody>
     </Table>
@@ -118,7 +122,7 @@ function MissionListPage() {
   const [missions, setMissions] = useState<MissionData[] | undefined>(undefined)
   const [loadFailed, setLoadFailed] = useState(false)
 
-  usePolling(async () => {
+  const refresh = useCallback(async () => {
     try {
       const data = await smmGetJSON<{ missions: MissionData[] }>('/mission/list/', {})
       setMissions(data.missions)
@@ -127,7 +131,9 @@ function MissionListPage() {
       console.error('Failed to fetch missions:', e)
       setLoadFailed(true)
     }
-  }, 10000)
+  }, [])
+
+  usePolling(refresh, 10000)
 
   const { active, closed } = useMemo(
     () => ({
@@ -143,7 +149,7 @@ function MissionListPage() {
 
   return (
     <div>
-      <ActiveMissionList missions={active} />
+      <ActiveMissionList missions={active} onChanged={refresh} />
       <GeneralMissionButtons />
       <CompletedMissionList missions={closed} />
     </div>

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -71,7 +71,7 @@ class MissionTestWrapper:
         """
         if client is None:
             client = self.smm.client1
-        return client.get(f'/mission/{self.mission_pk}/close/', follow=True)
+        return client.post(f'/mission/{self.mission_pk}/close/', follow=True)
 
     def add_asset(self, asset, client=None):
         """
@@ -241,6 +241,17 @@ class MissionTestCase(MissionBaseTestCase):
         mission.add_user()
         response = mission.close(client=self.smm.client2)
         self.assertEqual(response.status_code, 403)
+        mission_obj = mission.get_object()
+        self.assertIsNone(mission_obj.closed)
+        self.assertIsNone(mission_obj.closed_by)
+
+    def test_mission_close_rejects_get(self):
+        """
+        Closing a mission mutates state, so GET must be rejected (CSRF safe method).
+        """
+        mission = self.missions.create_mission('test_mission_close_rejects_get')
+        response = self.smm.client1.get(f'/mission/{mission.mission_pk}/close/')
+        self.assertEqual(response.status_code, 405)
         mission_obj = mission.get_object()
         self.assertIsNone(mission_obj.closed)
         self.assertIsNone(mission_obj.closed_by)

--- a/mission/views.py
+++ b/mission/views.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.http import require_POST
 
 from assets.models import Asset, AssetStatus
 from mission.helpers import get_my_assets_not_in_mission
@@ -97,6 +98,7 @@ class MissionDetailsView(View):
         return render(request, 'mission_details.html', data)
 
 
+@require_POST
 @login_required
 @mission_is_admin
 def mission_close(request, mission_user):


### PR DESCRIPTION
## Description

mission_close mutated state but accepted GET, which Django's CSRF middleware does not protect: a logged-in admin visiting a malicious page could be made to close a mission via a simple link/navigation.

Restrict mission_close to POST with @require_POST. The mission list's Close button is changed from an href link to an onClick that POSTs via smmPost and refreshes the list through a threaded onChanged callback (the poll fetch is extracted into a useCallback for reuse).

Tests: GET returns 405 without closing the mission; the existing close helper and its tests now POST; a frontend test covers the POST URL, list refresh, and that Close is hidden for non-admins and closed missions.

The smm-python client still closes via GET; a fixup note is tracked in that repo's todo/ to switch it to POST alongside this change.

## Summary by Sourcery

Require missions to be closed via POST only and update the mission list UI and tests accordingly.

Bug Fixes:
- Prevent CSRF-vulnerable mission closure by rejecting GET requests and requiring POST for mission_close.

Enhancements:
- Update the mission list frontend to close missions via an AJAX POST and refresh the list when a mission is closed.

Tests:
- Extend backend mission tests to cover rejection of GET close requests and update existing helpers to use POST.
- Add frontend tests for the mission close button behavior, including POST invocation, list refresh callback, and visibility rules.