### PR TITLE
mission: block writes to closed missions

### DIFF
--- a/mission/decorators.py
+++ b/mission/decorators.py
@@ -2,6 +2,8 @@
 Function decorators to make dealing with missions easier
 """
 
+from functools import wraps
+
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponseForbidden, Http404
 from django.core.exceptions import ObjectDoesNotExist
@@ -104,6 +106,24 @@ def mission_is_member_open(view_func):
             return closed
         return view_func(*args, mission_user=mission_user, **kwargs)
     return wrapper_is_member_open
+
+
+def mission_open_required(view_method):
+    """
+    Class-based-view handler decorator: reject the request with 403 if the
+    (already-resolved) mission_user's mission is closed.
+
+    Use on write handlers (post/patch/delete) of views whose dispatch already
+    runs mission_is_member, so reads of a closed mission keep working while
+    writes are rejected.
+    """
+    @wraps(view_method)
+    def wrapper(self, request, *args, mission_user, **kwargs):
+        closed = mission_closed_response(mission_user.mission)
+        if closed is not None:
+            return closed
+        return view_method(self, request, *args, mission_user=mission_user, **kwargs)
+    return wrapper
 
 
 def mission_is_admin(view_func):

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -3,6 +3,7 @@ Tests for missions
 """
 
 from django.test import TestCase
+from django.utils import timezone
 
 from smm.tests import SMMTestUsers
 
@@ -452,3 +453,42 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         self.assertEqual(response.status_code, 200)
         assets_data = response.json()
         self.assertEqual(len(assets_data['assets']), 1)
+
+
+class MissionClosedWriteProtectionTestCase(TestCase):
+    """
+    Closed missions are read-only: mission write endpoints must reject mutations.
+    """
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        self.assets = AssetsHelpers(self.smm)
+        missions = MissionFunctions(self.smm)
+        self.mission = missions.create_mission('closed mission')
+        mission_obj = self.mission.get_object()
+        mission_obj.closed = timezone.now()
+        mission_obj.closed_by = self.smm.user1
+        mission_obj.save()
+
+    def test_add_asset_rejected_on_closed_mission(self):
+        """Adding an asset to a closed mission is forbidden."""
+        asset = self.assets.create_asset()
+        response = self.mission.add_asset(asset)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(MissionAsset.objects.filter(mission=self.mission.get_object()).count(), 0)
+
+    def test_add_user_rejected_on_closed_mission(self):
+        """Adding a user to a closed mission is forbidden."""
+        response = self.mission.add_user(user=self.smm.user2)
+        self.assertEqual(response.status_code, 403)
+
+    def test_external_reference_create_rejected_on_closed_mission(self):
+        """Creating an external reference on a closed mission is forbidden."""
+        response = self.smm.client1.post(f'/mission/{self.mission.mission_pk}/externalreferences/', data={
+            'reference': 'IRD', 'url': 'http://example/x', 'notes': 'note',
+        })
+        self.assertEqual(response.status_code, 403)
+
+    def test_read_still_allowed_on_closed_mission(self):
+        """Reading mission details is still allowed after closure."""
+        response = self.mission.get_details(client=self.smm.client1)
+        self.assertEqual(response.status_code, 200)

--- a/mission/views.py
+++ b/mission/views.py
@@ -30,7 +30,7 @@ from timeline.helpers import timeline_record_create, \
 
 from .models import Mission, MissionExternalReference, MissionUser, MissionAsset, MissionAssetType, MissionOrganization, MissionAssetStatus, MissionAssetStatusValue, AssetCommand
 from .forms import AssetCommandForm, MissionForm, MissionUserForm, MissionAssetForm, MissionOrganizationForm
-from .decorators import get_user_from_id, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin
+from .decorators import get_user_from_id, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin, mission_open_required
 
 
 def user_can_command_asset(mission_user, asset):
@@ -236,6 +236,7 @@ class MissionTimelineView(View):
         }
         return render(request, 'mission_timeline.html', data)
 
+    @mission_open_required
     def post(self, request, mission_user):
         """
         Add a custom entry to the mission timeline
@@ -281,6 +282,7 @@ class MissionOrganizationsView(View):
             return self.as_json(mission_user.mission, list_not_included)
         return render(request, 'mission_organizations_list.html')
 
+    @mission_open_required
     def post(self, request, mission_user):
         """
         Add an organization to this mission
@@ -339,6 +341,7 @@ class MissionOrganizationView(View):
         setattr(mission_organization, f'permissions_{permission_type}', value)
         timeline_record_mission_organization_update(mission_user.mission, mission_user.user, mission_organization.organization, permission_type, value)
 
+    @mission_open_required
     def post(self, request, mission_user, organization):
         """
         Update the permissions of an organization
@@ -394,6 +397,7 @@ class MissionUsersView(View):
             return self.as_json(mission_user.mission, list_not_included)
         return render(request, 'mission_organizations_list.html')
 
+    @mission_open_required
     def post(self, request, mission_user):
         """
         Add a user to this mission
@@ -449,6 +453,7 @@ class MissionUserView(View):
         setattr(target_mission_user, f"permissions_{permission_type}", value)
         timeline_record_mission_user_update(mission_user.mission, mission_user.user, target_mission_user, permission_type, value)
 
+    @mission_open_required
     def patch(self, request, mission_user, user):
         """
         Update the permissions of a user
@@ -524,6 +529,7 @@ class MissionAssetsView(View):
             return self.as_json(request, mission_user)
         return render(request, "mission/assets_view.html", {'mission_asset_add': MissionAssetForm(user=request.user, mission=mission_user.mission)})
 
+    @mission_open_required
     def post(self, request, mission_user):
         """
         Add an asset to this mission
@@ -569,6 +575,7 @@ def mission_asset_is_owner(mission_user, asset, user):
 class MissionAssetView(View):
     """Manage a single asset within a mission."""
 
+    @mission_open_required
     def delete(self, request, mission_user, asset_id):
         """Remove an asset from the mission."""
         asset = get_object_or_404(Asset, pk=asset_id)
@@ -612,6 +619,7 @@ class MissionAssetStatusView(View):
             return self.as_json(request, mission_asset)
         return render(request, "mission_asset_status.html", {'mission_asset': mission_asset})
 
+    @mission_open_required
     def post(self, request, mission_user, asset):
         """
         Allow setting/updating the asset status
@@ -677,6 +685,7 @@ class MissionExternalReferencesView(View):
         }
         return render(request, 'mission_external_references.html', data)
 
+    @mission_open_required
     def post(self, request, mission_user):
         """
         Add an external reference to the mission
@@ -699,6 +708,7 @@ class MissionExternalReferenceView(View):
     """
     update/delete an external reference for this mission
     """
+    @mission_open_required
     def post(self, request, ext_ref_id, mission_user):
         """
         Update an external reference in the mission
@@ -718,6 +728,7 @@ class MissionExternalReferenceView(View):
             return HttpResponse("Done")
         return HttpResponse("Failed")
 
+    @mission_open_required
     def delete(self, request, ext_ref_id, mission_user):
         """
         Delete an external reference from the mission
@@ -750,6 +761,7 @@ class AssetCommandSetView(View):
             'requires_position': list(AssetCommand.REQUIRES_POSITION),
         })
 
+    @mission_open_required
     def post(self, request, mission_user):
         """
         Validate and create an AssetCommand; returns JSON status or field errors.


### PR DESCRIPTION
## Description

Extend closed-mission write protection to the mission app's class-based views. Add a mission_open_required handler decorator (for CBV write methods whose dispatch already runs mission_is_member) and apply it to every mission-scoped write handler: timeline add, organization add/modify, user add, user role change, asset add/remove, asset status, external reference add/update/delete, and asset command set. Reads still work on a closed mission.

Tests cover add asset, add user, and external reference create rejected on a closed mission, plus a read still succeeding.

The asset command *response* endpoint (AssetCommandView.post) is asset-scoped rather than mission-scoped and is left for a later pass.

## Summary by Sourcery

Enforce read-only behavior for closed missions by blocking write operations in mission class-based views.

Bug Fixes:
- Ensure mission-scoped write endpoints return 403 for closed missions while still allowing reads.

Enhancements:
- Introduce a mission_open_required decorator for class-based view write handlers that checks mission closure status.
- Apply closed-mission write protection across mission timeline, organization, user, asset, external reference, and asset command write views.

Tests:
- Add integration tests verifying asset addition, user addition, and external reference creation are rejected on closed missions while read operations continue to succeed.