### PR TITLE
marinesar/images: block writes to closed missions

### DIFF
--- a/images/tests.py
+++ b/images/tests.py
@@ -1,0 +1,38 @@
+"""
+Tests for images
+"""
+
+from django.test import TestCase
+from django.utils import timezone
+from django.contrib.gis.geos import Point
+
+from mission.models import Mission, MissionUser
+from smm.tests import SMMTestUsers
+
+from .models import GeoImage
+
+
+class ImageClosedMissionTestCase(TestCase):
+    """
+    Image upload and priority changes must be blocked on a closed mission.
+    """
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        self.mission = Mission.objects.create(creator=self.smm.user1, mission_name='closed', closed=timezone.now(), closed_by=self.smm.user1)
+        MissionUser(mission=self.mission, user=self.smm.user1, permissions_admin=True, creator=self.smm.user1).save()
+
+    def test_upload_rejected_on_closed_mission(self):
+        """Uploading an image to a closed mission is forbidden."""
+        response = self.smm.client1.post(f'/mission/{self.mission.pk}/image/upload/', {
+            'latitude': -43.5, 'longitude': 172.5, 'description': 'nope',
+        })
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(GeoImage.objects.count(), 0)
+
+    def test_priority_change_rejected_on_closed_mission(self):
+        """Changing image priority in a closed mission is forbidden and does not mutate it."""
+        image = GeoImage.objects.create(geo=Point(172.5, -43.5), description='img', original_format='jpeg', created_by=self.smm.user1, mission=self.mission)
+        response = self.smm.client1.patch(f'/image/{image.pk}/priority/', data='{"priority": true}', content_type='application/json')
+        self.assertEqual(response.status_code, 403)
+        image.refresh_from_db()
+        self.assertFalse(image.priority)

--- a/images/views.py
+++ b/images/views.py
@@ -11,7 +11,7 @@ from django.contrib.gis.geos import Point
 from django.utils.decorators import method_decorator
 from django.views import View
 
-from mission.decorators import mission_is_member, mission_is_member_no_variable
+from mission.decorators import mission_is_member, mission_is_member_no_variable, mission_open_required
 from data.decorators import data_get_mission_id
 from data.view_helpers import to_geojson
 from timeline.helpers import timeline_record_image_priority_changed
@@ -27,6 +27,7 @@ from .models import GeoImage
 class ImageUploadView(View):
     """Allow users (typically an asset) to upload an image with a location."""
 
+    @mission_open_required
     def post(self, request, mission_user):
         """Handle image upload."""
         form = UploadImageForm(request.POST, request.FILES)
@@ -113,6 +114,7 @@ def image_get_thumbnail(request, image):
 class ImagePriorityView(View):
     """Set or unset the priority flag on an image via PATCH."""
 
+    @mission_open_required
     def patch(self, request, image, mission_user):
         """Update image priority from JSON body {"priority": true/false}."""
         try:

--- a/marinesar/tests.py
+++ b/marinesar/tests.py
@@ -3,7 +3,8 @@ Tests for marinesar functionality
 """
 
 from django.test import TestCase
-from django.contrib.gis.geos import Point
+from django.utils import timezone
+from django.contrib.gis.geos import Point, LineString
 
 from data.models import GeoTimeLabel
 from mission.models import Mission, MissionUser
@@ -60,3 +61,39 @@ class MarineVectorCreateTestCase(TestCase):
         response = self.smm.client1.get(self._url(), self._payload(self.other_poi))
         self.assertEqual(response.status_code, 404)
         self.assertEqual(MarineTotalDriftVector.objects.count(), 0)
+
+
+class MarineVectorClosedMissionTestCase(TestCase):
+    """
+    Marine vector create/preview/delete must be blocked on a closed mission.
+    """
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        self.mission = Mission.objects.create(creator=self.smm.user1, mission_name='closed', closed=timezone.now(), closed_by=self.smm.user1)
+        MissionUser(mission=self.mission, user=self.smm.user1, permissions_admin=True, creator=self.smm.user1).save()
+        self.poi = GeoTimeLabel.objects.create(geo=Point(172.5, -43.5), created_by=self.smm.user1, label='datum', geo_type='poi', mission=self.mission)
+
+    def _create_url(self):
+        return f'/mission/{self.mission.pk}/sar/marine/vectors/create/'
+
+    def test_create_rejected_on_closed_mission(self):
+        """Saving a marine vector in a closed mission is forbidden."""
+        response = self.smm.client1.post(self._create_url(), {'poi_id': self.poi.pk})
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(MarineTotalDriftVector.objects.count(), 0)
+
+    def test_preview_rejected_on_closed_mission(self):
+        """Previewing a marine vector in a closed mission is forbidden."""
+        response = self.smm.client1.get(self._create_url(), {'poi_id': self.poi.pk})
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_rejected_on_closed_mission(self):
+        """Deleting a marine vector in a closed mission is forbidden."""
+        vector = MarineTotalDriftVector.objects.create(
+            geo=LineString((172.5, -43.5), (172.6, -43.6)), datum=self.poi,
+            leeway_multiplier=1.0, leeway_modifier=0.0, mission=self.mission, created_by=self.smm.user1,
+        )
+        response = self.smm.client1.delete(f'/sar/marine/vectors/{vector.pk}/')
+        self.assertEqual(response.status_code, 403)
+        vector.refresh_from_db()
+        self.assertIsNone(vector.deleted_at)

--- a/marinesar/views.py
+++ b/marinesar/views.py
@@ -4,6 +4,7 @@ Views for marinesar
 These views should only relate to presentation of the UI
 """
 
+from django.core.exceptions import PermissionDenied
 from django.db import connection as dbconn
 from django.contrib.auth.decorators import login_required
 from django.contrib.gis.geos import GEOSGeometry, LineString, Point
@@ -16,7 +17,7 @@ from django.views import View
 from data.decorators import data_get_mission_id
 from data.models import GeoTimeLabel
 from data.view_helpers import to_geojson
-from mission.decorators import mission_is_member
+from mission.decorators import mission_is_member, mission_open_required
 
 from .decorators import total_drift_from_type_id
 from .models import MarineTotalDriftVector, MarineTotalDriftVectorCurrent, MarineTotalDriftVectorWind
@@ -51,6 +52,8 @@ class MarineVectorCreateView(View):
 
     def _compute_vector(self, user_data, mission_user, save):  # pylint: disable=R0914,R0915
         """Build the drift vector from user_data; persist it if save=True."""
+        if mission_user.mission.is_closed():
+            raise PermissionDenied("This mission is closed")
         vectors = []
         current_vectors = []
         wind_vectors = []
@@ -138,6 +141,7 @@ class MarineVectorDetailView(View):
         """Return the vector as GeoJSON."""
         return to_geojson(MarineTotalDriftVector, [tdv])
 
+    @mission_open_required
     def delete(self, request, tdv, mission_user):
         """Delete the vector."""
         if not tdv.delete(mission_user.user):


### PR DESCRIPTION
## Description

Complete closed-mission write protection for the remaining apps.

marinesar: MarineVectorCreateView raises PermissionDenied (403) when the mission is closed, blocking both the save (POST) and preview (GET) paths via _compute_vector; MarineVectorDetailView.delete uses mission_open_required.

images: ImageUploadView.post and ImagePriorityView.patch use mission_open_required.

Tests: marine vector create/preview/delete and image upload/priority change are all rejected on a closed mission (marinesar gains a closed-mission case, images gains its first tests).

This finishes the closed-mission-write-protection item; the only remaining write not yet guarded is the asset-scoped command-response endpoint, tracked in todo/backend/asset-command-response-closed-mission.md.

## Summary by Sourcery

Enforce closed-mission write protection for marine SAR vectors and mission images.

Bug Fixes:
- Block marine vector creation, preview, and deletion when the associated mission is closed.
- Prevent image uploads and image priority changes for closed missions.

Tests:
- Add marinesar tests covering rejected vector create/preview/delete operations on closed missions.
- Add images app tests verifying upload and priority changes are rejected on closed missions.