### PR TITLE
data: escape user content in KML instead of wrapping in CDATA

### DIFF
--- a/data/test_view_helpers.py
+++ b/data/test_view_helpers.py
@@ -2,6 +2,8 @@
 Tests for data view helpers
 """
 
+from xml.etree import ElementTree
+
 from django.contrib.gis.geos import Point
 from django.test import TestCase, RequestFactory
 from django.http import HttpResponse
@@ -38,6 +40,26 @@ class ViewHelpersTestCase(TestCase):
         self.assertEqual(resp2.status_code, 200)
         self.assertEqual(resp2['Content-Type'], 'application/vnd.google-earth.kml+xml')
         self.assertIn('<kml', resp2.content.decode('utf-8'))
+
+    def test_to_kml_escapes_user_content(self):
+        """A label with CDATA/markup characters round-trips to well-formed KML."""
+        evil_label = 'pwn]]><script>alert(1)</script> & <b>x</b>'
+        ptl = GeoTimeLabel.objects.create(geo=Point(174.0, -41.0), label=evil_label, created_by=self.smm.user1, mission=self.mission, geo_type='poi')
+
+        resp = to_kml(GeoTimeLabel, [ptl])
+        content = resp.content.decode('utf-8')
+
+        # The raw markup must not appear unescaped (no CDATA breakout / tag injection)
+        self.assertNotIn('<script>', content)
+        self.assertNotIn(']]>', content)
+
+        # The document must be well-formed and the label must round-trip exactly
+        root = ElementTree.fromstring(content)
+        ns = {'kml': 'http://www.opengis.net/kml/2.2'}
+        name = root.find('.//kml:Placemark/kml:name', ns)
+        description = root.find('.//kml:Placemark/kml:description', ns)
+        self.assertEqual(name.text, str(ptl))
+        self.assertEqual(description.text, str(ptl))
 
     def test_geotimelabel_replace_checks(self):
         """geotimelabel_replace returns 404 for deleted or replaced objects."""

--- a/data/view_helpers.py
+++ b/data/view_helpers.py
@@ -8,6 +8,7 @@ views work.
 from django.http import HttpResponse, HttpResponseNotFound, HttpResponseBadRequest
 from django.core.serializers import serialize
 from django.contrib.gis.geos import Point, Polygon, LineString, GEOSGeometry
+from django.utils.html import escape
 
 from .models import GeoTimeLabel
 
@@ -29,8 +30,11 @@ def to_kml(objecttype, objects):
                '<kml xmlns="http://www.opengis.net/kml/2.2">\n' + \
                '\t<Document>\n'
     for obj in objects:
-        kml_data += f'\t\t<Placemark>\n\t\t\t<name><![CDATA[{str(obj)}]]></name>\n'
-        kml_data += f'\t\t\t<description><![CDATA[{str(obj)}]]></description>\n'
+        # Escape user-supplied text (e.g. GeoTimeLabel.label) so it cannot break
+        # out of the element and inject markup. str(obj) is plain text, not HTML.
+        label = escape(str(obj))
+        kml_data += f'\t\t<Placemark>\n\t\t\t<name>{label}</name>\n'
+        kml_data += f'\t\t\t<description>{label}</description>\n'
         kml_data += GEOSGeometry(getattr(obj, objecttype.GEOFIELD)).kml
         kml_data += '\n\t\t</Placemark>\n'
 


### PR DESCRIPTION
## Description

to_kml() embedded str(obj) inside <![CDATA[ ... ]]> for the <name> and <description> elements. For a GeoTimeLabel that string includes the user-supplied label, so a label containing ]]> terminated the CDATA section early, producing malformed KML and allowing arbitrary KML/XML markup to be injected into the exported document.

str(obj) is plain text for every type passed to to_kml(), so escape it with django.utils.html.escape and drop the CDATA wrapper. Markup and the ]]> sequence are now rendered as text and the output stays well-formed.

Test: a POI labelled with ]]> and tag markup round-trips through to_kml to well-formed XML whose name/description text matches the original label, and the raw markup does not appear unescaped.

## Summary by Sourcery

Escape KML placemark text content to prevent malformed XML and markup injection when exporting user-supplied labels.

Bug Fixes:
- Prevent KML/XML injection by escaping user-supplied label text instead of wrapping it in CDATA in to_kml.

Tests:
- Add regression test ensuring labels containing CDATA terminators and HTML-like markup round-trip to well-formed KML without unescaped script or tag injection.