### PR TITLE
mission: edit manual timeline entries

### DIFF
--- a/frontend/mission/timeline.test.tsx
+++ b/frontend/mission/timeline.test.tsx
@@ -5,10 +5,18 @@ import userEvent from '@testing-library/user-event'
 vi.mock('../page-shell', () => ({}))
 vi.mock('../ajax', () => ({
   smmGetJSON: vi.fn(),
-  smmPost: vi.fn(() => Promise.resolve(''))
+  smmPost: vi.fn(() => Promise.resolve('')),
+  smmPatch: vi.fn((_url: string, _data: unknown, success?: () => void) => {
+    success?.()
+    return Promise.resolve('')
+  }),
+  smmDelete: vi.fn((_url: string, success?: () => void) => {
+    success?.()
+    return Promise.resolve()
+  })
 }))
 
-import { smmGetJSON, smmPost } from '../ajax'
+import { smmDelete, smmGetJSON, smmPatch, smmPost } from '../ajax'
 import { MissionTimeLine, MissionTimeLineEntryAdd } from './timeline'
 
 afterEach(() => {
@@ -127,5 +135,81 @@ describe('MissionTimeLine', () => {
       action: 'User',
       q: 'medical'
     })
+  })
+
+  it('updates editable manual timeline entries', async () => {
+    vi.mocked(smmGetJSON).mockResolvedValue({
+      mission: {
+        id: 42,
+        name: 'Test mission',
+        description: 'description',
+        started: '2026-06-28T00:00:00.000Z',
+        creator: 'test1',
+        admin: true
+      },
+      timeline: [
+        {
+          id: 7,
+          timestamp: '2026-06-28T00:00:00.000Z',
+          creator: 'test1',
+          event_type_code: 'usr',
+          event_type: 'User defined Event',
+          message: 'Manual entry',
+          url: '',
+          can_edit: true
+        }
+      ]
+    })
+
+    render(<MissionTimeLine missionId={42} />)
+
+    const row = (await screen.findByText('Manual entry')).closest('tr')
+    if (!row) throw new Error('Timeline row not found')
+    await userEvent.click(within(row).getByRole('button', { name: 'Edit' }))
+    const messageInput = screen.getByDisplayValue('Manual entry')
+    fireEvent.change(messageInput, { target: { value: 'Updated entry' } })
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(smmPatch).toHaveBeenCalledWith(
+      '/mission/42/timeline/7/',
+      expect.objectContaining({
+        message: 'Updated entry',
+        url: ''
+      }),
+      expect.any(Function)
+    )
+  })
+
+  it('deletes editable manual timeline entries', async () => {
+    vi.mocked(smmGetJSON).mockResolvedValue({
+      mission: {
+        id: 42,
+        name: 'Test mission',
+        description: 'description',
+        started: '2026-06-28T00:00:00.000Z',
+        creator: 'test1',
+        admin: true
+      },
+      timeline: [
+        {
+          id: 7,
+          timestamp: '2026-06-28T00:00:00.000Z',
+          creator: 'test1',
+          event_type_code: 'usr',
+          event_type: 'User defined Event',
+          message: 'Manual entry',
+          url: '',
+          can_edit: true
+        }
+      ]
+    })
+
+    render(<MissionTimeLine missionId={42} />)
+
+    const row = (await screen.findByText('Manual entry')).closest('tr')
+    if (!row) throw new Error('Timeline row not found')
+    await userEvent.click(within(row).getByRole('button', { name: 'Delete' }))
+
+    expect(smmDelete).toHaveBeenCalledWith('/mission/42/timeline/7/', expect.any(Function))
   })
 })

--- a/frontend/mission/timeline.test.tsx
+++ b/frontend/mission/timeline.test.tsx
@@ -6,8 +6,8 @@ vi.mock('../page-shell', () => ({}))
 vi.mock('../ajax', () => ({
   smmGetJSON: vi.fn(),
   smmPost: vi.fn(() => Promise.resolve('')),
-  smmPatch: vi.fn((_url: string, _data: unknown, success?: () => void) => {
-    success?.()
+  smmPatch: vi.fn((_url: string, _data: unknown, success?: (data: string) => void) => {
+    success?.('')
     return Promise.resolve('')
   }),
   smmDelete: vi.fn((_url: string, success?: () => void) => {
@@ -176,8 +176,83 @@ describe('MissionTimeLine', () => {
         message: 'Updated entry',
         url: ''
       }),
+      expect.any(Function),
       expect.any(Function)
     )
+  })
+
+  it('shows validation feedback instead of silently ignoring invalid timeline edits', async () => {
+    vi.mocked(smmGetJSON).mockResolvedValue({
+      mission: {
+        id: 42,
+        name: 'Test mission',
+        description: 'description',
+        started: '2026-06-28T00:00:00.000Z',
+        creator: 'test1',
+        admin: true
+      },
+      timeline: [
+        {
+          id: 7,
+          timestamp: '2026-06-28T00:00:00.000Z',
+          creator: 'test1',
+          event_type_code: 'usr',
+          event_type: 'User defined Event',
+          message: 'Manual entry',
+          url: '',
+          can_edit: true
+        }
+      ]
+    })
+
+    render(<MissionTimeLine missionId={42} />)
+
+    const row = (await screen.findByText('Manual entry')).closest('tr')
+    if (!row) throw new Error('Timeline row not found')
+    await userEvent.click(within(row).getByRole('button', { name: 'Edit' }))
+    fireEvent.change(screen.getByDisplayValue('Manual entry'), { target: { value: '' } })
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a valid date/time and a message before saving.')
+    expect(smmPatch).not.toHaveBeenCalled()
+  })
+
+  it('shows feedback when saving a timeline edit fails', async () => {
+    vi.mocked(smmGetJSON).mockResolvedValue({
+      mission: {
+        id: 42,
+        name: 'Test mission',
+        description: 'description',
+        started: '2026-06-28T00:00:00.000Z',
+        creator: 'test1',
+        admin: true
+      },
+      timeline: [
+        {
+          id: 7,
+          timestamp: '2026-06-28T00:00:00.000Z',
+          creator: 'test1',
+          event_type_code: 'usr',
+          event_type: 'User defined Event',
+          message: 'Manual entry',
+          url: '',
+          can_edit: true
+        }
+      ]
+    })
+    vi.mocked(smmPatch).mockImplementationOnce((_url: string, _data: unknown, _success?: (data: string) => void, error?: (data?: unknown) => void) => {
+      error?.({ error: 'bad_request' })
+      return Promise.reject(new Error('HTTP 400'))
+    })
+
+    render(<MissionTimeLine missionId={42} />)
+
+    const row = (await screen.findByText('Manual entry')).closest('tr')
+    if (!row) throw new Error('Timeline row not found')
+    await userEvent.click(within(row).getByRole('button', { name: 'Edit' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not save the timeline entry. Check your input and try again.')
   })
 
   it('deletes editable manual timeline entries', async () => {

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -116,11 +116,13 @@ function MissionTimelineEntry({ timelineEntry, missionId, onChanged }: { timelin
   const [timestamp, setTimestamp] = useState('')
   const [message, setMessage] = useState('')
   const [url, setUrl] = useState('')
+  const [saveError, setSaveError] = useState('')
 
   function startEdit() {
     setTimestamp(isoToLocalDateTimeInput(timelineEntry.timestamp))
     setMessage(timelineEntry.message)
     setUrl(timelineEntry.url || '')
+    setSaveError('')
     setEditing(true)
   }
 
@@ -132,13 +134,18 @@ function MissionTimelineEntry({ timelineEntry, missionId, onChanged }: { timelin
     setTimestamp(isoToLocalDateTimeInput(timelineEntry.timestamp))
     setMessage(timelineEntry.message)
     setUrl(timelineEntry.url || '')
+    setSaveError('')
     setEditing(false)
   }
 
   function saveEdit() {
     const timestampIso = localDateTimeToIso(timestamp)
-    if (!timestampIso || !message.trim()) return
-    smmPatch(
+    if (!timestampIso || !message.trim()) {
+      setSaveError('Enter a valid date/time and a message before saving.')
+      return
+    }
+    setSaveError('')
+    void smmPatch(
       `/mission/${missionId}/timeline/${timelineEntry.id}/`,
       {
         timestamp: timestampIso,
@@ -148,8 +155,11 @@ function MissionTimelineEntry({ timelineEntry, missionId, onChanged }: { timelin
       () => {
         setEditing(false)
         refresh()
+      },
+      () => {
+        setSaveError('Could not save the timeline entry. Check your input and try again.')
       }
-    )
+    ).catch(() => undefined)
   }
 
   function deleteEntry() {
@@ -177,6 +187,11 @@ function MissionTimelineEntry({ timelineEntry, missionId, onChanged }: { timelin
               Cancel
             </Button>
           </div>
+          {saveError && (
+            <div className="text-danger small mt-1" role="alert">
+              {saveError}
+            </div>
+          )}
         </td>
       </tr>
     )

--- a/frontend/mission/timeline.tsx
+++ b/frontend/mission/timeline.tsx
@@ -6,7 +6,7 @@ import DateTimePicker from 'react-datetime-picker'
 import 'react-datetime-picker/dist/DateTimePicker.css'
 
 import { formatLocalDateTime } from '../format'
-import { smmGetJSON, smmPost } from '../ajax'
+import { smmDelete, smmGetJSON, smmPatch, smmPost } from '../ajax'
 import { MissionHeader } from './header'
 import { SMMMissionTopBar } from '../menu/topbar'
 import { usePolling } from '../hooks/usePolling'
@@ -76,9 +76,11 @@ interface TimeLineEntry {
   id: number
   timestamp: string
   creator: string
+  event_type_code?: string
   event_type: string
   message: string
   url: string
+  can_edit?: boolean
 }
 
 type TimelineSortOrder = 'desc' | 'asc'
@@ -98,18 +100,109 @@ function localDateTimeToIso(value: string) {
   return date.toISOString()
 }
 
+function isoToLocalDateTimeInput(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+  return localDate.toISOString().slice(0, 16)
+}
+
 function setIfPresent(params: TimelineQueryParams, key: keyof Omit<TimelineQueryParams, 'order'>, value?: string) {
   if (value) params[key] = value
 }
 
-function MissionTimelineEntry({ timelineEntry }: { timelineEntry: TimeLineEntry }) {
+function MissionTimelineEntry({ timelineEntry, missionId, onChanged }: { timelineEntry: TimeLineEntry; missionId: number; onChanged: () => Promise<void> }) {
+  const [editing, setEditing] = useState(false)
+  const [timestamp, setTimestamp] = useState('')
+  const [message, setMessage] = useState('')
+  const [url, setUrl] = useState('')
+
+  function startEdit() {
+    setTimestamp(isoToLocalDateTimeInput(timelineEntry.timestamp))
+    setMessage(timelineEntry.message)
+    setUrl(timelineEntry.url || '')
+    setEditing(true)
+  }
+
+  function refresh() {
+    void onChanged()
+  }
+
+  function cancelEdit() {
+    setTimestamp(isoToLocalDateTimeInput(timelineEntry.timestamp))
+    setMessage(timelineEntry.message)
+    setUrl(timelineEntry.url || '')
+    setEditing(false)
+  }
+
+  function saveEdit() {
+    const timestampIso = localDateTimeToIso(timestamp)
+    if (!timestampIso || !message.trim()) return
+    smmPatch(
+      `/mission/${missionId}/timeline/${timelineEntry.id}/`,
+      {
+        timestamp: timestampIso,
+        message,
+        url
+      },
+      () => {
+        setEditing(false)
+        refresh()
+      }
+    )
+  }
+
+  function deleteEntry() {
+    smmDelete(`/mission/${missionId}/timeline/${timelineEntry.id}/`, refresh)
+  }
+
+  if (editing) {
+    return (
+      <tr>
+        <td>
+          <Form.Control type="datetime-local" value={timestamp} onChange={(event: ChangeEvent<HTMLInputElement>) => setTimestamp(event.target.value)} />
+        </td>
+        <td>{timelineEntry.creator}</td>
+        <td>{timelineEntry.event_type}</td>
+        <td>
+          <Form.Control value={message} onChange={(event: ChangeEvent<HTMLInputElement>) => setMessage(event.target.value)} />
+        </td>
+        <td>
+          <div className="d-flex gap-2">
+            <Form.Control value={url} onChange={(event: ChangeEvent<HTMLInputElement>) => setUrl(event.target.value)} />
+            <Button type="button" variant="primary" size="sm" onClick={saveEdit}>
+              Save
+            </Button>
+            <Button type="button" variant="light" size="sm" onClick={cancelEdit}>
+              Cancel
+            </Button>
+          </div>
+        </td>
+      </tr>
+    )
+  }
+
   return (
     <tr>
       <td>{formatLocalDateTime(timelineEntry.timestamp)}</td>
       <td>{timelineEntry.creator}</td>
       <td>{timelineEntry.event_type}</td>
       <td>{timelineEntry.message}</td>
-      <td>{timelineEntry.url}</td>
+      <td>
+        <div className="d-flex gap-2 align-items-center">
+          <span>{timelineEntry.url}</span>
+          {timelineEntry.can_edit && (
+            <>
+              <Button type="button" variant="light" size="sm" onClick={startEdit}>
+                Edit
+              </Button>
+              <Button type="button" variant="danger" size="sm" onClick={deleteEntry}>
+                Delete
+              </Button>
+            </>
+          )}
+        </div>
+      </td>
     </tr>
   )
 }
@@ -235,7 +328,7 @@ export function MissionTimeLine({ missionId }: MissionTimeLineProps) {
         </thead>
         <tbody>
           {sortedTimelineEntries.map((entry) => (
-            <MissionTimelineEntry key={entry.id} timelineEntry={entry} />
+            <MissionTimelineEntry key={entry.id} timelineEntry={entry} missionId={missionId} onChanged={loadTimeline} />
           ))}
         </tbody>
       </Table>

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -463,6 +463,19 @@ class MissionTimelineTestCase(MissionBaseTestCase):
     """
     Mission timeline API
     """
+    def _create_manual_timeline_entry(self, mission, user=None, message='Manual entry'):
+        """
+        Create a manual timeline entry for edit/delete tests.
+        """
+        return TimeLineEntry.objects.create(
+            mission=mission.get_object(),
+            user=user or self.smm.user1,
+            event_type='usr',
+            message=message,
+            url='',
+            timestamp=datetime(2026, 6, 28, 12, 0, tzinfo=datetime_timezone.utc),
+        )
+
     @staticmethod
     def _timeline_messages(response):
         """
@@ -651,6 +664,117 @@ class MissionTimelineTestCase(MissionBaseTestCase):
             ).exists()
         )
 
+    def test_manual_timeline_entry_can_be_updated(self):
+        """
+        The entry creator can update a manual timeline entry.
+        """
+        mission = self.missions.create_mission('test_timeline_entry_update')
+        entry = self._create_manual_timeline_entry(mission)
+
+        response = self.smm.client1.patch(
+            f'/mission/{mission.mission_pk}/timeline/{entry.pk}/',
+            data='{"timestamp": "2026-06-28T13:00:00Z", "message": "Updated entry", "url": "http://example.test/update"}',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        entry.refresh_from_db()
+        self.assertEqual(entry.message, 'Updated entry')
+        self.assertEqual(entry.url, 'http://example.test/update')
+        self.assertEqual(entry.timestamp, datetime(2026, 6, 28, 13, 0, tzinfo=datetime_timezone.utc))
+
+    def test_manual_timeline_entry_can_be_deleted(self):
+        """
+        The entry creator can delete a manual timeline entry.
+        """
+        mission = self.missions.create_mission('test_timeline_entry_delete')
+        entry = self._create_manual_timeline_entry(mission)
+
+        response = self.smm.client1.delete(f'/mission/{mission.mission_pk}/timeline/{entry.pk}/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(TimeLineEntry.objects.filter(pk=entry.pk).exists())
+
+    def test_non_manual_timeline_entry_cannot_be_changed(self):
+        """
+        Generated timeline entries cannot be updated or deleted through the manual-entry endpoint.
+        """
+        mission = self.missions.create_mission('test_timeline_generated_entry')
+        entry = TimeLineEntry.objects.create(
+            mission=mission.get_object(),
+            user=self.smm.user1,
+            event_type='add',
+            message='Generated entry',
+            timestamp=datetime(2026, 6, 28, 12, 0, tzinfo=datetime_timezone.utc),
+        )
+
+        update_response = self.smm.client1.patch(
+            f'/mission/{mission.mission_pk}/timeline/{entry.pk}/',
+            data='{"message": "Updated generated entry"}',
+            content_type='application/json',
+        )
+        delete_response = self.smm.client1.delete(f'/mission/{mission.mission_pk}/timeline/{entry.pk}/')
+
+        self.assertEqual(update_response.status_code, 403)
+        self.assertEqual(delete_response.status_code, 403)
+        self.assertTrue(TimeLineEntry.objects.filter(pk=entry.pk).exists())
+
+    def test_manual_timeline_entry_rejects_non_owner(self):
+        """
+        A non-admin mission member cannot edit another user's manual timeline entry.
+        """
+        mission = self.missions.create_mission('test_timeline_entry_non_owner')
+        mission.add_user(user=self.smm.user2)
+        entry = self._create_manual_timeline_entry(mission)
+
+        response = self.smm.client2.patch(
+            f'/mission/{mission.mission_pk}/timeline/{entry.pk}/',
+            data='{"message": "Updated by another user"}',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 403)
+        entry.refresh_from_db()
+        self.assertEqual(entry.message, 'Manual entry')
+
+    def test_manual_timeline_entry_admin_can_update_other_user_entry(self):
+        """
+        A mission admin can update another user's manual timeline entry.
+        """
+        mission = self.missions.create_mission('test_timeline_entry_admin_update')
+        entry = self._create_manual_timeline_entry(mission, user=self.smm.user2)
+
+        response = self.smm.client1.patch(
+            f'/mission/{mission.mission_pk}/timeline/{entry.pk}/',
+            data='{"message": "Updated by admin"}',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        entry.refresh_from_db()
+        self.assertEqual(entry.message, 'Updated by admin')
+
+    def test_invalid_manual_timeline_entry_update_is_rejected(self):
+        """
+        Manual timeline entry updates require valid timestamps and non-empty messages.
+        """
+        mission = self.missions.create_mission('test_timeline_entry_invalid_update')
+        entry = self._create_manual_timeline_entry(mission)
+
+        timestamp_response = self.smm.client1.patch(
+            f'/mission/{mission.mission_pk}/timeline/{entry.pk}/',
+            data='{"timestamp": "not-a-date"}',
+            content_type='application/json',
+        )
+        message_response = self.smm.client1.patch(
+            f'/mission/{mission.mission_pk}/timeline/{entry.pk}/',
+            data='{"message": ""}',
+            content_type='application/json',
+        )
+
+        self.assertEqual(timestamp_response.status_code, 400)
+        self.assertEqual(message_response.status_code, 400)
+
 
 class MissionClosedWriteProtectionTestCase(TestCase):
     """
@@ -689,3 +813,19 @@ class MissionClosedWriteProtectionTestCase(TestCase):
         """Reading mission details is still allowed after closure."""
         response = self.mission.get_details(client=self.smm.client1)
         self.assertEqual(response.status_code, 200)
+
+    def test_timeline_entry_update_rejected_on_closed_mission(self):
+        """Updating a manual timeline entry on a closed mission is forbidden."""
+        entry = TimeLineEntry.objects.create(
+            mission=self.mission.get_object(),
+            user=self.smm.user1,
+            event_type='usr',
+            message='closed',
+            timestamp=timezone.now(),
+        )
+        response = self.smm.client1.patch(
+            f'/mission/{self.mission.mission_pk}/timeline/{entry.pk}/',
+            data='{"message": "updated"}',
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 403)

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -678,6 +678,8 @@ class MissionTimelineTestCase(MissionBaseTestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertEqual(response.json(), {'status': 'updated'})
         entry.refresh_from_db()
         self.assertEqual(entry.message, 'Updated entry')
         self.assertEqual(entry.url, 'http://example.test/update')
@@ -692,7 +694,8 @@ class MissionTimelineTestCase(MissionBaseTestCase):
 
         response = self.smm.client1.delete(f'/mission/{mission.mission_pk}/timeline/{entry.pk}/')
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.content, b'')
         self.assertFalse(TimeLineEntry.objects.filter(pk=entry.pk).exists())
 
     def test_non_manual_timeline_entry_cannot_be_changed(self):

--- a/mission/urls.py
+++ b/mission/urls.py
@@ -5,11 +5,13 @@ This is mapped in to /mission
 """
 
 from django.urls import re_path
+from timeline import views as timeline_views
 from . import views
 
 urlpatterns = [
     re_path(r'^mission/(?P<mission_id>\d+)/details/$', views.MissionDetailsView.as_view(), name='mission_details'),
     re_path(r'^mission/(?P<mission_id>\d+)/timeline/$', views.MissionTimelineView.as_view(), name='mission_timeline'),
+    re_path(r'^mission/(?P<mission_id>\d+)/timeline/(?P<entry_id>\d+)/$', timeline_views.MissionTimelineEntryView.as_view(), name='mission_timeline_entry'),
     re_path(r'^mission/(?P<mission_id>\d+)/organizations/$', views.MissionOrganizationsView.as_view(), name='mission_organizations'),
     re_path(r'^mission/(?P<mission_id>\d+)/organizations/(?P<organization_id>\d+)/$', views.MissionOrganizationView.as_view(), name='mission_organization'),
     re_path(r'^mission/(?P<mission_id>\d+)/users/$', views.MissionUsersView.as_view(), name='mission_users'),

--- a/mission/views.py
+++ b/mission/views.py
@@ -23,7 +23,7 @@ from mission.helpers import get_my_assets_not_in_mission
 from organization.decorators import asset_is_operator, get_organization_from_id, user_can_operate_asset
 from organization.models import Organization, OrganizationMember, OrganizationAsset
 from timeline.models import TimeLineEntry
-from timeline.helpers import timeline_record_create, \
+from timeline.helpers import can_change_timeline_entry, timeline_record_create, \
     timeline_record_external_reference_add, timeline_record_external_reference_remove, timeline_record_external_reference_update, \
     timeline_record_mission_organization_add, timeline_record_mission_organization_update, \
     timeline_record_mission_user_add, timeline_record_mission_user_update, \
@@ -219,7 +219,7 @@ class MissionTimelineView(View):
         """
         Return whether the mission user can change a manual timeline entry.
         """
-        return entry.event_type == 'usr' and (mission_user.is_admin() or entry.user == mission_user.user)
+        return can_change_timeline_entry(mission_user, entry)
 
     @staticmethod
     def _timeline_order_fields(request):

--- a/mission/views.py
+++ b/mission/views.py
@@ -215,6 +215,13 @@ class MissionTimelineView(View):
     Show/update the timeline for a mission
     """
     @staticmethod
+    def can_change_entry(mission_user, entry):
+        """
+        Return whether the mission user can change a manual timeline entry.
+        """
+        return entry.event_type == 'usr' and (mission_user.is_admin() or entry.user == mission_user.user)
+
+    @staticmethod
     def _timeline_order_fields(request):
         """
         Return database order fields for the requested timeline sort order.
@@ -297,10 +304,15 @@ class MissionTimelineView(View):
             return HttpResponseBadRequest("Invalid timeline date filter")
 
         timeline_entries = timeline_entries.order_by(*order_fields)
+        timeline = []
+        for timeline_entry in timeline_entries:
+            entry = timeline_entry.as_object()
+            entry['can_edit'] = self.can_change_entry(mission_user, timeline_entry)
+            timeline.append(entry)
 
         data = {
             'mission': mission_user.mission.as_object(mission_user.is_admin()),
-            'timeline': [timeline_entry.as_object() for timeline_entry in timeline_entries],
+            'timeline': timeline,
         }
         return JsonResponse(data)
 

--- a/timeline/helpers.py
+++ b/timeline/helpers.py
@@ -5,6 +5,13 @@ Helper functions for recording timeline activities
 from .models import TimeLineEntry
 
 
+def can_change_timeline_entry(mission_user, entry):
+    """
+    Return whether the mission user can change a manual timeline entry.
+    """
+    return entry.event_type == 'usr' and (mission_user.is_admin() or entry.user == mission_user.user)
+
+
 def timeline_record_create(mission, user, obj):
     """
     Create a timeline entry for an object being created

--- a/timeline/models.py
+++ b/timeline/models.py
@@ -62,6 +62,7 @@ class TimeLineEntry(models.Model):
             'id': self.pk,
             'creator': self.user.username,  # pylint: disable=E1101
             'timestamp': self.timestamp,
+            'event_type_code': self.event_type,
             'event_type': self.event_type_str(),
             'message': self.message,
             'url': self.url,

--- a/timeline/views.py
+++ b/timeline/views.py
@@ -4,7 +4,7 @@ Timeline views
 import json
 
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -12,6 +12,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 
 from mission.decorators import mission_is_member, mission_open_required
+from .helpers import can_change_timeline_entry
 from .models import TimeLineEntry
 
 
@@ -26,7 +27,7 @@ class MissionTimelineEntryView(View):
         """
         Return whether the mission user can change a manual timeline entry.
         """
-        return entry.event_type == 'usr' and (mission_user.is_admin() or entry.user == mission_user.user)
+        return can_change_timeline_entry(mission_user, entry)
 
     @staticmethod
     def _get_manual_entry(mission_user, entry_id):
@@ -107,7 +108,7 @@ class MissionTimelineEntryView(View):
         error = self._apply_patch(entry, body)
         if error is not None:
             return error
-        return HttpResponse("Done")
+        return JsonResponse({'status': 'updated'})
 
     @mission_open_required
     def delete(self, request, mission_user, entry_id):
@@ -118,4 +119,4 @@ class MissionTimelineEntryView(View):
         if error is not None:
             return error
         entry.delete()
-        return HttpResponse("Done")
+        return HttpResponse(status=204)

--- a/timeline/views.py
+++ b/timeline/views.py
@@ -1,3 +1,121 @@
 """
 Timeline views
 """
+import json
+
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
+from django.shortcuts import get_object_or_404
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+from django.utils.decorators import method_decorator
+from django.views import View
+
+from mission.decorators import mission_is_member, mission_open_required
+from .models import TimeLineEntry
+
+
+@method_decorator(login_required, name="dispatch")
+@method_decorator(mission_is_member, name="dispatch")
+class MissionTimelineEntryView(View):
+    """
+    Update or delete manual timeline entries.
+    """
+    @staticmethod
+    def _can_change_entry(mission_user, entry):
+        """
+        Return whether the mission user can change a manual timeline entry.
+        """
+        return entry.event_type == 'usr' and (mission_user.is_admin() or entry.user == mission_user.user)
+
+    @staticmethod
+    def _get_manual_entry(mission_user, entry_id):
+        """
+        Return a manual timeline entry in this mission, or an error response.
+        """
+        entry = get_object_or_404(TimeLineEntry, pk=entry_id, mission=mission_user.mission)
+        if entry.event_type != 'usr':
+            return None, HttpResponseForbidden("Only manual timeline entries can be changed")
+        if not MissionTimelineEntryView._can_change_entry(mission_user, entry):
+            return None, HttpResponseForbidden("You cannot change this timeline entry")
+        return entry, None
+
+    @staticmethod
+    def _parse_patch_timestamp(timestamp_raw):
+        """
+        Parse a timestamp supplied by a timeline entry patch.
+        """
+        if not isinstance(timestamp_raw, str):
+            return None
+        timestamp = parse_datetime(timestamp_raw)
+        if timestamp is None:
+            return None
+        if timezone.is_naive(timestamp):
+            return timezone.make_aware(timestamp, timezone.get_current_timezone())
+        return timestamp
+
+    @staticmethod
+    def _patch_body(request):
+        """
+        Return a JSON object request body, or an error response.
+        """
+        try:
+            body = json.loads(request.body)
+        except ValueError:
+            return None, HttpResponseBadRequest('Expected JSON body')
+        if not isinstance(body, dict):
+            return None, HttpResponseBadRequest('Expected JSON object')
+        return body, None
+
+    @staticmethod
+    def _apply_patch(entry, body):
+        """
+        Apply validated patch data to the manual timeline entry.
+        """
+        updated_fields = []
+        if 'timestamp' in body:
+            timestamp = MissionTimelineEntryView._parse_patch_timestamp(body['timestamp'])
+            if timestamp is None:
+                return HttpResponseBadRequest("Invalid timestamp")
+            entry.timestamp = timestamp
+            updated_fields.append('timestamp')
+        if 'message' in body:
+            if not isinstance(body['message'], str) or not body['message'].strip():
+                return HttpResponseBadRequest("Message is required")
+            entry.message = body['message']
+            updated_fields.append('message')
+        if 'url' in body:
+            if body['url'] is not None and not isinstance(body['url'], str):
+                return HttpResponseBadRequest("URL must be text")
+            entry.url = body['url'] or ''
+            updated_fields.append('url')
+        if updated_fields:
+            entry.save(update_fields=updated_fields)
+        return None
+
+    @mission_open_required
+    def patch(self, request, mission_user, entry_id):
+        """
+        Update a manual timeline entry.
+        """
+        entry, error = self._get_manual_entry(mission_user, entry_id)
+        if error is not None:
+            return error
+        body, error = self._patch_body(request)
+        if error is not None:
+            return error
+        error = self._apply_patch(entry, body)
+        if error is not None:
+            return error
+        return HttpResponse("Done")
+
+    @mission_open_required
+    def delete(self, request, mission_user, entry_id):
+        """
+        Delete a manual timeline entry.
+        """
+        entry, error = self._get_manual_entry(mission_user, entry_id)
+        if error is not None:
+            return error
+        entry.delete()
+        return HttpResponse("Done")


### PR DESCRIPTION
## Description

Manual timeline entries can contain corrected operational details, but previously a mistaken entry could only be superseded by adding another entry. Add PATCH and DELETE support for user-created timeline entries, expose inline Edit/Delete actions for entries the current user can change, and keep generated audit entries immutable.

Fixes #399

## Summary by Sourcery

Enable editing and deletion of manual mission timeline entries while keeping generated entries immutable and enforcing mission access rules.

New Features:
- Add API endpoint and frontend controls to PATCH and DELETE manual timeline entries owned by the user or mission admins.

Enhancements:
- Expose per-entry editability via can_edit in timeline API responses and surface inline Edit/Delete actions in the mission timeline UI.
- Provide client-side validation and error feedback when timeline entry edits are invalid or fail to save.
- Share timeline entry permission logic via a reusable helper used by both timeline listing and entry update/delete views.

Tests:
- Extend backend and frontend tests to cover manual timeline entry update/delete flows, permission checks, validation errors, and closed-mission write protections.