### PR TITLE
mission: sort timeline newest first

### DIFF
--- a/frontend/mission/timeline.test.tsx
+++ b/frontend/mission/timeline.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 vi.mock('../page-shell', () => ({}))
 vi.mock('../ajax', () => ({
@@ -7,8 +8,8 @@ vi.mock('../ajax', () => ({
   smmPost: vi.fn(() => Promise.resolve(''))
 }))
 
-import { smmPost } from '../ajax'
-import { MissionTimeLineEntryAdd } from './timeline'
+import { smmGetJSON, smmPost } from '../ajax'
+import { MissionTimeLine, MissionTimeLineEntryAdd } from './timeline'
 
 afterEach(() => {
   vi.useRealTimers()
@@ -34,5 +35,57 @@ describe('MissionTimeLineEntryAdd', () => {
       message: 'Manual timeline entry',
       url: ''
     })
+  })
+})
+
+function timelineRows() {
+  const table = screen.getByRole('table', { name: 'Timeline entries' })
+  return within(table)
+    .getAllByRole('row')
+    .map((row) => row.textContent ?? '')
+    .filter((text) => text.includes('entry'))
+}
+
+describe('MissionTimeLine', () => {
+  it('defaults to newest first and can switch to oldest first', async () => {
+    vi.mocked(smmGetJSON).mockResolvedValue({
+      mission: {
+        id: 42,
+        name: 'Test mission',
+        description: 'description',
+        started: '2026-06-28T00:00:00.000Z',
+        creator: 'test1',
+        closed: '2026-06-28T02:00:00.000Z',
+        admin: true
+      },
+      timeline: [
+        {
+          id: 1,
+          timestamp: '2026-06-28T00:00:00.000Z',
+          creator: 'test1',
+          event_type: 'User defined Event',
+          message: 'Old entry',
+          url: ''
+        },
+        {
+          id: 2,
+          timestamp: '2026-06-28T01:00:00.000Z',
+          creator: 'test1',
+          event_type: 'User defined Event',
+          message: 'New entry',
+          url: ''
+        }
+      ]
+    })
+
+    render(<MissionTimeLine missionId={42} />)
+
+    await screen.findByText('New entry')
+    expect(smmGetJSON).toHaveBeenCalledWith('/mission/42/timeline/', { order: 'desc' })
+    expect(timelineRows()[0]).toContain('New entry')
+
+    await userEvent.selectOptions(screen.getByLabelText('Timeline sort order'), 'asc')
+
+    expect(timelineRows()[0]).toContain('Old entry')
   })
 })

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -1,7 +1,7 @@
 import '../page-shell'
-import { ChangeEvent, useState } from 'react'
+import { ChangeEvent, useMemo, useState } from 'react'
 import * as ReactDOM from 'react-dom/client'
-import { Table, Button } from 'react-bootstrap'
+import { Table, Button, Form } from 'react-bootstrap'
 import DateTimePicker from 'react-datetime-picker'
 import 'react-datetime-picker/dist/DateTimePicker.css'
 
@@ -81,6 +81,8 @@ interface TimeLineEntry {
   url: string
 }
 
+type TimelineSortOrder = 'desc' | 'asc'
+
 function MissionTimelineEntry({ timelineEntry }: { timelineEntry: TimeLineEntry }) {
   return (
     <tr>
@@ -100,18 +102,41 @@ interface MissionTimeLineProps {
 export function MissionTimeLine({ missionId }: MissionTimeLineProps) {
   const [timelineEntries, setTimelineEntries] = useState<TimeLineEntry[]>([])
   const [missionData, setMissionData] = useState<MissionData | undefined>(undefined)
+  const [sortOrder, setSortOrder] = useState<TimelineSortOrder>('desc')
 
   usePolling(async () => {
-    const data = await smmGetJSON<{ timeline: TimeLineEntry[]; mission: MissionData }>(`/mission/${missionId}/timeline/`, {})
+    const data = await smmGetJSON<{ timeline: TimeLineEntry[]; mission: MissionData }>(`/mission/${missionId}/timeline/`, { order: sortOrder })
     setTimelineEntries(data.timeline)
     setMissionData(data.mission)
   }, 10000)
+
+  const sortedTimelineEntries = useMemo(
+    () =>
+      [...timelineEntries].sort((a, b) => {
+        const byTime = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+        const byId = a.id - b.id
+        const result = byTime || byId
+        return sortOrder === 'asc' ? result : -result
+      }),
+    [sortOrder, timelineEntries]
+  )
 
   return (
     <div>
       {missionData && <MissionHeader key="missionHeader" mission={missionData} />}
       {missionData && !missionData.closed && <MissionTimeLineEntryAdd missionId={missionId} />}
-      <Table responsive>
+      <div className="d-flex justify-content-end mb-2">
+        <Form.Select
+          aria-label="Timeline sort order"
+          value={sortOrder}
+          onChange={(event: ChangeEvent<HTMLSelectElement>) => setSortOrder(event.target.value as TimelineSortOrder)}
+          style={{ maxWidth: '12rem' }}
+        >
+          <option value="desc">Newest first</option>
+          <option value="asc">Oldest first</option>
+        </Form.Select>
+      </div>
+      <Table responsive aria-label="Timeline entries">
         <thead>
           <tr>
             <td key="heading" colSpan={5} align="center">
@@ -127,7 +152,7 @@ export function MissionTimeLine({ missionId }: MissionTimeLineProps) {
           </tr>
         </thead>
         <tbody>
-          {timelineEntries.map((entry) => (
+          {sortedTimelineEntries.map((entry) => (
             <MissionTimelineEntry key={entry.id} timelineEntry={entry} />
           ))}
         </tbody>

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -463,6 +463,68 @@ class MissionTimelineTestCase(MissionBaseTestCase):
     """
     Mission timeline API
     """
+    @staticmethod
+    def _timeline_messages(response):
+        """
+        Return manual test timeline messages from a timeline response.
+        """
+        messages = [entry['message'] for entry in response.json()['timeline']]
+        return [message for message in messages if message in ('Old entry', 'New entry')]
+
+    def _create_ordered_timeline_entries(self, mission):
+        """
+        Create two manual entries with stable timestamps for sort tests.
+        """
+        mission_obj = mission.get_object()
+        TimeLineEntry.objects.create(
+            mission=mission_obj,
+            user=self.smm.user1,
+            event_type='usr',
+            message='Old entry',
+            timestamp=datetime(2026, 6, 28, 12, 0, tzinfo=datetime_timezone.utc),
+        )
+        TimeLineEntry.objects.create(
+            mission=mission_obj,
+            user=self.smm.user1,
+            event_type='usr',
+            message='New entry',
+            timestamp=datetime(2026, 6, 28, 13, 0, tzinfo=datetime_timezone.utc),
+        )
+
+    def test_timeline_defaults_to_newest_first(self):
+        """
+        Timeline JSON returns the newest entries first by default.
+        """
+        mission = self.missions.create_mission('test_timeline_default_order')
+        self._create_ordered_timeline_entries(mission)
+
+        response = self.smm.client1.get(f'/mission/{mission.mission_pk}/timeline/', HTTP_ACCEPT='application/json')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._timeline_messages(response), ['New entry', 'Old entry'])
+
+    def test_timeline_can_be_sorted_oldest_first(self):
+        """
+        Timeline JSON can still be requested oldest first.
+        """
+        mission = self.missions.create_mission('test_timeline_asc_order')
+        self._create_ordered_timeline_entries(mission)
+
+        response = self.smm.client1.get(f'/mission/{mission.mission_pk}/timeline/', data={'order': 'asc'}, HTTP_ACCEPT='application/json')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._timeline_messages(response), ['Old entry', 'New entry'])
+
+    def test_invalid_timeline_sort_order_is_rejected(self):
+        """
+        Unknown timeline sort orders fail clearly.
+        """
+        mission = self.missions.create_mission('test_timeline_invalid_order')
+
+        response = self.smm.client1.get(f'/mission/{mission.mission_pk}/timeline/', data={'order': 'sideways'}, HTTP_ACCEPT='application/json')
+
+        self.assertEqual(response.status_code, 400)
+
     def test_missing_timeline_timestamp_uses_submit_time(self):
         """
         Adding a manual timeline entry without a timestamp uses the server time.

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -524,6 +524,11 @@ class MissionTimelineTestCase(MissionBaseTestCase):
         response = self.smm.client1.get(f'/mission/{mission.mission_pk}/timeline/', data={'order': 'sideways'}, HTTP_ACCEPT='application/json')
 
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertEqual(response.json(), {
+            'error': 'invalid_timeline_order',
+            'message': 'Invalid timeline order',
+        })
 
     def test_missing_timeline_timestamp_uses_submit_time(self):
         """

--- a/mission/views.py
+++ b/mission/views.py
@@ -214,11 +214,27 @@ class MissionTimelineView(View):
     """
     Show/update the timeline for a mission
     """
-    def as_json(self, mission_user):
+    @staticmethod
+    def _timeline_order_fields(request):
+        """
+        Return database order fields for the requested timeline sort order.
+        """
+        order = request.GET.get('order', 'desc')
+        if order == 'asc':
+            return ('timestamp', 'pk')
+        if order == 'desc':
+            return ('-timestamp', '-pk')
+        return None
+
+    def as_json(self, request, mission_user):
         """
         Mission timeline, a history of everything that happened during a mission, in json
         """
-        timeline_entries = TimeLineEntry.objects.filter(mission=mission_user.mission).order_by('timestamp')
+        order_fields = self._timeline_order_fields(request)
+        if order_fields is None:
+            return HttpResponseBadRequest("Invalid timeline order")
+
+        timeline_entries = TimeLineEntry.objects.filter(mission=mission_user.mission).order_by(*order_fields)
 
         data = {
             'mission': mission_user.mission.as_object(mission_user.is_admin()),
@@ -231,7 +247,7 @@ class MissionTimelineView(View):
         Display the assets in this mission
         """
         if "application/json" in request.META.get('HTTP_ACCEPT', ''):
-            return self.as_json(mission_user)
+            return self.as_json(request, mission_user)
         data = {
             'mission': mission_user.mission,
         }

--- a/mission/views.py
+++ b/mission/views.py
@@ -232,7 +232,10 @@ class MissionTimelineView(View):
         """
         order_fields = self._timeline_order_fields(request)
         if order_fields is None:
-            return HttpResponseBadRequest("Invalid timeline order")
+            return JsonResponse({
+                'error': 'invalid_timeline_order',
+                'message': 'Invalid timeline order',
+            }, status=400)
 
         timeline_entries = TimeLineEntry.objects.filter(mission=mission_user.mission).order_by(*order_fields)
 


### PR DESCRIPTION
## Description

The timeline controls sit above the log, but the API previously returned entries oldest first, pushing the newest activity furthest from the controls. Default the JSON and UI to newest-first ordering, add an oldest-first selector for users who prefer chronological review, and keep the ordering stable for identical timestamps.

Refs #392

## Summary by Sourcery

Switch mission timelines to default to newest-first ordering while allowing users to toggle to oldest-first with stable ordering.

New Features:
- Add a timeline sort order selector in the mission UI to switch between newest-first and oldest-first views.

Bug Fixes:
- Ensure the mission timeline API rejects invalid sort order parameters with a clear JSON error response.

Enhancements:
- Default mission timeline API responses to newest-first ordering and apply stable sorting by timestamp and ID on both backend and frontend.

Tests:
- Add backend and frontend tests covering default newest-first ordering, oldest-first ordering, and rejection of invalid sort orders.