### PR TITLE
data: require POST to create or replace POIs, lines and polygons

### DIFF
--- a/data/test_poi.py
+++ b/data/test_poi.py
@@ -48,6 +48,28 @@ class POIsTestCase(UserDataTestCase):
         pois = GeoTimeLabel.objects.filter(label='Test API POI 3')
         self.assertEqual(len(pois), 0)
 
+    def test_poi_api_create_rejects_get(self):
+        """
+        Creating a POI mutates state, so GET must be rejected (CSRF safe method).
+        """
+        client = Client()
+        client.login(username='test', password='password')
+        poi_create_url = f'/mission/{self.mission.pk}/data/pois/create/'
+        response = client.get(poi_create_url, {'lat': -43.5, 'lon': 172.5, 'label': 'GET POI'})
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(GeoTimeLabel.objects.filter(label='GET POI').count(), 0)
+
+    def test_poi_api_replace_rejects_get(self):
+        """
+        Replacing a POI mutates state, so GET must be rejected.
+        """
+        client = Client()
+        client.login(username='test', password='password')
+        poi = GeoTimeLabel.objects.create(geo=Point(172.5, -43.5), created_by=self.user, label='Replace GET POI', geo_type='poi', mission=self.mission)
+        response = client.get(f'/data/pois/{poi.pk}/replace/', {'lat': -44.5, 'lon': 171.5, 'label': 'Replaced via GET'})
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(GeoTimeLabel.objects.filter(label='Replaced via GET').count(), 0)
+
     def test_poi_api_move(self):
         """
         Check the api for moving POIs

--- a/data/test_udl.py
+++ b/data/test_udl.py
@@ -2,6 +2,7 @@
 Tests for the User Drawn Lines (user created line/time/label)
 """
 
+from django.test import Client
 from django.contrib.gis.geos import LineString
 
 from .models import GeoTimeLabel
@@ -33,3 +34,70 @@ class UserDrawnLineTestCase(UserDataTestCase):
         for i in range(1, 100):
             self.assertEqual(line.geo[i][0], 172.0 + i * 0.1)
             self.assertEqual(line.geo[i][1], -42 - i * 0.1)
+
+    def test_line_api_create_via_post(self):
+        """
+        Creating a line via POST works.
+        """
+        client = Client()
+        client.login(username='test', password='password')
+        url = f'/mission/{self.mission.pk}/data/userlines/create/'
+        response = client.post(url, {
+            'label': 'POST Line', 'points': 2,
+            'point0_lat': -43.5, 'point0_lng': 172.5,
+            'point1_lat': -43.6, 'point1_lng': 172.6,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(GeoTimeLabel.objects.filter(label='POST Line', geo_type='line').count(), 1)
+
+    def test_line_api_create_rejects_get(self):
+        """
+        Creating a line mutates state, so GET must be rejected (CSRF safe method).
+        """
+        client = Client()
+        client.login(username='test', password='password')
+        url = f'/mission/{self.mission.pk}/data/userlines/create/'
+        response = client.get(url, {
+            'label': 'GET Line', 'points': 2,
+            'point0_lat': -43.5, 'point0_lng': 172.5,
+            'point1_lat': -43.6, 'point1_lng': 172.6,
+        })
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(GeoTimeLabel.objects.filter(label='GET Line').count(), 0)
+
+
+class UserDrawnPolygonTestCase(UserDataTestCase):
+    """
+    Test the user polygon create API
+    """
+    def test_polygon_api_create_via_post(self):
+        """
+        Creating a polygon via POST works.
+        """
+        client = Client()
+        client.login(username='test', password='password')
+        url = f'/mission/{self.mission.pk}/data/userpolygons/create/'
+        response = client.post(url, {
+            'label': 'POST Polygon', 'points': 3,
+            'point0_lat': -43.5, 'point0_lng': 172.5,
+            'point1_lat': -43.6, 'point1_lng': 172.6,
+            'point2_lat': -43.5, 'point2_lng': 172.6,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(GeoTimeLabel.objects.filter(label='POST Polygon', geo_type='polygon').count(), 1)
+
+    def test_polygon_api_create_rejects_get(self):
+        """
+        Creating a polygon mutates state, so GET must be rejected.
+        """
+        client = Client()
+        client.login(username='test', password='password')
+        url = f'/mission/{self.mission.pk}/data/userpolygons/create/'
+        response = client.get(url, {
+            'label': 'GET Polygon', 'points': 3,
+            'point0_lat': -43.5, 'point0_lng': 172.5,
+            'point1_lat': -43.6, 'point1_lng': 172.6,
+            'point2_lat': -43.5, 'point2_lng': 172.6,
+        })
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(GeoTimeLabel.objects.filter(label='GET Polygon').count(), 0)

--- a/data/test_view_helpers.py
+++ b/data/test_view_helpers.py
@@ -73,13 +73,11 @@ class ViewHelpersTestCase(TestCase):
         self.assertIn('created', resp2.content.decode('utf-8'))
 
     def test_user_polygon_and_line_make(self):  # pylint: disable=too-many-locals
-        """user_polygon_make and user_line_make handle GET rejection, creation, and replace failure."""
-        # polygon should reject non-POST
-        req = self.factory.get('/')
-        req.user = self.smm.user1
-        resp = user_polygon_make(req, mission=self.mission)
-        self.assertEqual(resp.status_code, 400)
+        """user_polygon_make and user_line_make handle creation and replace failure.
 
+        Method rejection is enforced by @require_POST on the views (see the
+        userlines/userpolygons create tests in test_udl.py).
+        """
         # valid polygon create
         data = {
             'label': 'poly',
@@ -106,10 +104,6 @@ class ViewHelpersTestCase(TestCase):
         req3.user = self.smm.user1
         resp3 = user_polygon_make(req3, mission=self.mission, replaces=Dummy())
         self.assertEqual(resp3.status_code, 400)
-
-        # line should reject non-POST
-        resp_line = user_line_make(self.factory.get('/'), mission=self.mission)
-        self.assertEqual(resp_line.status_code, 400)
 
         # valid line create
         data_line = {

--- a/data/view_helpers.py
+++ b/data/view_helpers.py
@@ -57,17 +57,9 @@ def point_label_make(request, mission=None, replaces=None):
     """
     Create or replace a POI based on user supplied data.
     """
-    poi_lat = ''
-    poi_lon = ''
-    poi_label = ''
-    if request.method == 'GET':
-        poi_lat = request.GET.get('lat')
-        poi_lon = request.GET.get('lon')
-        poi_label = request.GET.get('label')
-    elif request.method == 'POST':
-        poi_lat = request.POST.get('lat')
-        poi_lon = request.POST.get('lon')
-        poi_label = request.POST.get('label')
+    poi_lat = request.POST.get('lat')
+    poi_lon = request.POST.get('lon')
+    poi_label = request.POST.get('label')
 
     if poi_lat is None or poi_lon is None or poi_label is None:
         return HttpResponseBadRequest()
@@ -88,8 +80,6 @@ def user_polygon_make(request, mission=None, replaces=None):
     """
     Create a polygon based on user supplied data.
     """
-    if request.method != 'POST':
-        return HttpResponseBadRequest()
     points = []
     label = request.POST['label']
     points_count = int(request.POST['points'])
@@ -111,8 +101,6 @@ def user_line_make(request, mission=None, replaces=None):
     """
     Create a line (string) based on user supplied data.
     """
-    if request.method != 'POST':
-        return HttpResponseBadRequest()
     points = []
     label = request.POST['label']
     points_count = int(request.POST['points'])

--- a/data/views.py
+++ b/data/views.py
@@ -328,6 +328,7 @@ def point_labels_all_kml(request, mission_id):
     return to_kml(GeoTimeLabel, GeoTimeLabel.all_current_of_geo(mission.mission, geo_type='poi'))
 
 
+@require_POST
 @login_required
 @mission_is_member
 def point_label_create(request, mission_user):
@@ -337,6 +338,7 @@ def point_label_create(request, mission_user):
     return point_label_make(request, mission=mission_user.mission)
 
 
+@require_POST
 @login_required
 @geotimelabel_from_type_id
 @data_get_mission_id(arg_name='usergeo')
@@ -356,6 +358,7 @@ def user_polygons_all_kml(request, mission_id):
     return to_kml(GeoTimeLabel, GeoTimeLabel.all_current_of_geo(mission, geo_type='polygon'))
 
 
+@require_POST
 @login_required
 @mission_is_member
 def user_polygon_create(request, mission_user):
@@ -365,6 +368,7 @@ def user_polygon_create(request, mission_user):
     return user_polygon_make(request, mission=mission_user.mission)
 
 
+@require_POST
 @login_required
 @geotimelabel_from_type_id
 @data_get_mission_id(arg_name='usergeo')
@@ -384,6 +388,7 @@ def user_lines_all_kml(request, mission_id):
     return to_kml(GeoTimeLabel, GeoTimeLabel.all_current_of_geo(mission, geo_type='line'))
 
 
+@require_POST
 @login_required
 @mission_is_member
 def user_line_create(request, mission_user):
@@ -393,6 +398,7 @@ def user_line_create(request, mission_user):
     return user_line_make(request, mission=mission_user.mission)
 
 
+@require_POST
 @login_required
 @geotimelabel_from_type_id
 @data_get_mission_id(arg_name='usergeo')


### PR DESCRIPTION
## Description

point_label_make read lat/lon/label from GET as well as POST and saved a new POI either way, so a POI could be created from a GET request, which Django's CSRF middleware does not protect. The polygon and line helpers already rejected non-POST (with a 400), but inconsistently.

Make all six create/replace views @require_POST so GET now returns a consistent 405, and simplify the make helpers to read only from request.POST (dropping the GET branch in point_label_make and the now redundant method guards in the polygon/line helpers). The frontend and smm-python already POST these endpoints.

Tests: client-level GET returns 405 without creating an object for POI, line and polygon create and for POI replace; add POST happy-path tests for the line and polygon create APIs (previously only model-level tests existed). The view-helper unit test drops its direct GET-rejection checks, which are now enforced by @require_POST at the view.

## Summary by Sourcery

Enforce POST-only semantics for creating and replacing user POIs, lines, and polygons, and align tests with the new behavior.

Bug Fixes:
- Prevent POI creation and replacement via GET by requiring POST for the relevant views and ensuring GET returns 405 without side effects.
- Ensure line and polygon creation endpoints reject GET requests and do not mutate state.

Enhancements:
- Simplify POI, line, and polygon helper functions to read input exclusively from POST data, relying on view-level method enforcement.
- Expand client-level tests for line and polygon creation and adjust view-helper tests to reflect method enforcement at the view layer.

Tests:
- Add client-level POST success and GET rejection tests for user line and polygon create APIs.
- Add GET rejection tests for POI create and replace APIs.
- Update view-helper tests to cover creation and replace failure paths while delegating method checks to the views.