### PR TITLE
search: require mission membership to create or preview searches

### DIFF
--- a/search/tests.py
+++ b/search/tests.py
@@ -510,3 +510,56 @@ class SearchTestCase(TestCase):
         response = self.smm.client1.post(f'/search/{search.search_id}/finished/', data={'asset_id': self.asset1.pk})
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(search.as_object().completed_at)
+
+
+class SearchCreateMembershipTestCase(TestCase):
+    """
+    Search creation/preview must verify the user is a member of the datum's mission.
+    """
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        self.assets = AssetsHelpers(self.smm)
+        self.missions = MissionFunctions(self.smm)
+        self.asset_type = self.assets.create_asset_type()
+        # A mission owned by user2 that user1 is not a member of
+        self.other_mission = self.missions.create_mission('other mission', client=self.smm.client2)
+
+    def _other_geo(self, geo, geo_type):
+        """Create a geometry owned by user2 in the mission user1 is not a member of."""
+        return GeoTimeLabel.objects.create(geo=geo, created_by=self.smm.user2, label='datum', geo_type=geo_type, mission=self.other_mission.get_object())
+
+    def test_create_sector_rejects_non_member_datum(self):
+        """Creating a search against another mission's POI returns 404."""
+        poi = self._other_geo(Point(172.5, -43.5), 'poi')
+        response = self.smm.client1.post('/search/sector/create/', data={
+            'poi_id': poi.pk, 'asset_type_id': self.asset_type.pk, 'sweep_width': 200,
+        })
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(Search.objects.count(), 0)
+
+    def test_preview_sector_rejects_non_member_datum(self):
+        """The GET preview path also rejects another mission's POI."""
+        poi = self._other_geo(Point(172.5, -43.5), 'poi')
+        response = self.smm.client1.get('/search/sector/create/', data={
+            'poi_id': poi.pk, 'asset_type_id': self.asset_type.pk, 'sweep_width': 200,
+        })
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(Search.objects.count(), 0)
+
+    def test_create_trackline_rejects_non_member_datum(self):
+        """Line-datum searches reject a line from a mission the user is not in."""
+        line = self._other_geo(LineString((172.5, -43.5), (172.6, -43.6)), 'line')
+        response = self.smm.client1.post('/search/trackline/create/', data={
+            'line_id': line.pk, 'asset_type_id': self.asset_type.pk, 'sweep_width': 200,
+        })
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(Search.objects.count(), 0)
+
+    def test_create_polygon_creepingline_rejects_non_member_datum(self):
+        """Polygon-datum searches reject a polygon from a mission the user is not in."""
+        poly = self._other_geo(Polygon(((172.5, -43.5), (172.6, -43.5), (172.6, -43.6), (172.5, -43.5))), 'polygon')
+        response = self.smm.client1.post('/search/creepingline/create/polygon/', data={
+            'poly_id': poly.pk, 'asset_type_id': self.asset_type.pk, 'sweep_width': 200,
+        })
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(Search.objects.count(), 0)

--- a/search/views.py
+++ b/search/views.py
@@ -27,7 +27,7 @@ from data.decorators import data_get_mission_id
 from data.models import GeoTimeLabel
 from data.view_helpers import to_kml, to_geojson
 from mission.models import Mission, MissionAsset, AssetCommand
-from mission.decorators import mission_is_member, mission_asset_get_mission, mission_asset_get
+from mission.decorators import mission_is_member, mission_asset_get_mission, mission_asset_get, mission_user_get
 from timeline.helpers import timeline_record_search_finished
 from .decorators import search_from_id
 from .models import Search, SearchParams, ExpandingBoxSearchParams, TrackLineCreepingSearchParams
@@ -39,6 +39,20 @@ def mission_get(mission_id):
     Convert a mission id into an object
     """
     return get_object_or_404(Mission, pk=mission_id)
+
+
+def get_search_datum(request, geo_id, geo_type):
+    """
+    Load a search datum geometry and verify the user is a member of its mission.
+
+    Search creation/preview is mission-scoped via the datum's mission, but the
+    views only require login. Without this check an authenticated non-member
+    could create or preview a search against another mission's geometry by id.
+    mission_user_get raises Http404 for non-members, matching mission_is_member.
+    """
+    geo = get_object_or_404(GeoTimeLabel, pk=geo_id, geo_type=geo_type)
+    mission_user_get(geo.mission_id, request.user)
+    return geo
 
 
 def _parse_first_bearing(value) -> int:
@@ -285,14 +299,14 @@ class SectorSearchCreateView(View):
 
     def get(self, request):
         """Preview a sector search without saving"""
-        poi = get_object_or_404(GeoTimeLabel, pk=request.GET.get('poi_id'), geo_type='poi')
+        poi = get_search_datum(request, request.GET.get('poi_id'), 'poi')
         asset_type = get_object_or_404(AssetType, pk=request.GET.get('asset_type_id'))
         params = SearchParams(poi, asset_type, request.user, request.GET.get('sweep_width'))
         return to_geojson(Search, [Search.create_sector_search(params, save=False)])
 
     def post(self, request):
         """Create and save a sector search"""
-        poi = get_object_or_404(GeoTimeLabel, pk=request.POST.get('poi_id'), geo_type='poi')
+        poi = get_search_datum(request, request.POST.get('poi_id'), 'poi')
         asset_type = get_object_or_404(AssetType, pk=request.POST.get('asset_type_id'))
         params = SearchParams(poi, asset_type, request.user, request.POST.get('sweep_width'))
         return to_geojson(Search, [Search.create_sector_search(params, save=True)])
@@ -304,7 +318,7 @@ class ExpandingBoxSearchCreateView(View):
 
     def get(self, request):
         """Preview an expanding box search without saving"""
-        poi = get_object_or_404(GeoTimeLabel, pk=request.GET.get('poi_id'), geo_type='poi')
+        poi = get_search_datum(request, request.GET.get('poi_id'), 'poi')
         asset_type = get_object_or_404(AssetType, pk=request.GET.get('asset_type_id'))
         sweep_width = float(request.GET.get('sweep_width'))
         first_bearing = _parse_first_bearing(request.GET.get('first_bearing'))
@@ -313,7 +327,7 @@ class ExpandingBoxSearchCreateView(View):
 
     def post(self, request):
         """Create and save an expanding box search"""
-        poi = get_object_or_404(GeoTimeLabel, pk=request.POST.get('poi_id'), geo_type='poi')
+        poi = get_search_datum(request, request.POST.get('poi_id'), 'poi')
         asset_type = get_object_or_404(AssetType, pk=request.POST.get('asset_type_id'))
         sweep_width = float(request.POST.get('sweep_width'))
         first_bearing = _parse_first_bearing(request.POST.get('first_bearing'))
@@ -327,14 +341,14 @@ class TrackLineSearchCreateView(View):
 
     def get(self, request):
         """Preview a track line search without saving"""
-        line = get_object_or_404(GeoTimeLabel, pk=request.GET.get('line_id'), geo_type='line')
+        line = get_search_datum(request, request.GET.get('line_id'), 'line')
         asset_type = get_object_or_404(AssetType, pk=request.GET.get('asset_type_id'))
         params = SearchParams(line, asset_type, request.user, request.GET.get('sweep_width'))
         return to_geojson(Search, [Search.create_track_line_search(params, save=False)])
 
     def post(self, request):
         """Create and save a track line search"""
-        line = get_object_or_404(GeoTimeLabel, pk=request.POST.get('line_id'), geo_type='line')
+        line = get_search_datum(request, request.POST.get('line_id'), 'line')
         asset_type = get_object_or_404(AssetType, pk=request.POST.get('asset_type_id'))
         params = SearchParams(line, asset_type, request.user, request.POST.get('sweep_width'))
         return to_geojson(Search, [Search.create_track_line_search(params, save=True)])
@@ -346,14 +360,14 @@ class ShoreLineSearchCreateView(View):
 
     def get(self, request):
         """Preview a shore line search without saving"""
-        line = get_object_or_404(GeoTimeLabel, pk=request.GET.get('line_id'), geo_type='line')
+        line = get_search_datum(request, request.GET.get('line_id'), 'line')
         asset_type = get_object_or_404(AssetType, pk=request.GET.get('asset_type_id'))
         params = SearchParams(line, asset_type, request.user, request.GET.get('sweep_width'))
         return to_geojson(Search, [Search.create_shore_line_search(params, save=False)])
 
     def post(self, request):
         """Create and save a shore line search"""
-        line = get_object_or_404(GeoTimeLabel, pk=request.POST.get('line_id'), geo_type='line')
+        line = get_search_datum(request, request.POST.get('line_id'), 'line')
         asset_type = get_object_or_404(AssetType, pk=request.POST.get('asset_type_id'))
         params = SearchParams(line, asset_type, request.user, request.POST.get('sweep_width'))
         return to_geojson(Search, [Search.create_shore_line_search(params, save=True)])
@@ -365,14 +379,14 @@ class TrackCreepingLineSearchCreateView(View):
 
     def get(self, request):
         """Preview a track creeping line search without saving"""
-        line = get_object_or_404(GeoTimeLabel, pk=request.GET.get('line_id'), geo_type='line')
+        line = get_search_datum(request, request.GET.get('line_id'), 'line')
         asset_type = get_object_or_404(AssetType, pk=request.GET.get('asset_type_id'))
         params = TrackLineCreepingSearchParams(line, asset_type, request.user, request.GET.get('sweep_width'), request.GET.get('width'))
         return to_geojson(Search, [Search.create_track_line_creeping_search(params, save=False)])
 
     def post(self, request):
         """Create and save a track creeping line search"""
-        line = get_object_or_404(GeoTimeLabel, pk=request.POST.get('line_id'), geo_type='line')
+        line = get_search_datum(request, request.POST.get('line_id'), 'line')
         asset_type = get_object_or_404(AssetType, pk=request.POST.get('asset_type_id'))
         params = TrackLineCreepingSearchParams(line, asset_type, request.user, request.POST.get('sweep_width'), request.POST.get('width'))
         return to_geojson(Search, [Search.create_track_line_creeping_search(params, save=True)])
@@ -384,14 +398,14 @@ class PolygonCreepingLineSearchCreateView(View):
 
     def get(self, request):
         """Preview a polygon creeping line search without saving"""
-        poly = get_object_or_404(GeoTimeLabel, pk=request.GET.get('poly_id'), geo_type='polygon')
+        poly = get_search_datum(request, request.GET.get('poly_id'), 'polygon')
         asset_type = get_object_or_404(AssetType, pk=request.GET.get('asset_type_id'))
         params = SearchParams(poly, asset_type, request.user, request.GET.get('sweep_width'))
         return to_geojson(Search, [Search.create_polygon_creeping_line_search(params, save=False)])
 
     def post(self, request):
         """Create and save a polygon creeping line search"""
-        poly = get_object_or_404(GeoTimeLabel, pk=request.POST.get('poly_id'), geo_type='polygon')
+        poly = get_search_datum(request, request.POST.get('poly_id'), 'polygon')
         asset_type = get_object_or_404(AssetType, pk=request.POST.get('asset_type_id'))
         params = SearchParams(poly, asset_type, request.user, request.POST.get('sweep_width'))
         return to_geojson(Search, [Search.create_polygon_creeping_line_search(params, save=True)])


### PR DESCRIPTION
## Description

The six search create views (sector, expanding box, track line, shore line, track creeping line, polygon creeping line) only required login. Each loaded the datum geometry by a user-submitted id and built a search in that geometry's mission, so an authenticated non-member could create or preview a search against another mission's geometry by guessing an id.

Add a get_search_datum() helper that loads the datum geometry and verifies the user is a member of its mission via mission_user_get (which raises Http404 for non-members, matching mission_is_member). Route all twelve datum lookups (get + post in each view) through it.

Tests live in a new SearchCreateMembershipTestCase: a non-member using another mission's POI/line/polygon id gets 404 with no search created, for both the save (POST) and preview (GET) paths.

## Summary by Sourcery

Enforce mission membership checks when creating or previewing searches based on shared geometry data.

Bug Fixes:
- Prevent authenticated non-members from creating or previewing searches using datum geometries from missions they do not belong to.

Enhancements:
- Introduce a shared helper to load search datum geometries while enforcing mission membership across all search creation and preview views.

Tests:
- Add tests ensuring search creation and preview endpoints return 404 and do not create searches when using geometry from a mission the user is not a member of.