### PR TITLE
Keep organizations from losing their last admin

### DIFF
--- a/organization/models.py
+++ b/organization/models.py
@@ -98,6 +98,28 @@ class OrganizationMember(models.Model):
         return self.role in ('A', 'b')
 
     @classmethod
+    def is_valid_role(cls, role):
+        """
+        Return whether a role code is one of the model's declared choices.
+        """
+        return role in {value for value, _label in cls.USER_ROLE}
+
+    def is_only_active_admin(self):
+        """
+        Return whether this active admin is the organization's only admin.
+
+        The check treats this membership as the admin being changed and asks
+        whether any other active admin membership remains.
+        """
+        if self.role != 'A' or self.removed is not None:
+            return False
+        return not OrganizationMember.objects.filter(
+            organization=self.organization,
+            role='A',
+            removed__isnull=True,
+        ).exclude(pk=self.pk).exists()
+
+    @classmethod
     def user_current(cls, user):
         """
         Get all the OrganizationMember classes a user is currently in

--- a/organization/tests.py
+++ b/organization/tests.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from smm.tests import SMMTestUsers
 
 from assets.tests import AssetsHelpers
+from .models import OrganizationMember
 
 
 class OrganizationWrapper:
@@ -39,7 +40,7 @@ class OrganizationWrapper:
         """
         if client is None:
             client = self.smm.client1
-        client.delete(f'/organization/{self.org_id}/user/{user}/')
+        return client.delete(f'/organization/{self.org_id}/user/{user}/')
 
     def get_details(self, client=None):
         """
@@ -122,6 +123,81 @@ class OrganizationFunctions:
         organization_list_mine_url = '/organization/?only=mine'
         json_data = self.get_url_json(organization_list_mine_url, client=client)
         return json_data['organizations']
+
+
+class OrganizationRoleGuardTestCase(TestCase):
+    """
+    Tests for organization role safety checks.
+    """
+    def setUp(self):
+        self.smm = SMMTestUsers()
+        self.orgs = OrganizationFunctions(self.smm)
+
+    def create_organization(self):
+        """
+        Create a test organization owned by user1.
+        """
+        return self.orgs.create_organization(organization_name='role-guard-org', client=self.smm.client1)
+
+    def current_member(self, org, user):
+        """
+        Return the active membership for a user.
+        """
+        return OrganizationMember.objects.get(organization_id=org.org_id, user=user, removed__isnull=True)
+
+    def test_invalid_role_is_rejected_without_creating_member(self):
+        """
+        Unknown role codes should not be persisted.
+        """
+        org = self.create_organization()
+
+        response = org.add_user(user=self.smm.user2.username, client=self.smm.client1, role='X')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(
+            OrganizationMember.objects.filter(
+                organization_id=org.org_id,
+                user=self.smm.user2,
+                removed__isnull=True,
+            ).exists()
+        )
+
+    def test_last_admin_cannot_be_demoted(self):
+        """
+        An organization must retain at least one active admin.
+        """
+        org = self.create_organization()
+
+        response = org.add_user(user=self.smm.user1.username, client=self.smm.client1, role='M')
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(self.current_member(org, self.smm.user1).role, 'A')
+
+    def test_last_admin_cannot_be_removed(self):
+        """
+        Removing the final admin would make the organization unmanageable.
+        """
+        org = self.create_organization()
+
+        response = org.remove_user(user=self.smm.user1.username, client=self.smm.client1)
+
+        self.assertEqual(response.status_code, 403)
+        member = self.current_member(org, self.smm.user1)
+        self.assertEqual(member.role, 'A')
+        self.assertIsNone(member.removed)
+
+    def test_admin_can_be_demoted_when_another_admin_remains(self):
+        """
+        Demotion is allowed once another active admin can manage the organization.
+        """
+        org = self.create_organization()
+        org.add_user(user=self.smm.user2.username, client=self.smm.client1, role='A')
+
+        response = org.add_user(user=self.smm.user1.username, client=self.smm.client1, role='M')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.current_member(org, self.smm.user1).role, 'M')
+        self.assertEqual(self.current_member(org, self.smm.user2).role, 'A')
 
 
 class OrganizationTestCase(TestCase):

--- a/organization/tests.py
+++ b/organization/tests.py
@@ -145,6 +145,29 @@ class OrganizationRoleGuardTestCase(TestCase):
         """
         return OrganizationMember.objects.get(organization_id=org.org_id, user=user, removed__isnull=True)
 
+    def test_model_validates_role_codes_from_choices(self):
+        """
+        Role validation belongs to the membership model.
+        """
+        self.assertTrue(OrganizationMember.is_valid_role('A'))
+        self.assertTrue(OrganizationMember.is_valid_role('b'))
+        self.assertFalse(OrganizationMember.is_valid_role('X'))
+
+    def test_model_identifies_only_active_admin(self):
+        """
+        The only-admin check excludes the member being changed.
+        """
+        org = self.create_organization()
+        admin = self.current_member(org, self.smm.user1)
+        self.assertTrue(admin.is_only_active_admin())
+
+        org.add_user(user=self.smm.user2.username, client=self.smm.client1, role='A')
+
+        admin.refresh_from_db()
+        other_admin = self.current_member(org, self.smm.user2)
+        self.assertFalse(admin.is_only_active_admin())
+        self.assertFalse(other_admin.is_only_active_admin())
+
     def test_invalid_role_is_rejected_without_creating_member(self):
         """
         Unknown role codes should not be persisted.

--- a/organization/views.py
+++ b/organization/views.py
@@ -14,20 +14,6 @@ from .models import Organization, OrganizationMember, OrganizationAsset
 from .decorators import organization_is_admin, organization_assets_admin, organization_is_radio_operator, get_target_user
 
 
-def _valid_member_role(role):
-    return role in {value for value, _label in OrganizationMember.USER_ROLE}
-
-
-def _is_last_active_admin(organization_member):
-    if organization_member.role != 'A':
-        return False
-    return OrganizationMember.objects.filter(
-        organization=organization_member.organization,
-        role='A',
-        removed__isnull=True,
-    ).count() <= 1
-
-
 @method_decorator(login_required, name="dispatch")
 class OrganizationView(View):
     """
@@ -103,7 +89,7 @@ class OrganizationUserView(View):
     def post(self, request, organization_member, target_user):
         # Create/modify the membership
         role = request.POST.get('role')
-        if role is not None and not _valid_member_role(role):
+        if role is not None and not OrganizationMember.is_valid_role(role):
             return HttpResponseBadRequest("Invalid organization role")
 
         try:
@@ -112,7 +98,7 @@ class OrganizationUserView(View):
             om = OrganizationMember(organization=organization_member.organization, user=target_user, added_by=request.user)
             om.save()
         if role is not None:
-            if role != 'A' and _is_last_active_admin(om):
+            if role != 'A' and om.is_only_active_admin():
                 return HttpResponseForbidden("Cannot remove the last organization admin")
             om.role = role
             om.save()
@@ -120,7 +106,7 @@ class OrganizationUserView(View):
 
     def delete(self, request, organization_member, target_user):
         om = get_object_or_404(OrganizationMember, organization=organization_member.organization, user=target_user, removed__isnull=True)
-        if _is_last_active_admin(om):
+        if om.is_only_active_admin():
             return HttpResponseForbidden("Cannot remove the last organization admin")
         om.removed = timezone.now()
         om.removed_by = organization_member.user

--- a/organization/views.py
+++ b/organization/views.py
@@ -14,6 +14,20 @@ from .models import Organization, OrganizationMember, OrganizationAsset
 from .decorators import organization_is_admin, organization_assets_admin, organization_is_radio_operator, get_target_user
 
 
+def _valid_member_role(role):
+    return role in {value for value, _label in OrganizationMember.USER_ROLE}
+
+
+def _is_last_active_admin(organization_member):
+    if organization_member.role != 'A':
+        return False
+    return OrganizationMember.objects.filter(
+        organization=organization_member.organization,
+        role='A',
+        removed__isnull=True,
+    ).count() <= 1
+
+
 @method_decorator(login_required, name="dispatch")
 class OrganizationView(View):
     """
@@ -88,19 +102,26 @@ class OrganizationUserView(View):
 
     def post(self, request, organization_member, target_user):
         # Create/modify the membership
+        role = request.POST.get('role')
+        if role is not None and not _valid_member_role(role):
+            return HttpResponseBadRequest("Invalid organization role")
+
         try:
             om = OrganizationMember.objects.get(organization=organization_member.organization, user=target_user, removed__isnull=True)
         except ObjectDoesNotExist:
             om = OrganizationMember(organization=organization_member.organization, user=target_user, added_by=request.user)
             om.save()
-        role = request.POST.get('role')
         if role is not None:
+            if role != 'A' and _is_last_active_admin(om):
+                return HttpResponseForbidden("Cannot remove the last organization admin")
             om.role = role
             om.save()
         return JsonResponse(om.as_object(request.user))
 
     def delete(self, request, organization_member, target_user):
         om = get_object_or_404(OrganizationMember, organization=organization_member.organization, user=target_user, removed__isnull=True)
+        if _is_last_active_admin(om):
+            return HttpResponseForbidden("Cannot remove the last organization admin")
         om.removed = timezone.now()
         om.removed_by = organization_member.user
         om.save()


### PR DESCRIPTION
## Summary by Sourcery

Enforce organization role safety by preventing invalid roles and ensuring an organization never loses its last admin.

Bug Fixes:
- Prevent demotion or removal of the final active admin from an organization.

Enhancements:
- Add validation for organization member roles to reject unknown role codes.
- Return responses from organization user removal helper to allow status code assertions in tests.

Tests:
- Add organization role guard tests covering invalid roles, last-admin demotion/removal, and safe demotion when another admin exists.