### PR TITLE
mission: filter timeline entries

### DIFF
--- a/frontend/mission/timeline.test.tsx
+++ b/frontend/mission/timeline.test.tsx
@@ -88,4 +88,44 @@ describe('MissionTimeLine', () => {
 
     expect(timelineRows()[0]).toContain('Old entry')
   })
+
+  it('sends timeline filters to the endpoint', async () => {
+    vi.mocked(smmGetJSON).mockResolvedValue({
+      mission: {
+        id: 42,
+        name: 'Test mission',
+        description: 'description',
+        started: '2026-06-28T00:00:00.000Z',
+        creator: 'test1',
+        closed: '2026-06-28T02:00:00.000Z',
+        admin: true
+      },
+      timeline: [
+        {
+          id: 1,
+          timestamp: '2026-06-28T00:00:00.000Z',
+          creator: 'test1',
+          event_type: 'User defined Event',
+          message: 'Medical note',
+          url: ''
+        }
+      ]
+    })
+
+    render(<MissionTimeLine missionId={42} />)
+
+    await screen.findByText('Medical note')
+    await userEvent.type(screen.getByLabelText('User'), 'test1')
+    await userEvent.type(screen.getByLabelText('Action'), 'User')
+    await userEvent.type(screen.getByLabelText('Contains'), 'medical')
+
+    const calls = vi.mocked(smmGetJSON).mock.calls
+    const lastCall = calls[calls.length - 1]
+    expect(lastCall?.[1]).toMatchObject({
+      order: 'desc',
+      user: 'test1',
+      action: 'User',
+      q: 'medical'
+    })
+  })
 })

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -1,5 +1,5 @@
 import '../page-shell'
-import { ChangeEvent, useMemo, useState } from 'react'
+import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { Table, Button, Form } from 'react-bootstrap'
 import DateTimePicker from 'react-datetime-picker'
@@ -82,6 +82,25 @@ interface TimeLineEntry {
 }
 
 type TimelineSortOrder = 'desc' | 'asc'
+type TimelineQueryParams = {
+  order: TimelineSortOrder
+  start?: string
+  end?: string
+  user?: string
+  action?: string
+  q?: string
+}
+
+function localDateTimeToIso(value: string) {
+  if (!value) return undefined
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return undefined
+  return date.toISOString()
+}
+
+function setIfPresent(params: TimelineQueryParams, key: keyof Omit<TimelineQueryParams, 'order'>, value?: string) {
+  if (value) params[key] = value
+}
 
 function MissionTimelineEntry({ timelineEntry }: { timelineEntry: TimeLineEntry }) {
   return (
@@ -103,12 +122,38 @@ export function MissionTimeLine({ missionId }: MissionTimeLineProps) {
   const [timelineEntries, setTimelineEntries] = useState<TimeLineEntry[]>([])
   const [missionData, setMissionData] = useState<MissionData | undefined>(undefined)
   const [sortOrder, setSortOrder] = useState<TimelineSortOrder>('desc')
+  const [startFilter, setStartFilter] = useState('')
+  const [endFilter, setEndFilter] = useState('')
+  const [userFilter, setUserFilter] = useState('')
+  const [actionFilter, setActionFilter] = useState('')
+  const [textFilter, setTextFilter] = useState('')
+  const skipInitialRefresh = useRef(true)
 
-  usePolling(async () => {
-    const data = await smmGetJSON<{ timeline: TimeLineEntry[]; mission: MissionData }>(`/mission/${missionId}/timeline/`, { order: sortOrder })
+  const queryParams = useMemo(() => {
+    const params: TimelineQueryParams = { order: sortOrder }
+    setIfPresent(params, 'start', localDateTimeToIso(startFilter))
+    setIfPresent(params, 'end', localDateTimeToIso(endFilter))
+    setIfPresent(params, 'user', userFilter.trim())
+    setIfPresent(params, 'action', actionFilter.trim())
+    setIfPresent(params, 'q', textFilter.trim())
+    return params
+  }, [actionFilter, endFilter, sortOrder, startFilter, textFilter, userFilter])
+
+  const loadTimeline = useCallback(async () => {
+    const data = await smmGetJSON<{ timeline: TimeLineEntry[]; mission: MissionData }>(`/mission/${missionId}/timeline/`, queryParams)
     setTimelineEntries(data.timeline)
     setMissionData(data.mission)
-  }, 10000)
+  }, [missionId, queryParams])
+
+  useEffect(() => {
+    if (skipInitialRefresh.current) {
+      skipInitialRefresh.current = false
+      return
+    }
+    void loadTimeline()
+  }, [loadTimeline])
+
+  usePolling(loadTimeline, 10000)
 
   const sortedTimelineEntries = useMemo(
     () =>
@@ -121,21 +166,58 @@ export function MissionTimeLine({ missionId }: MissionTimeLineProps) {
     [sortOrder, timelineEntries]
   )
 
+  function clearFilters() {
+    setStartFilter('')
+    setEndFilter('')
+    setUserFilter('')
+    setActionFilter('')
+    setTextFilter('')
+  }
+
   return (
     <div>
       {missionData && <MissionHeader key="missionHeader" mission={missionData} />}
       {missionData && !missionData.closed && <MissionTimeLineEntryAdd missionId={missionId} />}
-      <div className="d-flex justify-content-end mb-2">
-        <Form.Select
-          aria-label="Timeline sort order"
-          value={sortOrder}
-          onChange={(event: ChangeEvent<HTMLSelectElement>) => setSortOrder(event.target.value as TimelineSortOrder)}
-          style={{ maxWidth: '12rem' }}
-        >
-          <option value="desc">Newest first</option>
-          <option value="asc">Oldest first</option>
-        </Form.Select>
-      </div>
+      <Form className="mb-2" onSubmit={(event) => event.preventDefault()}>
+        <div className="row g-2 align-items-end">
+          <Form.Group className="col-sm-6 col-lg-2" controlId="timelineSortOrder">
+            <Form.Label>Sort</Form.Label>
+            <Form.Select
+              aria-label="Timeline sort order"
+              value={sortOrder}
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => setSortOrder(event.target.value as TimelineSortOrder)}
+            >
+              <option value="desc">Newest first</option>
+              <option value="asc">Oldest first</option>
+            </Form.Select>
+          </Form.Group>
+          <Form.Group className="col-sm-6 col-lg-2" controlId="timelineStartFilter">
+            <Form.Label>From</Form.Label>
+            <Form.Control type="datetime-local" value={startFilter} onChange={(event: ChangeEvent<HTMLInputElement>) => setStartFilter(event.target.value)} />
+          </Form.Group>
+          <Form.Group className="col-sm-6 col-lg-2" controlId="timelineEndFilter">
+            <Form.Label>To</Form.Label>
+            <Form.Control type="datetime-local" value={endFilter} onChange={(event: ChangeEvent<HTMLInputElement>) => setEndFilter(event.target.value)} />
+          </Form.Group>
+          <Form.Group className="col-sm-6 col-lg-2" controlId="timelineUserFilter">
+            <Form.Label>User</Form.Label>
+            <Form.Control value={userFilter} onChange={(event: ChangeEvent<HTMLInputElement>) => setUserFilter(event.target.value)} />
+          </Form.Group>
+          <Form.Group className="col-sm-6 col-lg-2" controlId="timelineActionFilter">
+            <Form.Label>Action</Form.Label>
+            <Form.Control value={actionFilter} onChange={(event: ChangeEvent<HTMLInputElement>) => setActionFilter(event.target.value)} />
+          </Form.Group>
+          <Form.Group className="col-sm-6 col-lg-2" controlId="timelineTextFilter">
+            <Form.Label>Contains</Form.Label>
+            <div className="d-flex gap-2">
+              <Form.Control value={textFilter} onChange={(event: ChangeEvent<HTMLInputElement>) => setTextFilter(event.target.value)} />
+              <Button type="button" variant="light" onClick={clearFilters}>
+                Clear
+              </Button>
+            </div>
+          </Form.Group>
+        </div>
+      </Form>
       <Table responsive aria-label="Timeline entries">
         <thead>
           <tr>

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -491,6 +491,35 @@ class MissionTimelineTestCase(MissionBaseTestCase):
             timestamp=datetime(2026, 6, 28, 13, 0, tzinfo=datetime_timezone.utc),
         )
 
+    def _create_filter_timeline_entries(self, mission):
+        """
+        Create timeline entries that can be filtered independently.
+        """
+        mission_obj = mission.get_object()
+        TimeLineEntry.objects.create(
+            mission=mission_obj,
+            user=self.smm.user1,
+            event_type='usr',
+            message='Medical note',
+            url='http://example.test/medical',
+            timestamp=datetime(2026, 6, 28, 12, 0, tzinfo=datetime_timezone.utc),
+        )
+        TimeLineEntry.objects.create(
+            mission=mission_obj,
+            user=self.smm.user2,
+            event_type='que',
+            message='Search queue noise',
+            url='',
+            timestamp=datetime(2026, 6, 28, 13, 0, tzinfo=datetime_timezone.utc),
+        )
+
+    @staticmethod
+    def _messages(response):
+        """
+        Return all timeline messages from a timeline response.
+        """
+        return [entry['message'] for entry in response.json()['timeline']]
+
     def test_timeline_defaults_to_newest_first(self):
         """
         Timeline JSON returns the newest entries first by default.
@@ -529,6 +558,57 @@ class MissionTimelineTestCase(MissionBaseTestCase):
             'error': 'invalid_timeline_order',
             'message': 'Invalid timeline order',
         })
+
+    def test_timeline_filters_by_date_range(self):
+        """
+        Timeline JSON can be filtered to a date/time range.
+        """
+        mission = self.missions.create_mission('test_timeline_date_filter')
+        self._create_filter_timeline_entries(mission)
+
+        response = self.smm.client1.get(
+            f'/mission/{mission.mission_pk}/timeline/',
+            data={
+                'start': '2026-06-28T12:30:00Z',
+                'end': '2026-06-28T13:30:00Z',
+            },
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Search queue noise', self._messages(response))
+        self.assertNotIn('Medical note', self._messages(response))
+
+    def test_timeline_filters_by_user_action_and_text(self):
+        """
+        Timeline JSON can be filtered by creator, action, and message/url contents.
+        """
+        mission = self.missions.create_mission('test_timeline_field_filters')
+        self._create_filter_timeline_entries(mission)
+
+        response = self.smm.client1.get(
+            f'/mission/{mission.mission_pk}/timeline/',
+            data={'user': 'test1', 'action': 'User defined', 'q': 'medical'},
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Medical note', self._messages(response))
+        self.assertNotIn('Search queue noise', self._messages(response))
+
+    def test_invalid_timeline_date_filter_is_rejected(self):
+        """
+        Invalid date filters fail clearly.
+        """
+        mission = self.missions.create_mission('test_timeline_invalid_date_filter')
+
+        response = self.smm.client1.get(
+            f'/mission/{mission.mission_pk}/timeline/',
+            data={'start': 'not-a-date'},
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
 
     def test_missing_timeline_timestamp_uses_submit_time(self):
         """

--- a/mission/views.py
+++ b/mission/views.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseBadRequest, JsonResponse, HttpResponseRedirect, HttpResponseForbidden, HttpResponseNotFound, HttpResponse
 from django.db import transaction
-from django.db.models import OuterRef, Prefetch, Subquery, Exists
+from django.db.models import OuterRef, Prefetch, Q, Subquery, Exists
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django.utils.decorators import method_decorator
@@ -226,6 +226,61 @@ class MissionTimelineView(View):
             return ('-timestamp', '-pk')
         return None
 
+    @staticmethod
+    def _parse_timeline_datetime(value):
+        """
+        Parse a timeline filter datetime from the request query.
+        """
+        if not value:
+            return None
+        timestamp = parse_datetime(value)
+        if timestamp is None:
+            return False
+        if timezone.is_naive(timestamp):
+            return timezone.make_aware(timestamp, timezone.get_current_timezone())
+        return timestamp
+
+    @staticmethod
+    def _timeline_action_codes(action_filter):
+        """
+        Match an action filter against timeline event codes and labels.
+        """
+        action_filter = action_filter.lower()
+        return [
+            code
+            for code, label in TimeLineEntry.EVENT_TYPE
+            if action_filter in code.lower() or action_filter in label.lower()
+        ]
+
+    def _timeline_entries(self, request, mission):
+        """
+        Return filtered timeline entries for the mission.
+        """
+        timeline_entries = TimeLineEntry.objects.filter(mission=mission)
+
+        start = self._parse_timeline_datetime(request.GET.get('start'))
+        end = self._parse_timeline_datetime(request.GET.get('end'))
+        if start is False or end is False:
+            return None
+        if start:
+            timeline_entries = timeline_entries.filter(timestamp__gte=start)
+        if end:
+            timeline_entries = timeline_entries.filter(timestamp__lte=end)
+
+        user_filter = request.GET.get('user', '').strip()
+        if user_filter:
+            timeline_entries = timeline_entries.filter(user__username__icontains=user_filter)
+
+        action_filter = request.GET.get('action', '').strip()
+        if action_filter:
+            timeline_entries = timeline_entries.filter(event_type__in=self._timeline_action_codes(action_filter))
+
+        text_filter = request.GET.get('q', '').strip()
+        if text_filter:
+            timeline_entries = timeline_entries.filter(Q(message__icontains=text_filter) | Q(url__icontains=text_filter))
+
+        return timeline_entries
+
     def as_json(self, request, mission_user):
         """
         Mission timeline, a history of everything that happened during a mission, in json
@@ -237,7 +292,11 @@ class MissionTimelineView(View):
                 'message': 'Invalid timeline order',
             }, status=400)
 
-        timeline_entries = TimeLineEntry.objects.filter(mission=mission_user.mission).order_by(*order_fields)
+        timeline_entries = self._timeline_entries(request, mission_user.mission)
+        if timeline_entries is None:
+            return HttpResponseBadRequest("Invalid timeline date filter")
+
+        timeline_entries = timeline_entries.order_by(*order_fields)
 
         data = {
             'mission': mission_user.mission.as_object(mission_user.is_admin()),


### PR DESCRIPTION
## Description

Busy missions produce noisy timelines, and manual entries can be hard to find. Add API and UI filters for date range, creator, action, and message or URL contents so users can narrow the log without exporting or scanning every row. This also completes the date-range part of the timeline sort request.

Fixes #391

Fixes #392

## Summary by Sourcery

Add server-side and UI support for filtering mission timeline entries by date range, creator, action, and text while preserving sort order.

New Features:
- Introduce mission timeline API filters for start/end date, creator, action, and message or URL contents.
- Add timeline filter controls to the mission timeline UI, including clearable inputs alongside sort selection.

Bug Fixes:
- Reject invalid timeline date parameters with a clear 400 error from the API.

Enhancements:
- Refine mission timeline polling to reload entries when filters or sort order change.
- Map free-text action filters to underlying timeline event codes and labels for more flexible matching.

Tests:
- Add backend tests covering timeline filtering by date range, user, action, text, and invalid date handling.
- Add frontend tests verifying that timeline filters are sent to the API as expected.