### PR TITLE
search: block writes to closed missions

### DIFF
--- a/search/tests.py
+++ b/search/tests.py
@@ -3,6 +3,7 @@ Tests for search creation/management
 """
 
 from django.test import TestCase
+from django.utils import timezone
 from django.contrib.gis.geos import Point, LineString, Polygon
 
 from data.models import GeoTimeLabel
@@ -563,3 +564,58 @@ class SearchCreateMembershipTestCase(TestCase):
         })
         self.assertEqual(response.status_code, 404)
         self.assertEqual(Search.objects.count(), 0)
+
+
+class SearchClosedMissionTestCase(TestCase):
+    """
+    Search create/preview/queue/begin/finished must be blocked on a closed mission.
+    """
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        assets = AssetsHelpers(self.smm)
+        searches = SearchHelpers(self.smm)
+        missions = MissionFunctions(self.smm)
+        self.asset_type = assets.create_asset_type()
+        self.asset = assets.create_asset(asset_type=self.asset_type)
+        mission = missions.create_mission('closed search mission')
+        mission.add_asset(self.asset)
+        self.poi = GeoTimeLabel.objects.create(geo=Point(172.5, -43.5), created_by=self.smm.user1, label='datum', geo_type='poi', mission=mission.get_object())
+        # Create a search while the mission is open, then close the mission.
+        self.search = searches.create_sector(self.poi, 200, self.asset_type)
+        mission_obj = mission.get_object()
+        mission_obj.closed = timezone.now()
+        mission_obj.closed_by = self.smm.user1
+        mission_obj.save()
+
+    def test_create_rejected_on_closed_mission(self):
+        """Saving a new search against a closed mission's datum is forbidden."""
+        response = self.smm.client1.post('/search/sector/create/', data={
+            'poi_id': self.poi.pk, 'asset_type_id': self.asset_type.pk, 'sweep_width': 200,
+        })
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(Search.objects.count(), 1)  # only the one created during setUp
+
+    def test_preview_rejected_on_closed_mission(self):
+        """Previewing a search against a closed mission's datum is forbidden."""
+        response = self.smm.client1.get('/search/sector/create/', data={
+            'poi_id': self.poi.pk, 'asset_type_id': self.asset_type.pk, 'sweep_width': 200,
+        })
+        self.assertEqual(response.status_code, 403)
+
+    def test_queue_rejected_on_closed_mission(self):
+        """Queueing a search in a closed mission is forbidden."""
+        response = self.smm.client1.post(f'/search/{self.search.search_id}/queue/', data={})
+        self.assertEqual(response.status_code, 403)
+        self.assertIsNone(self.search.as_object().queued_at)
+
+    def test_begin_rejected_on_closed_mission(self):
+        """Beginning a search in a closed mission is forbidden."""
+        response = self.smm.client1.post(f'/search/{self.search.search_id}/begin/', data={'asset_id': self.asset.pk})
+        self.assertEqual(response.status_code, 403)
+        self.assertIsNone(self.search.as_object().inprogress_by)
+
+    def test_finished_rejected_on_closed_mission(self):
+        """Finishing a search in a closed mission is forbidden."""
+        response = self.smm.client1.post(f'/search/{self.search.search_id}/finished/', data={'asset_id': self.asset.pk})
+        self.assertEqual(response.status_code, 403)
+        self.assertIsNone(self.search.as_object().completed_at)

--- a/search/views.py
+++ b/search/views.py
@@ -12,6 +12,7 @@ Basic overview of presented API:
  - List all completed searches
  - Details
 """
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseForbidden, HttpResponseNotFound, JsonResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 from django.contrib.auth.decorators import login_required
@@ -27,7 +28,7 @@ from data.decorators import data_get_mission_id
 from data.models import GeoTimeLabel
 from data.view_helpers import to_kml, to_geojson
 from mission.models import Mission, MissionAsset, AssetCommand
-from mission.decorators import mission_is_member, mission_asset_get_mission, mission_asset_get, mission_user_get
+from mission.decorators import mission_is_member, mission_is_member_open, mission_asset_get_mission, mission_asset_get, mission_user_get, mission_closed_response
 from timeline.helpers import timeline_record_search_finished
 from .decorators import search_from_id
 from .models import Search, SearchParams, ExpandingBoxSearchParams, TrackLineCreepingSearchParams
@@ -52,6 +53,8 @@ def get_search_datum(request, geo_id, geo_type):
     """
     geo = get_object_or_404(GeoTimeLabel, pk=geo_id, geo_type=geo_type)
     mission_user_get(geo.mission_id, request.user)
+    if geo.mission.is_closed():
+        raise PermissionDenied("This mission is closed")
     return geo
 
 
@@ -158,6 +161,10 @@ def search_begin(request, search_id, object_class, asset, mission):
     """
     search = get_object_or_404(object_class, pk=search_id)
 
+    closed = mission_closed_response(mission)
+    if closed is not None:
+        return closed
+
     if search.mission != mission:
         return HttpResponseForbidden("Asset not currently assigned to the mission this search is in.")
 
@@ -181,6 +188,11 @@ def search_finished(request, search_id, object_class, asset, mission):
     A search has been completed
     """
     search = get_object_or_404(object_class, pk=search_id)
+
+    closed = mission_closed_response(mission)
+    if closed is not None:
+        return closed
+
     error = check_search_state(search, 'complete', asset)
     if error is not None:
         return error
@@ -198,7 +210,7 @@ def search_finished(request, search_id, object_class, asset, mission):
 @login_required
 @search_from_id
 @data_get_mission_id(arg_name='search')
-@mission_is_member
+@mission_is_member_open
 def search_queue(request, search, mission_user):
     """
     Queue a search


### PR DESCRIPTION
## Description

Extend closed-mission write protection to the search app. Creating or previewing a search now raises PermissionDenied (403) when the datum's mission is closed (via get_search_datum), and queueing, beginning, or finishing a search is rejected with 403 on a closed mission.

search_queue uses the mission_is_member_open decorator; search_begin and search_finished check mission_closed_response since they resolve the mission from the asset.

Tests cover create, preview, queue, begin and finished all rejected on a closed mission.

## Summary by Sourcery

Block search creation and lifecycle actions when associated missions are closed.

Bug Fixes:
- Prevent creating or previewing searches when the datum belongs to a closed mission.
- Reject queue, begin, and finish actions for searches in closed missions to enforce mission write protection.

Tests:
- Add a dedicated test case verifying create, preview, queue, begin, and finished search endpoints all return 403 for closed missions.