### PR TITLE
mission: require admin or operator permission to command an asset

### DIFF
--- a/mission/test_asset_command.py
+++ b/mission/test_asset_command.py
@@ -9,7 +9,7 @@ from assets.tests import AssetsHelpers
 from assets.models import Asset, AssetType
 from smm.tests import SMMTestUsers
 
-from .models import AssetCommand
+from .models import AssetCommand, MissionAsset
 from .tests import MissionFunctions
 
 
@@ -71,3 +71,38 @@ class AssetCommandWebTestCase(TestCase):
         command = response.json()['command']
         response = self.smm.client1.post(f'/assets/{pccr.pk}/command/', data={'command_id': command['id'], 'type': 'test', 'message': 'test response'})
         self.assertEqual(response.status_code, 200)
+
+    def _set_command(self, client, mission, asset):
+        """Send a (no-position) command to an asset via the command set endpoint."""
+        return client.post(f'/mission/{mission.mission_pk}/assets/command/set/', data={
+            'asset': asset.pk, 'command': 'RON', 'reason': 'test',
+        })
+
+    def test_command_set_as_mission_admin(self):
+        """A mission admin can command an asset in the mission."""
+        mission = self.missions.create_mission('admin command')
+        asset = self.assets.create_asset(name='admin asset')
+        MissionAsset.objects.create(mission=mission.get_object(), asset=asset, creator=self.smm.user1)
+        response = self._set_command(self.smm.client1, mission, asset)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(AssetCommand.objects.filter(asset=asset, command='RON').count(), 1)
+
+    def test_command_set_as_asset_owner(self):
+        """A non-admin member who owns the asset can command it."""
+        mission = self.missions.create_mission('owner command')
+        mission.add_user(user=self.smm.user2)
+        asset = self.assets.create_asset(name='owner asset', owner=self.smm.user2)
+        MissionAsset.objects.create(mission=mission.get_object(), asset=asset, creator=self.smm.user2)
+        response = self._set_command(self.smm.client2, mission, asset)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(AssetCommand.objects.filter(asset=asset, command='RON').count(), 1)
+
+    def test_command_set_rejected_for_plain_member(self):
+        """A non-admin member who cannot operate the asset is forbidden."""
+        mission = self.missions.create_mission('plain member command')
+        mission.add_user(user=self.smm.user2)
+        asset = self.assets.create_asset(name='others asset')
+        MissionAsset.objects.create(mission=mission.get_object(), asset=asset, creator=self.smm.user1)
+        response = self._set_command(self.smm.client2, mission, asset)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(AssetCommand.objects.filter(asset=asset).count(), 0)

--- a/mission/views.py
+++ b/mission/views.py
@@ -19,7 +19,7 @@ from django.views.decorators.http import require_POST
 
 from assets.models import Asset, AssetStatus
 from mission.helpers import get_my_assets_not_in_mission
-from organization.decorators import asset_is_operator, get_organization_from_id
+from organization.decorators import asset_is_operator, get_organization_from_id, user_can_operate_asset
 from organization.models import Organization, OrganizationMember, OrganizationAsset
 from timeline.models import TimeLineEntry
 from timeline.helpers import timeline_record_create, \
@@ -31,6 +31,17 @@ from timeline.helpers import timeline_record_create, \
 from .models import Mission, MissionExternalReference, MissionUser, MissionAsset, MissionAssetType, MissionOrganization, MissionAssetStatus, MissionAssetStatusValue, AssetCommand
 from .forms import AssetCommandForm, MissionForm, MissionUserForm, MissionAssetForm, MissionOrganizationForm
 from .decorators import get_user_from_id, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin
+
+
+def user_can_command_asset(mission_user, asset):
+    """
+    Whether this user may send operational commands to the asset.
+
+    Currently allowed for mission admins and users who can operate the asset
+    (its owner or an organization radio operator). This is the single place to
+    extend as missions and organizations gain finer operational roles.
+    """
+    return mission_user.is_admin() or user_can_operate_asset(mission_user.user, asset)
 
 
 @method_decorator(login_required, name="dispatch")
@@ -746,6 +757,9 @@ class AssetCommandSetView(View):
         form = AssetCommandForm(request.POST, mission=mission_user.mission)
         if not form.is_valid():
             return JsonResponse({'errors': form.errors}, status=400)
+        asset = form.cleaned_data['asset']
+        if not user_can_command_asset(mission_user, asset):
+            return HttpResponseForbidden("You do not have permission to command this asset")
         point = None
         if form.cleaned_data['command'] in AssetCommand.REQUIRES_POSITION:
             try:
@@ -753,7 +767,7 @@ class AssetCommandSetView(View):
             except (ValueError, TypeError):
                 return JsonResponse({'errors': {'position': ['Invalid lat/long']}}, status=400)
         AssetCommand(
-            asset=form.cleaned_data['asset'],
+            asset=asset,
             command=form.cleaned_data['command'],
             issued_by=request.user,
             reason=form.cleaned_data['reason'],


### PR DESCRIPTION
## Description

AssetCommandSetView only required mission membership, so any mission member could send operational commands (return to launch, goto, etc.) to any asset in the mission.

Restrict command sending: the user must be a mission admin or able to operate the asset (its owner or an organization radio operator). The rule is centralised in a single helper, user_can_command_asset(mission_user, asset), so it can be extended as missions and organizations gain richer operational roles. A disallowed user now gets 403 and no command is saved.

Tests cover a mission admin (allowed), a non-admin asset owner (allowed), and a plain mission member who cannot operate the asset (forbidden, no command created).

The frontend still shows the command control to all viewers; gating it is tracked as a follow-up in todo/backend/asset-command-permissions.md, along with the planned mission/organization operational roles.

## Summary by Sourcery

Restrict asset command operations in missions to users with appropriate roles and centralize the permission logic.

New Features:
- Introduce a centralized user_can_command_asset helper to determine who may send operational commands to an asset.

Bug Fixes:
- Prevent plain mission members from sending operational commands to assets they cannot operate, returning 403 and avoiding command creation.

Enhancements:
- Update the mission asset command endpoint to enforce admin or operator permissions before creating commands.

Tests:
- Add tests verifying command permissions for mission admins, asset owners, and plain mission members for the asset command set endpoint.