### PR TITLE
Prevent terminal searches from being reopened

### DIFF
--- a/search/models.py
+++ b/search/models.py
@@ -241,16 +241,22 @@ class Search(GeoTime):
         return self.created_for
 
     @classmethod
-    def queue_state_change_queryset(cls):
+    def _active_state_change_queryset(cls):
         """
-        Searches whose queue state can be safely changed.
+        Searches that can still move through active workflow states.
         """
         return cls.objects.filter(
-            inprogress_by__isnull=True,
             completed_at__isnull=True,
             deleted_at__isnull=True,
             replaced_at__isnull=True,
         )
+
+    @classmethod
+    def queue_state_change_queryset(cls):
+        """
+        Searches whose queue state can be safely changed.
+        """
+        return cls._active_state_change_queryset().filter(inprogress_by__isnull=True)
 
     def queue_search(self, mission_user, asset=None):
         '''
@@ -279,7 +285,7 @@ class Search(GeoTime):
         '''
         Set the asset that conducting this search
         '''
-        Search.objects.filter(pk=self.pk, inprogress_by__isnull=True, deleted_at__isnull=True).update(inprogress_at=timezone.now(), inprogress_by=asset)
+        self._active_state_change_queryset().filter(pk=self.pk, inprogress_by__isnull=True).update(inprogress_at=timezone.now(), inprogress_by=asset)
         self.refresh_from_db()
         if self.inprogress_by == asset:
             timeline_record_search_begin(self.mission, user, asset, self)
@@ -291,7 +297,7 @@ class Search(GeoTime):
         Delete this search
         '''
         time = timezone.now()
-        Search.objects.filter(pk=self.pk, inprogress_by__isnull=True, deleted_at__isnull=True).update(deleted_at=time, deleted_by=user)
+        self._active_state_change_queryset().filter(pk=self.pk, inprogress_by__isnull=True).update(deleted_at=time, deleted_by=user)
         return self.check_and_record_delete(time)
 
     @staticmethod

--- a/search/models.py
+++ b/search/models.py
@@ -24,6 +24,31 @@ from timeline.helpers import (
 )
 
 
+TERMINAL_DELETED = 'deleted'
+TERMINAL_REPLACED = 'replaced'
+TERMINAL_COMPLETED = 'completed'
+
+ACTIVE_STATE_CHANGE_FILTERS = {
+    'completed_at__isnull': True,
+    'completed_by__isnull': True,
+    'deleted_at__isnull': True,
+    'replaced_at__isnull': True,
+}
+
+
+def search_terminal_state(search):
+    """
+    Return the terminal state for a search, or None while it is still active.
+    """
+    if search.deleted_at is not None:
+        return TERMINAL_DELETED
+    if search.replaced_at is not None or getattr(search, 'replaced_by', None) is not None:
+        return TERMINAL_REPLACED
+    if search.completed_at is not None or search.completed_by is not None:
+        return TERMINAL_COMPLETED
+    return None
+
+
 def dictfetchall(cursor):
     "Return all rows from a cursor as a dict"
     columns = [col[0] for col in cursor.description]
@@ -245,11 +270,7 @@ class Search(GeoTime):
         """
         Searches that can still move through active workflow states.
         """
-        return cls.objects.filter(
-            completed_at__isnull=True,
-            deleted_at__isnull=True,
-            replaced_at__isnull=True,
-        )
+        return cls.objects.filter(**ACTIVE_STATE_CHANGE_FILTERS)
 
     @classmethod
     def queue_state_change_queryset(cls):
@@ -285,7 +306,7 @@ class Search(GeoTime):
         '''
         Set the asset that conducting this search
         '''
-        self._active_state_change_queryset().filter(pk=self.pk, inprogress_by__isnull=True).update(inprogress_at=timezone.now(), inprogress_by=asset)
+        Search._active_state_change_queryset().filter(pk=self.pk, inprogress_by__isnull=True).update(inprogress_at=timezone.now(), inprogress_by=asset)
         self.refresh_from_db()
         if self.inprogress_by == asset:
             timeline_record_search_begin(self.mission, user, asset, self)
@@ -297,7 +318,7 @@ class Search(GeoTime):
         Delete this search
         '''
         time = timezone.now()
-        self._active_state_change_queryset().filter(pk=self.pk, inprogress_by__isnull=True).update(deleted_at=time, deleted_by=user)
+        Search._active_state_change_queryset().filter(pk=self.pk, inprogress_by__isnull=True).update(deleted_at=time, deleted_by=user)
         return self.check_and_record_delete(time)
 
     @staticmethod

--- a/search/tests.py
+++ b/search/tests.py
@@ -609,6 +609,22 @@ class SearchStateTransitionTestCase(TestCase):
         self.assertIsNone(search.inprogress_at)
         self.assertIsNone(search.inprogress_by)
 
+    def test_begin_rejects_completed_by_only_search_without_reopening(self):
+        """
+        A partially completed search record is still terminal.
+        """
+        search = self.create_search()
+        search_obj = search.as_object()
+        search_obj.completed_by = self.asset
+        search_obj.save()
+
+        response = search.begin(asset=self.asset)
+
+        self.assertEqual(response.status_code, 403)
+        search_obj.refresh_from_db()
+        self.assertIsNone(search_obj.inprogress_at)
+        self.assertIsNone(search_obj.inprogress_by)
+
 
 class SearchQueueTestCase(TestCase):
     """

--- a/search/tests.py
+++ b/search/tests.py
@@ -86,13 +86,16 @@ class SearchWrapper:
             data['asset_id'] = asset.pk
         return client.post(f'/search/{self.search_id}/begin/', data=data)
 
-    def finished(self, client=None):
+    def finished(self, asset=None, client=None):
         """
         Mark this search as finished
         """
         if client is None:
             client = self.smm.client1
-        return client.post(f'/search/{self.search_id}/details/')
+        data = {}
+        if asset is not None:
+            data['asset_id'] = asset.pk
+        return client.post(f'/search/{self.search_id}/finished/', data=data)
 
 
 class SearchHelpers:
@@ -523,6 +526,88 @@ class SearchTestCase(TestCase):
         response = self.smm.client1.post(f'/search/{search.search_id}/finished/', data={'asset_id': self.asset1.pk})
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(search.as_object().completed_at)
+
+
+class SearchStateTransitionTestCase(TestCase):
+    """
+    Tests for invalid search state transitions.
+    """
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        self.assets = AssetsHelpers(self.smm)
+        self.searches = SearchHelpers(self.smm)
+        self.missions = MissionFunctions(self.smm)
+        self.asset_type = self.assets.create_asset_type()
+        self.asset = self.assets.create_asset(asset_type=self.asset_type)
+        self.mission = self.missions.create_mission('test mission')
+        self.mission.add_asset(self.asset)
+
+    def create_poi(self):
+        """
+        Create a POI for the test mission.
+        """
+        return GeoTimeLabel.objects.create(
+            geo=Point(172.5, -43.5),
+            created_by=self.smm.user1,
+            label='Test Point',
+            geo_type='poi',
+            mission=self.mission.get_object(),
+        )
+
+    def create_search(self):
+        """
+        Create a sector search for state-transition tests.
+        """
+        return self.searches.create_sector(self.create_poi(), 200, self.asset_type)
+
+    def test_begin_rejects_completed_search_without_reopening(self):
+        """
+        A completed search must not be moved back into progress.
+        """
+        search = self.create_search()
+        search_obj = search.as_object()
+        search_obj.completed_at = timezone.now()
+        search_obj.completed_by = self.asset
+        search_obj.save()
+
+        response = search.begin(asset=self.asset)
+
+        self.assertEqual(response.status_code, 403)
+        search_obj.refresh_from_db()
+        self.assertIsNone(search_obj.inprogress_at)
+        self.assertIsNone(search_obj.inprogress_by)
+
+    def test_begin_rejects_replaced_search_without_reopening(self):
+        """
+        A replaced search must not be moved back into progress.
+        """
+        search = self.create_search()
+        search_obj = search.as_object()
+        search_obj.replaced_at = timezone.now()
+        search_obj.save()
+
+        response = search.begin(asset=self.asset)
+
+        self.assertEqual(response.status_code, 404)
+        search_obj.refresh_from_db()
+        self.assertIsNone(search_obj.inprogress_at)
+        self.assertIsNone(search_obj.inprogress_by)
+
+    def test_model_begin_rejects_terminal_search_without_reopening(self):
+        """
+        Direct model calls use the same terminal-state guard as the view.
+        """
+        search = self.create_search().as_object()
+        search.completed_at = timezone.now()
+        search.completed_by = self.asset
+        search.save()
+
+        changed = search.set_inprogress_by(self.asset, self.smm.user1)
+
+        self.assertFalse(changed)
+        search.refresh_from_db()
+        self.assertIsNone(search.inprogress_at)
+        self.assertIsNone(search.inprogress_by)
 
 
 class SearchQueueTestCase(TestCase):

--- a/search/views.py
+++ b/search/views.py
@@ -37,7 +37,7 @@ from mission.models import Mission, MissionAsset, AssetCommand
 from mission.decorators import mission_is_member, mission_is_member_open, mission_asset_get_mission, mission_asset_get, mission_user_get, mission_closed_response
 from timeline.helpers import timeline_record_search_finished
 from .decorators import search_from_id
-from .models import Search, SearchParams, ExpandingBoxSearchParams, TrackLineCreepingSearchParams
+from .models import Search, SearchParams, ExpandingBoxSearchParams, TrackLineCreepingSearchParams, TERMINAL_COMPLETED, TERMINAL_DELETED, TERMINAL_REPLACED, search_terminal_state
 from .view_helpers import check_searches_in_progress
 
 
@@ -135,11 +135,12 @@ def check_search_state(search, action, asset):
     a suitable error response if it's not suitable for desired action
     """
     # pylint: disable=R0911
-    if search.deleted_at is not None:
+    terminal_state = search_terminal_state(search)
+    if terminal_state == TERMINAL_DELETED:
         return HttpResponseForbidden("Search has been deleted")
-    if search.replaced_at is not None or search.replaced_by is not None:
+    if terminal_state == TERMINAL_REPLACED:
         return HttpResponseNotFound("Search has been replaced")
-    if search.completed_at is not None or search.completed_by is not None:
+    if terminal_state == TERMINAL_COMPLETED:
         return HttpResponseForbidden("Search already completed")
 
     if action == 'begin':

--- a/search/views.py
+++ b/search/views.py
@@ -137,7 +137,7 @@ def check_search_state(search, action, asset):
     # pylint: disable=R0911
     if search.deleted_at is not None:
         return HttpResponseForbidden("Search has been deleted")
-    if search.replaced_by is not None:
+    if search.replaced_at is not None or search.replaced_by is not None:
         return HttpResponseNotFound("Search has been replaced")
     if search.completed_at is not None or search.completed_by is not None:
         return HttpResponseForbidden("Search already completed")
@@ -177,6 +177,10 @@ def search_begin(request, search_id, object_class, asset, mission):
     if search.mission != mission:
         return HttpResponseForbidden("Asset not currently assigned to the mission this search is in.")
 
+    error = check_search_state(search, 'begin', asset)
+    if error is not None:
+        return error
+
     inprogress_search = check_searches_in_progress(mission, asset)
     if inprogress_search is not None and inprogress_search != search:
         return HttpResponseForbidden("Asset already has a search in progress.")
@@ -184,8 +188,7 @@ def search_begin(request, search_id, object_class, asset, mission):
     if search.set_inprogress_by(asset, request.user):
         return to_geojson(object_class, [search])
 
-    error = check_search_state(search, 'begin', asset)
-    return error if error is not None else HttpResponseNotFound('Try Again')
+    return HttpResponseNotFound('Try Again')
 
 
 @require_POST


### PR DESCRIPTION
## Summary by Sourcery

Enforce terminal search states so completed or replaced searches cannot be restarted or modified, and align view/model logic and tests with the stricter state transition rules.

Bug Fixes:
- Prevent previously completed searches from being moved back into progress via the begin endpoint or direct model calls.
- Prevent replaced searches from being moved back into progress and ensure they are correctly treated as unavailable in views.

Enhancements:
- Introduce a shared active-state queryset helper to centralize and tighten state transition guards for queueing, starting, and deleting searches.
- Adjust search state checks in views to consider both replaced timestamps and references, ensuring consistent terminal state handling.

Tests:
- Add new test cases covering invalid state transitions for completed and replaced searches, including direct model-level operations.
- Update test helpers to reflect the new finished endpoint behavior and asset parameter handling.