### PR TITLE
mission: use submit time for timeline entries

### DIFF
--- a/frontend/mission/timeline.test.tsx
+++ b/frontend/mission/timeline.test.tsx
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+vi.mock('../page-shell', () => ({}))
+vi.mock('../ajax', () => ({
+  smmGetJSON: vi.fn(),
+  smmPost: vi.fn(() => Promise.resolve(''))
+}))
+
+import { smmPost } from '../ajax'
+import { MissionTimeLineEntryAdd } from './timeline'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('MissionTimeLineEntryAdd', () => {
+  it('uses the current time at submit when Now is selected', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-28T00:00:00.000Z'))
+    render(<MissionTimeLineEntryAdd missionId={42} />)
+
+    vi.setSystemTime(new Date('2026-06-28T00:05:00.000Z'))
+    const messageInput = screen.getAllByRole('textbox')[0]
+    if (!messageInput) throw new Error('Message input not found')
+    fireEvent.change(messageInput, {
+      target: { value: 'Manual timeline entry' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(smmPost).toHaveBeenCalledWith('/mission/42/timeline/', {
+      timestamp: '2026-06-28T00:05:00.000Z',
+      message: 'Manual timeline entry',
+      url: ''
+    })
+  })
+})

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -16,7 +16,7 @@ interface MissionTimeLineEntryAddProps {
   missionId: number
 }
 
-function MissionTimeLineEntryAdd({ missionId }: MissionTimeLineEntryAddProps) {
+export function MissionTimeLineEntryAdd({ missionId }: MissionTimeLineEntryAddProps) {
   const [timeNow, setTimeNow] = useState(true)
   const [specificDateTime, setSpecificDateTime] = useState<Date>(() => new Date())
   const [message, setMessage] = useState('')

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -2,12 +2,16 @@
 Tests for missions
 """
 
+from datetime import datetime, timezone as datetime_timezone
+from unittest.mock import patch
+
 from django.test import TestCase
 from django.utils import timezone
 
 from smm.tests import SMMTestUsers
 
 from assets.tests import AssetsHelpers
+from timeline.models import TimeLineEntry
 
 from .models import Mission, MissionUser, MissionAsset
 
@@ -453,6 +457,52 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         self.assertEqual(response.status_code, 200)
         assets_data = response.json()
         self.assertEqual(len(assets_data['assets']), 1)
+
+
+class MissionTimelineTestCase(MissionBaseTestCase):
+    """
+    Mission timeline API
+    """
+    def test_missing_timeline_timestamp_uses_submit_time(self):
+        """
+        Adding a manual timeline entry without a timestamp uses the server time.
+        """
+        mission = self.missions.create_mission('test_missing_timeline_timestamp')
+        submitted_at = datetime(2026, 6, 28, 12, 30, tzinfo=datetime_timezone.utc)
+
+        with patch('mission.views.timezone.now', return_value=submitted_at):
+            response = self.smm.client1.post(
+                f'/mission/{mission.mission_pk}/timeline/',
+                data={'message': 'Manual entry without client timestamp'},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        entry = TimeLineEntry.objects.get(
+            mission=mission.get_object(),
+            event_type='usr',
+            message='Manual entry without client timestamp',
+        )
+        self.assertEqual(entry.timestamp, submitted_at)
+
+    def test_invalid_timeline_timestamp_is_rejected(self):
+        """
+        Invalid manual timeline timestamps fail clearly instead of saving junk.
+        """
+        mission = self.missions.create_mission('test_invalid_timeline_timestamp')
+
+        response = self.smm.client1.post(
+            f'/mission/{mission.mission_pk}/timeline/',
+            data={'message': 'Manual entry with invalid timestamp', 'timestamp': 'not-a-date'},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(
+            TimeLineEntry.objects.filter(
+                mission=mission.get_object(),
+                event_type='usr',
+                message='Manual entry with invalid timestamp',
+            ).exists()
+        )
 
 
 class MissionClosedWriteProtectionTestCase(TestCase):

--- a/mission/views.py
+++ b/mission/views.py
@@ -12,6 +12,7 @@ from django.http import HttpResponseBadRequest, JsonResponse, HttpResponseRedire
 from django.db import transaction
 from django.db.models import OuterRef, Prefetch, Subquery, Exists
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -243,7 +244,15 @@ class MissionTimelineView(View):
         """
         message = request.POST.get('message')
         url = request.POST.get('url')
-        timestamp = request.POST.get('timestamp')
+        timestamp_raw = request.POST.get('timestamp')
+        if timestamp_raw:
+            timestamp = parse_datetime(timestamp_raw)
+            if timestamp is None:
+                return HttpResponseBadRequest("Invalid timestamp")
+            if timezone.is_naive(timestamp):
+                timestamp = timezone.make_aware(timestamp, timezone.get_current_timezone())
+        else:
+            timestamp = timezone.now()
         if message:
             entry = TimeLineEntry(mission=mission_user.mission, user=request.user, message=message, timestamp=timestamp, url=url, event_type='usr')
             entry.save()


### PR DESCRIPTION
## Description

Manual timeline entries can be opened well before they are submitted. The frontend now generates the default timestamp at click time, but the backend still assumed every client supplied a valid timestamp. Use the server submit time when the field is omitted and reject malformed timestamps so stale or broken clients cannot create misleading mission history. Add backend and frontend regressions for #386.

## Summary by Sourcery

Handle manual mission timeline timestamps more robustly in both backend and frontend.

New Features:
- Allow manual mission timeline entries to default to server submit time when no timestamp is provided.

Bug Fixes:
- Reject malformed manual mission timeline timestamps to prevent invalid timeline data from being stored.
- Ensure naive timestamps for manual mission entries are correctly converted to timezone-aware values.

Enhancements:
- Export the MissionTimeLineEntryAdd component for reuse and testing in the frontend.

Tests:
- Add backend regression tests covering missing and invalid manual mission timeline timestamps.
- Add frontend tests for the mission timeline entry add component.