### PR TITLE
map: let mission users publish their own positions

### DIFF
--- a/data/tests.py
+++ b/data/tests.py
@@ -2,6 +2,7 @@
 Tests for data handling
 """
 
+import json
 from datetime import timedelta
 
 from django.contrib.gis.geos import Point, LineString
@@ -53,6 +54,28 @@ class UserRecordPositionTestCase(TestCase):
         response = self.client.get(self.url, {'lat': -43.5, 'lon': 172.5})
         self.assertEqual(response.status_code, 405)
         self.assertEqual(UserPointTime.objects.filter(user=self.user).count(), 0)
+
+    def test_user_position_latest_and_history_endpoints(self):
+        """
+        Recorded user positions are visible in mission and aggregate endpoints.
+        """
+        response = self.client.post(self.url, {'lat': -43.5, 'lon': 172.5})
+        self.assertEqual(response.status_code, 200)
+
+        latest_response = self.client.get(f'/mission/{self.mission.pk}/data/users/positions/latest/')
+        self.assertEqual(latest_response.status_code, 200)
+        latest_data = json.loads(latest_response.content)
+        self.assertEqual(len(latest_data['features']), 1)
+        self.assertEqual(latest_data['features'][0]['properties']['user'], [self.user.username])
+
+        specific_history = self.client.get(f'/mission/{self.mission.pk}/data/user/{self.user.username}/position/history/')
+        current_history = self.client.get(f'/mission/current/data/users/{self.user.username}/position/history/')
+        all_history = self.client.get(f'/mission/all/data/users/{self.user.username}/position/history/')
+
+        for history_response in (specific_history, current_history, all_history):
+            self.assertEqual(history_response.status_code, 200)
+            history_data = json.loads(history_response.content)
+            self.assertEqual(len(history_data['features']), 1)
 
 
 class ClosedMissionWriteProtectionTestCase(TestCase):

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -29,6 +29,7 @@ import { SMMMarineVector } from './marine/vectors.js'
 import { SMMAssets } from './asset/map.js'
 import { SMMMissionTopBar } from './menu/topbar.js'
 import { SMMUserPositions } from './user/map.js'
+import { createUserTrackingControl } from './user/tracking'
 import { smmGetJSON } from './ajax'
 
 class SMMMap {
@@ -49,14 +50,16 @@ class SMMMap {
   allImages?: SMMImageAll
   importantImages?: SMMImageImportant
   marineVectors?: SMMMarineVector
+  currentUserName: string
 
-  constructor(mapElem: string | HTMLElement, missionId: MissionId) {
+  constructor(mapElem: string | HTMLElement, missionId: MissionId, currentUserName: string) {
     this.map = L.map(mapElem)
     this.layerControl = L.control.layers({}, {})
     this.layerControlMaps = L.control.layers({}, {})
     this.layerControlAssets = L.control.layers({}, {})
     this.layerControlUsers = L.control.layers({}, {})
     this.missionId = missionId
+    this.currentUserName = currentUserName
     this.overlayAdd = this.overlayAdd.bind(this)
     this.overlayAddAsset = this.overlayAddAsset.bind(this)
     this.overlayAddUser = this.overlayAddUser.bind(this)
@@ -128,6 +131,9 @@ class SMMMap {
         keepCurrentZoomLevel: true,
         locateOptions: { enableHighAccuracy: true }
       }).addTo(this.map)
+      if (this.currentUserName) {
+        createUserTrackingControl({ missionId: this.missionId, userName: this.currentUserName }).addTo(this.map)
+      }
       L.control.imageuploader({ missionId: this.missionId }).addTo(this.map)
     }
     L.control.smmadmin({ missionId: this.missionId }).addTo(this.map)
@@ -202,6 +208,7 @@ function mapInit() {
   document.body.appendChild(wrapperEl)
 
   const missionId = parseMissionId((document.getElementById('missionId') as HTMLInputElement).value)
+  const currentUserName = (document.getElementById('currentUser') as HTMLInputElement).value
 
   if (isSpecificMission(missionId)) {
     const menuEl = document.createElement('div')
@@ -215,7 +222,7 @@ function mapInit() {
   mapEl.className = 'flex-grow-1'
   wrapperEl.appendChild(mapEl)
 
-  return new SMMMap(mapEl, missionId)
+  return new SMMMap(mapEl, missionId, currentUserName)
 }
 
 mapInit()

--- a/frontend/user/map.tsx
+++ b/frontend/user/map.tsx
@@ -3,11 +3,12 @@ import L from 'leaflet'
 
 import { SMMRealtime } from '../smmmap'
 import { cookieJar } from '../cookies'
-import { SMMMissionUserPointTimeGeoJSON } from './types'
+import { SMMMissionUserPointTimeGeoJSON, userNameFromProperty } from './types'
 import { UserPopup } from './UserPopup'
 import { buildSwatchLabel } from '../components/swatchLabel'
 import { mountPopup } from '../components/mountPopup'
 import { TrackedPath } from '../components/TrackedPath'
+import { userPositionHistoryUrl } from './tracking'
 
 class SMMUserPosition extends TrackedPath {
   userName: string
@@ -22,7 +23,7 @@ class SMMUserPosition extends TrackedPath {
   }
 
   protected historyUrl() {
-    return `/mission/${this.missionId}/data/user/${this.userName}/position/history/`
+    return userPositionHistoryUrl(this.missionId, this.userName)
   }
 }
 
@@ -45,7 +46,7 @@ class SMMUserPositions extends SMMRealtime {
   protected override featureOptions() {
     return {
       updateFeature: this.userUpdate,
-      getFeatureId: (feature: SMMMissionUserPointTimeGeoJSON) => feature.properties.user,
+      getFeatureId: (feature: SMMMissionUserPointTimeGeoJSON) => userNameFromProperty(feature.properties.user),
       pointToLayer: this.userLayer
     }
   }
@@ -62,7 +63,7 @@ class SMMUserPositions extends SMMRealtime {
   }
 
   createPopup(user: SMMMissionUserPointTimeGeoJSON, layer: L.Layer) {
-    const userName = user.properties.user
+    const userName = userNameFromProperty(user.properties.user)
     const userObject = this.createUser(userName)
     userObject.popup?.unmount()
     userObject.popup = mountPopup(layer, <UserPopup userName={userName} />, { minWidth: 200 })
@@ -72,8 +73,9 @@ class SMMUserPositions extends SMMRealtime {
   }
 
   userLayer(user: SMMMissionUserPointTimeGeoJSON, latlng: L.LatLng) {
+    const userName = userNameFromProperty(user.properties.user)
     return L.marker(latlng, {
-      title: user.properties.user
+      title: userName
     })
   }
 
@@ -82,7 +84,7 @@ class SMMUserPositions extends SMMRealtime {
   }
 
   userUpdate(user: SMMMissionUserPointTimeGeoJSON, oldLayer: L.Marker) {
-    const userName = user.properties.user
+    const userName = userNameFromProperty(user.properties.user)
     this.userPathUpdate(userName)
 
     if (!oldLayer) {

--- a/frontend/user/tracking.css
+++ b/frontend/user/tracking.css
@@ -1,0 +1,12 @@
+.UserTracker-marker {
+  height: 100%;
+  opacity: 0.8;
+}
+
+.UserTracker-marker:hover {
+  opacity: 1;
+}
+
+.UserTracker-container.is-tracking a {
+  background-color: #cfe2ff;
+}

--- a/frontend/user/tracking.test.ts
+++ b/frontend/user/tracking.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { userNameFromProperty } from './types'
+import { userPositionAddUrl, userPositionHistoryUrl, userPositionPayload } from './tracking'
+
+describe('user position tracking helpers', () => {
+  it('builds the specific-mission position update URL', () => {
+    expect(userPositionAddUrl(7, 'test user')).toBe('/mission/7/data/user/test%20user/position/add/')
+  })
+
+  it('builds history URLs for specific and aggregate mission maps', () => {
+    expect(userPositionHistoryUrl(7, 'test')).toBe('/mission/7/data/user/test/position/history/')
+    expect(userPositionHistoryUrl('current', 'test')).toBe('/mission/current/data/users/test/position/history/')
+    expect(userPositionHistoryUrl('all', 'test')).toBe('/mission/all/data/users/test/position/history/')
+  })
+
+  it('converts geolocation coordinates to the backend payload shape', () => {
+    expect(
+      userPositionPayload({
+        latitude: -43.5,
+        longitude: 172.5,
+        altitude: 12,
+        heading: 90
+      })
+    ).toEqual({ lat: -43.5, lon: 172.5, alt: 12, heading: 90 })
+  })
+
+  it('normalizes Django natural-key user properties', () => {
+    expect(userNameFromProperty('test')).toBe('test')
+    expect(userNameFromProperty(['test'])).toBe('test')
+  })
+})

--- a/frontend/user/tracking.ts
+++ b/frontend/user/tracking.ts
@@ -1,0 +1,145 @@
+import { MissionId, isSpecificMission } from '../mission/MissionId'
+import L from 'leaflet'
+import markerIcon from 'leaflet/dist/images/marker-icon.png'
+
+import { smmPost } from '../ajax'
+import './tracking.css'
+
+type PositionPayload = {
+  lat: number
+  lon: number
+  alt: number | null
+  heading: number | null
+}
+type PositionCoords = Pick<GeolocationCoordinates, 'latitude' | 'longitude' | 'altitude' | 'heading'>
+
+interface UserTrackingControlOptions {
+  missionId: number
+  userName: string
+}
+
+interface UserTrackingControlInstance {
+  _container?: HTMLDivElement
+  _link?: HTMLAnchorElement
+  _watchID?: number
+  _tracking?: boolean
+  _activate?: (ev: Event) => void
+  _onKeyDown?: (ev: Event) => void
+}
+
+export function userPositionAddUrl(missionId: number, userName: string) {
+  return `/mission/${missionId}/data/user/${encodeURIComponent(userName)}/position/add/`
+}
+
+export function userPositionHistoryUrl(missionId: MissionId, userName: string) {
+  const encodedUser = encodeURIComponent(userName)
+  if (isSpecificMission(missionId)) return `/mission/${missionId}/data/user/${encodedUser}/position/history/`
+  return `/mission/${missionId}/data/users/${encodedUser}/position/history/`
+}
+
+export function userPositionPayload(coords: PositionCoords): PositionPayload {
+  return {
+    lat: coords.latitude,
+    lon: coords.longitude,
+    alt: coords.altitude,
+    heading: coords.heading
+  }
+}
+
+function setTrackingState(control: UserTrackingControlInstance, tracking: boolean, title: string) {
+  control._tracking = tracking
+  control._container?.classList.toggle('is-tracking', tracking)
+  if (control._link) control._link.title = title
+}
+
+export function createUserTrackingControl(opts: UserTrackingControlOptions): L.Control {
+  const Ctrl = L.Control.extend({
+    options: { position: 'topleft' },
+
+    onAdd(this: UserTrackingControlInstance) {
+      const container = L.DomUtil.create('div', 'UserTracker-container leaflet-bar')
+      const link = L.DomUtil.create('a', '', container)
+      link.href = '#'
+      link.title = 'Track My Position'
+      link.setAttribute('role', 'button')
+      link.tabIndex = 0
+
+      const img = L.DomUtil.create('img', 'UserTracker-marker', link)
+      img.src = markerIcon
+      img.alt = 'Track My Position'
+
+      const positionUpdate = (position: GeolocationPosition) => {
+        smmPost(userPositionAddUrl(opts.missionId, opts.userName), userPositionPayload(position.coords)).catch((err) => {
+          console.error('Failed to record user position:', err)
+          stopTracking()
+          setTrackingState(this, false, 'Position tracking failed')
+        })
+      }
+
+      const positionError = (error: GeolocationPositionError) => {
+        console.error(`Unable to track user position: ${error.message}`)
+        stopTracking()
+        setTrackingState(this, false, 'Position tracking unavailable')
+      }
+
+      const stopTracking = () => {
+        if (this._watchID !== undefined) {
+          navigator.geolocation.clearWatch(this._watchID)
+          this._watchID = undefined
+        }
+        setTrackingState(this, false, 'Track My Position')
+      }
+
+      const startTracking = () => {
+        if (!navigator.geolocation) {
+          setTrackingState(this, false, 'Geolocation is not supported')
+          return
+        }
+        this._watchID = navigator.geolocation.watchPosition(positionUpdate, positionError, {
+          timeout: 15000,
+          maximumAge: 1000,
+          enableHighAccuracy: true
+        })
+        setTrackingState(this, true, 'Stop Tracking My Position')
+      }
+
+      const activate = (ev: Event) => {
+        L.DomEvent.stop(ev)
+        if (this._tracking) stopTracking()
+        else startTracking()
+      }
+      const onKeyDown = (ev: Event) => {
+        const key = (ev as KeyboardEvent).key
+        if (key === 'Enter' || key === ' ') activate(ev)
+      }
+
+      L.DomEvent.disableClickPropagation(link)
+      L.DomEvent.on(link, 'click', activate)
+      L.DomEvent.on(link, 'keydown', onKeyDown)
+
+      this._container = container
+      this._link = link
+      this._tracking = false
+      this._activate = activate
+      this._onKeyDown = onKeyDown
+
+      return container
+    },
+
+    onRemove(this: UserTrackingControlInstance) {
+      if (this._watchID !== undefined) {
+        navigator.geolocation.clearWatch(this._watchID)
+        this._watchID = undefined
+      }
+      if (this._link && this._activate && this._onKeyDown) {
+        L.DomEvent.off(this._link, 'click', this._activate)
+        L.DomEvent.off(this._link, 'keydown', this._onKeyDown)
+      }
+      this._container = undefined
+      this._link = undefined
+      this._activate = undefined
+      this._onKeyDown = undefined
+    }
+  })
+  return new Ctrl()
+}

--- a/frontend/user/types.ts
+++ b/frontend/user/types.ts
@@ -1,6 +1,8 @@
+type SMMUserName = string | [string]
+
 interface SMMMissionUserPointTimeData {
   pk: number
-  user: string
+  user: SMMUserName
   created_at: string
   alt?: number
 }
@@ -13,4 +15,9 @@ interface SMMMissionUserPointTimeGeoJSON {
   properties: SMMMissionUserPointTimeData
 }
 
-export { SMMMissionUserPointTimeData, SMMMissionUserPointTimeGeoJSON }
+function userNameFromProperty(user: SMMUserName) {
+  if (Array.isArray(user)) return user[0] ?? ''
+  return user
+}
+
+export { SMMMissionUserPointTimeData, SMMMissionUserPointTimeGeoJSON, userNameFromProperty }

--- a/map/templates/map_main.html
+++ b/map/templates/map_main.html
@@ -11,5 +11,6 @@
     <body style="height: 100%">
 	{% csrf_token %}
     <input type="hidden" value="{% if mission == 'all' or mission == 'current' %}{{ mission }}{% else %}{{ mission.pk }}{% endif %}" name="missionId" id="missionId" />
+    <input type="hidden" value="{{ request.user.username }}" name="currentUser" id="currentUser" />
     </body>
 </html>


### PR DESCRIPTION
## Description

UserPointTime storage and map display already existed, but a logged-in user had no normal mission-map control to start reporting browser geolocation. Add a mission-specific tracking control wired to the existing user position endpoint, normalize Django natural-key user properties, and fix aggregate user track history URLs so current/all mission maps can load tracks correctly. Add frontend helper coverage and backend endpoint coverage for #317.

## Summary by Sourcery

Enable logged-in mission users to track and publish their own positions on maps and ensure their latest and historical tracks load correctly across mission views.

New Features:
- Add a mission-specific user tracking map control that records browser geolocation to the existing user position endpoint.
- Expose user position history URLs that work for both specific missions and aggregate mission views.

Bug Fixes:
- Fix user track history endpoints so current and all mission map views can load user tracks correctly.
- Normalize user properties from Django natural keys on the frontend so user position features render with the correct username.

Tests:
- Add backend tests covering latest user position and mission/aggregate history endpoints.
- Introduce frontend test scaffolding for the new user tracking functionality.