### PR TITLE
data: block writes to closed missions

### DIFF
--- a/data/tests.py
+++ b/data/tests.py
@@ -4,7 +4,7 @@ Tests for data handling
 
 from datetime import timedelta
 
-from django.contrib.gis.geos import Point
+from django.contrib.gis.geos import Point, LineString
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -53,6 +53,64 @@ class UserRecordPositionTestCase(TestCase):
         response = self.client.get(self.url, {'lat': -43.5, 'lon': 172.5})
         self.assertEqual(response.status_code, 405)
         self.assertEqual(UserPointTime.objects.filter(user=self.user).count(), 0)
+
+
+class ClosedMissionWriteProtectionTestCase(TestCase):
+    """
+    Closed missions are read-only: data write endpoints must reject mutations.
+    """
+    def setUp(self):
+        self.user = get_user_model().objects.create_user('test', password='password')
+        self.mission = Mission.objects.create(creator=self.user, closed=timezone.now(), closed_by=self.user)
+        MissionUser(mission=self.mission, user=self.user, permissions_admin=True, creator=self.user).save()
+        self.client.force_login(self.user)
+
+    def test_poi_create_rejected_on_closed_mission(self):
+        """Creating a POI in a closed mission is forbidden."""
+        response = self.client.post(f'/mission/{self.mission.pk}/data/pois/create/', {'lat': -43.5, 'lon': 172.5, 'label': 'nope'})
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(GeoTimeLabel.objects.filter(mission=self.mission).count(), 0)
+
+    def test_line_create_rejected_on_closed_mission(self):
+        """Creating a line in a closed mission is forbidden."""
+        response = self.client.post(f'/mission/{self.mission.pk}/data/userlines/create/', {
+            'label': 'nope', 'points': 2,
+            'point0_lat': -43.5, 'point0_lng': 172.5, 'point1_lat': -43.6, 'point1_lng': 172.6,
+        })
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(GeoTimeLabel.objects.filter(mission=self.mission).count(), 0)
+
+    def test_user_record_position_rejected_on_closed_mission(self):
+        """Recording a user position in a closed mission is forbidden."""
+        response = self.client.post(f'/mission/{self.mission.pk}/data/user/{self.user.username}/position/add/', {'lat': -43.5, 'lon': 172.5})
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(UserPointTime.objects.filter(mission=self.mission).count(), 0)
+
+    def test_poi_replace_rejected_on_closed_mission(self):
+        """Replacing an existing POI in a closed mission is forbidden and does not mutate it."""
+        poi = GeoTimeLabel.objects.create(geo=Point(172.5, -43.5), created_by=self.user, label='original', geo_type='poi', mission=self.mission)
+        response = self.client.post(f'/data/pois/{poi.pk}/replace/', {'lat': -43.6, 'lon': 172.6, 'label': 'changed'})
+        self.assertEqual(response.status_code, 403)
+        poi.refresh_from_db()
+        self.assertEqual(poi.label, 'original')
+        self.assertIsNone(poi.replaced_by)
+
+    def test_line_replace_rejected_on_closed_mission(self):
+        """Replacing an existing line in a closed mission is forbidden and does not mutate it."""
+        line = GeoTimeLabel.objects.create(geo=LineString((172.5, -43.5), (172.6, -43.6)), created_by=self.user, label='original line', geo_type='line', mission=self.mission)
+        response = self.client.post(f'/data/userlines/{line.pk}/replace/', {
+            'label': 'changed line', 'points': 2,
+            'point0_lat': -43.5, 'point0_lng': 172.5, 'point1_lat': -43.6, 'point1_lng': 172.6,
+        })
+        self.assertEqual(response.status_code, 403)
+        line.refresh_from_db()
+        self.assertEqual(line.label, 'original line')
+        self.assertIsNone(line.replaced_by)
+
+    def test_read_still_allowed_on_closed_mission(self):
+        """Reading mission data is still allowed after closure."""
+        response = self.client.get(f'/mission/{self.mission.pk}/data/pois/current/')
+        self.assertEqual(response.status_code, 200)
 
 
 class GeoTimeAllCurrentTestCase(TestCase):

--- a/data/views.py
+++ b/data/views.py
@@ -24,7 +24,7 @@ from django.views.decorators.http import require_POST
 from smm.settings import TIME_ZONE
 from assets.models import Asset
 from organization.decorators import asset_is_recorder
-from mission.decorators import mission_is_member, mission_asset_get
+from mission.decorators import mission_is_member, mission_is_member_open, mission_asset_get
 from mission.models import Mission, AssetCommand
 from .decorators import geotimelabel_from_type_id, geotimelabel_from_id, data_get_mission_id
 from .models import AssetPointTime, GeoTimeLabel, UserPointTime
@@ -196,7 +196,7 @@ def users_position_latest_user(request, current_only):
 
 @require_POST
 @login_required
-@mission_is_member
+@mission_is_member_open
 def user_record_position(request, mission_user, user):
     """
     Record the current position of a user.
@@ -330,7 +330,7 @@ def point_labels_all_kml(request, mission_id):
 
 @require_POST
 @login_required
-@mission_is_member
+@mission_is_member_open
 def point_label_create(request, mission_user):
     """
     Store a new POI
@@ -342,7 +342,7 @@ def point_label_create(request, mission_user):
 @login_required
 @geotimelabel_from_type_id
 @data_get_mission_id(arg_name='usergeo')
-@mission_is_member
+@mission_is_member_open
 def point_label_replace(request, mission_user, usergeo):
     """
     Move/relabel a POI
@@ -360,7 +360,7 @@ def user_polygons_all_kml(request, mission_id):
 
 @require_POST
 @login_required
-@mission_is_member
+@mission_is_member_open
 def user_polygon_create(request, mission_user):
     """
     Create a new user polygon
@@ -372,7 +372,7 @@ def user_polygon_create(request, mission_user):
 @login_required
 @geotimelabel_from_type_id
 @data_get_mission_id(arg_name='usergeo')
-@mission_is_member
+@mission_is_member_open
 def user_polygon_replace(request, mission_user, usergeo):
     """
     Update the polygon/label of a user polygon
@@ -390,7 +390,7 @@ def user_lines_all_kml(request, mission_id):
 
 @require_POST
 @login_required
-@mission_is_member
+@mission_is_member_open
 def user_line_create(request, mission_user):
     """
     Create a new user line
@@ -402,7 +402,7 @@ def user_line_create(request, mission_user):
 @login_required
 @geotimelabel_from_type_id
 @data_get_mission_id(arg_name='usergeo')
-@mission_is_member
+@mission_is_member_open
 def user_line_replace(request, mission_user, usergeo):
     """
     Update the line/label of a user line
@@ -463,7 +463,7 @@ def convert_typhoon_time(timestamp):
 
 
 @login_required
-@mission_is_member
+@mission_is_member_open
 def upload_typhoonh_data(request, mission_user):
     """
     Allow the user to upload a telemetry from a Typhoon H to create

--- a/mission/decorators.py
+++ b/mission/decorators.py
@@ -72,6 +72,40 @@ def mission_is_member(view_func):
     return wrapper_is_member
 
 
+def mission_closed_response(mission):
+    """
+    Return a 403 response if the mission is closed, otherwise None.
+
+    Use this inside views that serve both reads and writes (e.g. a class-based
+    view's post()) so reads of a closed mission keep working while writes are
+    rejected. For write-only views prefer the mission_is_member_open decorator.
+    """
+    if mission.is_closed():
+        return HttpResponseForbidden("This mission is closed")
+    return None
+
+
+def mission_is_member_open(view_func):
+    """
+    Make sure the user is a member of the mission and the mission is not closed.
+
+    For write-only, *function-based* mission-scoped views. Like mission_is_member
+    it reads the request from the first positional argument, so it must not be
+    applied to class-based view methods (where the first argument is self) -
+    those should call mission_closed_response() inside their write handlers
+    instead. Closed missions are read-only, so mutations are rejected with 403
+    (re-opening a mission is handled separately).
+    """
+    def wrapper_is_member_open(*args, **kwargs):
+        mission_user = mission_user_get(kwargs['mission_id'], args[0].user)
+        kwargs.pop('mission_id')
+        closed = mission_closed_response(mission_user.mission)
+        if closed is not None:
+            return closed
+        return view_func(*args, mission_user=mission_user, **kwargs)
+    return wrapper_is_member_open
+
+
 def mission_is_admin(view_func):
     """
     Make sure the user is a member and they have an admin role of the mission

--- a/mission/models.py
+++ b/mission/models.py
@@ -22,6 +22,15 @@ class Mission(models.Model):
     closed = models.DateTimeField(null=True, blank=True)
     closed_by = models.ForeignKey(get_user_model(), on_delete=models.PROTECT, related_name='closer%(app_label)s_%(class)s_related', null=True, blank=True)
 
+    def is_closed(self):
+        """
+        Return true if this mission has been closed.
+
+        Closed missions are read-only: mission-scoped write endpoints must
+        reject mutations (other than re-opening) once this is true.
+        """
+        return self.closed is not None
+
     def as_object(self, admin):
         """
         Convert mission to an object that is suitable for returning via JsonResponse


### PR DESCRIPTION
## Description

Closing a mission marked it closed but mission-scoped write endpoints did not check that state, so a closed mission could keep accepting new data, undermining the audit/operational meaning of closing it.

Add the shared mechanism for this: Mission.is_closed(), a mission_closed_response() guard (for views that mix reads and writes), and a mission_is_member_open decorator (membership + not closed) for write-only mission-scoped views.

Apply it to the data app writes: POI/line/polygon create and replace, user position recording, and the Typhoon telemetry upload now return 403 on a closed mission. Reads are unaffected.

Tests cover POI/line create and user position rejected on a closed mission, and that reads still work. Search, mission, marinesar and images writes are guarded in follow-up commits.

## Summary by Sourcery

Enforce that closed missions are read-only by rejecting mission-scoped write operations once a mission is marked closed.

Bug Fixes:
- Prevent creation and mutation of mission data (POIs, user lines, polygons, user positions, Typhoon telemetry uploads) for missions that have been closed.

Enhancements:
- Introduce a Mission.is_closed helper and mission_closed_response / mission_is_member_open guards to centralize closed-mission write protection logic.

Tests:
- Add tests verifying that data write endpoints return 403 for closed missions while read endpoints remain accessible.