### PR TITLE
data: require POST to record asset and user positions

### DIFF
--- a/assets/tests.py
+++ b/assets/tests.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from smm.tests import SMMTestUsers
 
 from organization.models import Organization, OrganizationMember, OrganizationAsset
+from data.models import AssetPointTime
 
 from .models import AssetType, Asset
 
@@ -213,3 +214,12 @@ class AssetTestCase(TestCase):
             'heading': 0,
         })
         self.assertEqual(response.status_code, 403)
+
+    def test_asset_record_position_rejects_get(self):
+        """
+        Recording a position mutates state, so GET must be rejected (CSRF safe method).
+        """
+        asset = self.assets.create_asset()
+        response = self.smm.client1.get(f'/data/assets/{asset.pk}/position/add/', {'lat': -43.5, 'lon': 172.5})
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(AssetPointTime.objects.filter(asset=asset).count(), 0)

--- a/data/tests.py
+++ b/data/tests.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from mission.models import Mission, MissionUser
-from .models import GeoTimeLabel
+from .models import GeoTimeLabel, UserPointTime
 
 
 class UserDataTestCase(TestCase):
@@ -25,6 +25,34 @@ class UserDataTestCase(TestCase):
         self.user_non_member = get_user_model().objects.create_user('test2', password='password')
         self.mission = Mission.objects.create(creator=self.user)
         MissionUser(mission=self.mission, user=self.user, permissions_admin=True, creator=self.user).save()
+
+
+class UserRecordPositionTestCase(TestCase):
+    """
+    Tests for recording a user's own position
+    """
+    def setUp(self):
+        self.user = get_user_model().objects.create_user('test', password='password')
+        self.mission = Mission.objects.create(creator=self.user)
+        MissionUser(mission=self.mission, user=self.user, permissions_admin=True, creator=self.user).save()
+        self.url = f'/mission/{self.mission.pk}/data/user/{self.user.username}/position/add/'
+        self.client.force_login(self.user)
+
+    def test_user_record_position_via_post(self):
+        """
+        Recording a user position via POST works.
+        """
+        response = self.client.post(self.url, {'lat': -43.5, 'lon': 172.5})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(UserPointTime.objects.filter(user=self.user).count(), 1)
+
+    def test_user_record_position_rejects_get(self):
+        """
+        Recording a user position mutates state, so GET must be rejected.
+        """
+        response = self.client.get(self.url, {'lat': -43.5, 'lon': 172.5})
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(UserPointTime.objects.filter(user=self.user).count(), 0)
 
 
 class GeoTimeAllCurrentTestCase(TestCase):

--- a/data/views.py
+++ b/data/views.py
@@ -19,6 +19,7 @@ from django.contrib.gis.geos import Point
 from django.shortcuts import get_object_or_404, render
 from django.utils.decorators import method_decorator
 from django.views import View
+from django.views.decorators.http import require_POST
 
 from smm.settings import TIME_ZONE
 from assets.models import Asset
@@ -64,6 +65,7 @@ def assets_position_latest_user(request, current_only):
     return to_geojson(AssetPointTime, positions)
 
 
+@require_POST
 @login_required
 @asset_is_recorder
 def asset_record_position(request, asset):
@@ -71,30 +73,18 @@ def asset_record_position(request, asset):
     Record the current position of an asset.
 
     Only allows recording of the assets position by the owner.
-    Accepts get requests because some assets are very basic.
+
+    Recording a position mutates state, so it requires POST (Django's CSRF
+    protection only covers unsafe methods). Basic assets that can only issue
+    simple requests can authenticate with an in-URL token (see the tokens app).
 
     Return the last command that applies to an object
     """
-    lat = ''
-    lon = ''
-    fix = None
-    alt = None
-    heading = None
-
-    if request.method == 'GET':
-        lat = request.GET.get('lat')
-        lon = request.GET.get('lon')
-        fix = request.GET.get('fix')
-        alt = request.GET.get('alt')
-        heading = request.GET.get('heading')
-    elif request.method == 'POST':
-        lat = request.POST.get('lat')
-        lon = request.POST.get('lon')
-        fix = request.POST.get('fix')
-        alt = request.POST.get('alt')
-        heading = request.POST.get('heading')
-    else:
-        return HttpResponseBadRequest("Unsupported method")
+    lat = request.POST.get('lat')
+    lon = request.POST.get('lon')
+    fix = request.POST.get('fix')
+    alt = request.POST.get('alt')
+    heading = request.POST.get('heading')
 
     point = None
     with contextlib.suppress(ValueError, TypeError):
@@ -204,6 +194,7 @@ def users_position_latest_user(request, current_only):
     return to_geojson(UserPointTime, positions)
 
 
+@require_POST
 @login_required
 @mission_is_member
 def user_record_position(request, mission_user, user):
@@ -211,30 +202,18 @@ def user_record_position(request, mission_user, user):
     Record the current position of a user.
 
     Only allows recording of the assets position by the owner.
-    """
-    lat = ''
-    lon = ''
-    fix = None
-    alt = None
-    heading = None
 
+    Recording a position mutates state, so it requires POST (Django's CSRF
+    protection only covers unsafe methods).
+    """
     if request.user.username != user:
         return HttpResponse('Unauthorized', status=401)
 
-    if request.method == 'GET':
-        lat = request.GET.get('lat')
-        lon = request.GET.get('lon')
-        fix = request.GET.get('fix')
-        alt = request.GET.get('alt')
-        heading = request.GET.get('heading')
-    elif request.method == 'POST':
-        lat = request.POST.get('lat')
-        lon = request.POST.get('lon')
-        fix = request.POST.get('fix')
-        alt = request.POST.get('alt')
-        heading = request.POST.get('heading')
-    else:
-        return HttpResponseBadRequest("Unsupported method")
+    lat = request.POST.get('lat')
+    lon = request.POST.get('lon')
+    fix = request.POST.get('fix')
+    alt = request.POST.get('alt')
+    heading = request.POST.get('heading')
 
     point = None
     with contextlib.suppress(ValueError, TypeError):


### PR DESCRIPTION
## Description

asset_record_position and user_record_position wrote position data but accepted GET, which Django's CSRF middleware does not protect. Recording a position is a state change and should not be reachable from a safe method.

Restrict both to POST with @require_POST and drop the now-dead GET/else branches, reading directly from request.POST. The frontend (smmPost) and the smm-python client already POST these endpoints.

The smm-asset-api C library still reports positions via GET query string; a fixup note is tracked in that repo's todo/ to switch it to POST. Basic assets that cannot manage a session will authenticate POSTs via the planned in-URL token support.

Tests: GET returns 405 without saving a point for both endpoints; a new UserRecordPositionTestCase covers the POST happy path.

## Summary by Sourcery

Restrict position-recording endpoints to POST-only and update tests accordingly.

Bug Fixes:
- Prevent recording asset and user positions via GET requests, ensuring only POST is allowed for these state-changing operations.

Enhancements:
- Clarify documentation in position-recording views about POST requirement and CSRF protection.

Tests:
- Add tests confirming user position recording works via POST and is rejected via GET for both asset and user position endpoints.