### PR TITLE
Provide asset metadata for aggregate mission maps

### DIFF
--- a/frontend/asset/map.test.ts
+++ b/frontend/asset/map.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { assetMetadataUrl } from './map'
+
+describe('asset map helpers', () => {
+  it('builds metadata URLs for specific and aggregate mission maps', () => {
+    expect(assetMetadataUrl(7)).toBe('/mission/7/assets/?include_removed=true')
+    expect(assetMetadataUrl('current')).toBe('/mission/current/assets/?include_removed=true')
+    expect(assetMetadataUrl('all')).toBe('/mission/all/assets/?include_removed=true')
+  })
+})

--- a/frontend/asset/map.tsx
+++ b/frontend/asset/map.tsx
@@ -12,6 +12,10 @@ import { buildSwatchLabel } from '../components/swatchLabel'
 import { mountPopup } from '../components/mountPopup'
 import { TrackedPath } from '../components/TrackedPath'
 
+function assetMetadataUrl(missionId: MissionId) {
+  return `/mission/${missionId}/assets/?include_removed=true`
+}
+
 class SMMAsset extends TrackedPath {
   assetId: number
   constructor(map: L.Map, missionId: MissionId, assetId: number, assetName: string, color: string) {
@@ -55,7 +59,7 @@ class SMMAssets extends SMMRealtime {
   }
 
   async updateAssetNameMap() {
-    const data = await smmGetJSON<{ assets: Array<MissionAssetSummary> }>(`/mission/${this.missionId}/assets/?include_removed=true`, {})
+    const data = await smmGetJSON<{ assets: Array<MissionAssetSummary> }>(assetMetadataUrl(this.missionId), {})
     // Rebuild the maps from scratch so an asset that drops its icon /
     // status / name on the server doesn't carry a stale entry forever.
     const names: { [key: number]: string } = {}
@@ -156,4 +160,4 @@ function customAssetIcon(iconUrl: string): L.Icon {
   return L.icon({ iconUrl, iconSize: [50, 50], iconAnchor: [25, 50] })
 }
 
-export { SMMAssets }
+export { assetMetadataUrl, SMMAssets }

--- a/frontend/map.tsx
+++ b/frontend/map.tsx
@@ -135,8 +135,8 @@ class SMMMap {
         createUserTrackingControl({ missionId: this.missionId, userName: this.currentUserName }).addTo(this.map)
       }
       L.control.imageuploader({ missionId: this.missionId }).addTo(this.map)
+      L.control.smmadmin({ missionId: this.missionId }).addTo(this.map)
     }
-    L.control.smmadmin({ missionId: this.missionId }).addTo(this.map)
 
     const assetUpdateFreq = 3 * 1000
     const userUpdateFreq = 3 * 1000

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -458,6 +458,27 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         assets_data = response.json()
         self.assertEqual(len(assets_data['assets']), 1)
 
+    def test_aggregate_mission_asset_json(self):
+        """
+        Aggregate map asset metadata uses explicit all/current mission routes.
+        """
+        current_mission = self.missions.create_mission('test_mission_asset_current')
+        closed_mission = self.missions.create_mission('test_mission_asset_closed')
+        closed_asset = self.assets.create_asset(name='closed-asset', asset_type=self.asset_type)
+        current_mission.add_asset(self.asset, client=self.smm.client1)
+        closed_mission.add_asset(closed_asset, client=self.smm.client1)
+        closed_mission.close(client=self.smm.client1)
+
+        response = self.smm.client1.get('/mission/all/assets/?include_removed=true', HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
+        assets = response.json()['assets']
+        self.assertEqual({asset['name'] for asset in assets}, {'test-asset', 'closed-asset'})
+
+        response = self.smm.client1.get('/mission/current/assets/?include_removed=true', HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
+        assets = response.json()['assets']
+        self.assertEqual([asset['name'] for asset in assets], ['test-asset'])
+
 
 class MissionTimelineTestCase(MissionBaseTestCase):
     """

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -474,6 +474,11 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         assets = response.json()['assets']
         self.assertEqual({asset['name'] for asset in assets}, {'test-asset', 'closed-asset'})
 
+        response = self.smm.client1.get('/mission/all/assets/?include_removed=false', HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
+        assets = response.json()['assets']
+        self.assertEqual([asset['name'] for asset in assets], ['test-asset'])
+
         response = self.smm.client1.get('/mission/current/assets/?include_removed=true', HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)
         assets = response.json()['assets']

--- a/mission/tests.py
+++ b/mission/tests.py
@@ -11,9 +11,12 @@ from django.utils import timezone
 from smm.tests import SMMTestUsers
 
 from assets.tests import AssetsHelpers
+from organization.tests import OrganizationFunctions
 from timeline.models import TimeLineEntry
 
-from .models import Mission, MissionUser, MissionAsset
+from .models import (
+    Mission, MissionUser, MissionAsset, MissionAssetStatus, MissionAssetStatusValue
+)
 
 
 class MissionTestWrapper:
@@ -398,6 +401,7 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         """
         super().setUp()
         self.assets = AssetsHelpers(self.smm)
+        self.organizations = OrganizationFunctions(self.smm)
         self.asset_type = self.assets.create_asset_type(at_name='test_type')
         self.asset = self.assets.create_asset(name='test-asset', asset_type=self.asset_type)
 
@@ -468,11 +472,19 @@ class MissionAssetsTestCase(MissionBaseTestCase):
         current_mission.add_asset(self.asset, client=self.smm.client1)
         closed_mission.add_asset(closed_asset, client=self.smm.client1)
         closed_mission.close(client=self.smm.client1)
+        org = self.organizations.create_organization()
+        current_mission.add_organization(org)
+        status_value = MissionAssetStatusValue.objects.create(name='ready')
+        mission_asset = MissionAsset.objects.get(mission=current_mission.get_object(), asset=self.asset)
+        MissionAssetStatus.objects.create(mission_asset=mission_asset, status=status_value)
 
         response = self.smm.client1.get('/mission/all/assets/?include_removed=true', HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)
         assets = response.json()['assets']
         self.assertEqual({asset['name'] for asset in assets}, {'test-asset', 'closed-asset'})
+        self.assertEqual([asset['name'] for asset in assets].count('test-asset'), 1)
+        test_asset = next(asset for asset in assets if asset['name'] == 'test-asset')
+        self.assertEqual(test_asset['status']['status'], 'ready')
 
         response = self.smm.client1.get('/mission/all/assets/?include_removed=false', HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)

--- a/mission/urls.py
+++ b/mission/urls.py
@@ -16,6 +16,8 @@ urlpatterns = [
     re_path(r'^mission/(?P<mission_id>\d+)/organizations/(?P<organization_id>\d+)/$', views.MissionOrganizationView.as_view(), name='mission_organization'),
     re_path(r'^mission/(?P<mission_id>\d+)/users/$', views.MissionUsersView.as_view(), name='mission_users'),
     re_path(r'^mission/(?P<mission_id>\d+)/users/(?P<user_id>\d+)/$', views.MissionUserView.as_view(), name='mission_user'),
+    re_path(r'^mission/all/assets/$', views.MissionUserAssetsView.as_view(), {'current_only': False}, name='mission_all_assets'),
+    re_path(r'^mission/current/assets/$', views.MissionUserAssetsView.as_view(), {'current_only': True}, name='mission_current_assets'),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/$', views.MissionAssetsView.as_view()),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/(?P<asset_id>\d+)/$', views.MissionAssetView.as_view(), name='mission_asset'),
     re_path(r'^mission/(?P<mission_id>\d+)/assets/(?P<asset_id>\d+)/status/$', views.MissionAssetStatusView.as_view()),

--- a/mission/views.py
+++ b/mission/views.py
@@ -34,9 +34,29 @@ from .forms import AssetCommandForm, MissionForm, MissionUserForm, MissionAssetF
 from .decorators import get_user_from_id, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin, mission_open_required
 
 
+def _current_statuses_for_assets(mission_asset_ids):
+    if not mission_asset_ids:
+        return {}
+
+    statuses = MissionAssetStatus.objects.filter(
+        mission_asset_id__in=mission_asset_ids,
+    ).select_related(
+        'status',
+        'mission_asset__asset',
+    ).order_by(
+        'mission_asset_id',
+        '-since',
+    ).distinct('mission_asset_id')
+    return {status.mission_asset_id: status for status in statuses}
+
+
 def _mission_assets_json(assets):
+    mission_assets = list(assets)
+    current_statuses = _current_statuses_for_assets([
+        mission_asset.pk for mission_asset in mission_assets
+    ])
     assets_json = []
-    for mission_asset in assets:
+    for mission_asset in mission_assets:
         asset_data = {
             'id': mission_asset.asset.pk,
             'name': mission_asset.asset.name,
@@ -44,7 +64,7 @@ def _mission_assets_json(assets):
             'type_name': mission_asset.asset.asset_type.name,
             'icon_url': mission_asset.asset.icon_url(),
         }
-        if asset_status := MissionAssetStatus.current_for_asset(mission_asset):
+        if asset_status := current_statuses.get(mission_asset.pk):
             asset_data['status'] = asset_status.as_object()
         assets_json.append(asset_data)
 
@@ -678,7 +698,7 @@ class MissionUserAssetsView(View):
         ).values_list('mission_id', flat=True)
         mission_filter = Q(mission_id__in=user_mission_ids)
         mission_filter |= Q(mission_id__in=organization_mission_ids)
-        assets = MissionAsset.objects.filter(mission_filter)
+        assets = MissionAsset.objects.filter(mission_filter).distinct()
         if current_only:
             assets = assets.filter(mission__closed__isnull=True)
         if not _query_param_true(request, 'include_removed'):

--- a/mission/views.py
+++ b/mission/views.py
@@ -51,6 +51,11 @@ def _mission_assets_json(assets):
     return JsonResponse({'assets': assets_json})
 
 
+def _query_param_true(request, name):
+    value = request.GET.get(name)
+    return isinstance(value, str) and value.lower() in {'1', 'true', 'yes'}
+
+
 def user_can_command_asset(mission_user, asset):
     """
     Whether this user may send operational commands to the asset.
@@ -615,7 +620,7 @@ class MissionAssetsView(View):
             assets = get_my_assets_not_in_mission(mission_user.mission, mission_user.user)
             return JsonResponse({'assets': [a.as_object() for a in assets]})
 
-        if request.GET.get('include_removed', False):
+        if _query_param_true(request, 'include_removed'):
             assets = MissionAsset.objects.filter(mission=mission_user.mission)
         else:
             assets = MissionAsset.objects.filter(mission=mission_user.mission, removed__isnull=True)
@@ -660,11 +665,23 @@ class MissionUserAssetsView(View):
         """
         Return assets from all missions visible to the current user.
         """
-        mission_ids = {mission.pk for mission in Mission.all_user_missions(request.user)}
-        assets = MissionAsset.objects.filter(mission_id__in=mission_ids)
+        user_mission_ids = MissionUser.objects.filter(
+            user=request.user,
+        ).values_list('mission_id', flat=True)
+        org_ids = OrganizationMember.objects.filter(
+            user=request.user,
+            removed__isnull=True,
+        ).values_list('organization_id', flat=True)
+        organization_mission_ids = MissionOrganization.objects.filter(
+            organization_id__in=org_ids,
+            removed__isnull=True,
+        ).values_list('mission_id', flat=True)
+        mission_filter = Q(mission_id__in=user_mission_ids)
+        mission_filter |= Q(mission_id__in=organization_mission_ids)
+        assets = MissionAsset.objects.filter(mission_filter)
         if current_only:
             assets = assets.filter(mission__closed__isnull=True)
-        if not request.GET.get('include_removed', False):
+        if not _query_param_true(request, 'include_removed'):
             assets = assets.filter(removed__isnull=True)
         return _mission_assets_json(assets.select_related('asset', 'asset__asset_type'))
 

--- a/mission/views.py
+++ b/mission/views.py
@@ -34,6 +34,23 @@ from .forms import AssetCommandForm, MissionForm, MissionUserForm, MissionAssetF
 from .decorators import get_user_from_id, mission_can_add_organization, mission_can_add_user, mission_is_member, mission_is_admin, mission_open_required
 
 
+def _mission_assets_json(assets):
+    assets_json = []
+    for mission_asset in assets:
+        asset_data = {
+            'id': mission_asset.asset.pk,
+            'name': mission_asset.asset.name,
+            'type_id': mission_asset.asset.asset_type.pk,
+            'type_name': mission_asset.asset.asset_type.name,
+            'icon_url': mission_asset.asset.icon_url(),
+        }
+        if asset_status := MissionAssetStatus.current_for_asset(mission_asset):
+            asset_data['status'] = asset_status.as_object()
+        assets_json.append(asset_data)
+
+    return JsonResponse({'assets': assets_json})
+
+
 def user_can_command_asset(mission_user, asset):
     """
     Whether this user may send operational commands to the asset.
@@ -602,23 +619,7 @@ class MissionAssetsView(View):
             assets = MissionAsset.objects.filter(mission=mission_user.mission)
         else:
             assets = MissionAsset.objects.filter(mission=mission_user.mission, removed__isnull=True)
-        assets_json = []
-        for mission_asset in assets:
-            asset_data = {
-                'id': mission_asset.asset.pk,
-                'name': mission_asset.asset.name,
-                'type_id': mission_asset.asset.asset_type.pk,
-                'type_name': mission_asset.asset.asset_type.name,
-                'icon_url': mission_asset.asset.icon_url(),
-            }
-            if asset_status := MissionAssetStatus.current_for_asset(mission_asset):
-                asset_data['status'] = asset_status.as_object()
-            assets_json.append(asset_data)
-
-        data = {
-            'assets': assets_json,
-        }
-        return JsonResponse(data)
+        return _mission_assets_json(assets.select_related('asset', 'asset__asset_type'))
 
     def get(self, request, mission_user):
         """
@@ -648,6 +649,24 @@ class MissionAssetsView(View):
 
             return HttpResponseRedirect(f'/mission/{mission_user.mission.pk}/details/')
         return HttpResponseNotFound()
+
+
+@method_decorator(login_required, name="dispatch")
+class MissionUserAssetsView(View):
+    """
+    Read-only asset metadata for aggregate mission maps.
+    """
+    def get(self, request, current_only):
+        """
+        Return assets from all missions visible to the current user.
+        """
+        mission_ids = {mission.pk for mission in Mission.all_user_missions(request.user)}
+        assets = MissionAsset.objects.filter(mission_id__in=mission_ids)
+        if current_only:
+            assets = assets.filter(mission__closed__isnull=True)
+        if not request.GET.get('include_removed', False):
+            assets = assets.filter(removed__isnull=True)
+        return _mission_assets_json(assets.select_related('asset', 'asset__asset_type'))
 
 
 def mission_asset_is_owner(mission_user, asset, user):


### PR DESCRIPTION
## Summary by Sourcery

Add aggregate mission asset metadata endpoints and reuse shared asset JSON helper for mission views.

New Features:
- Expose read-only aggregate mission asset metadata APIs for all missions and current missions visible to the user.
- Support querying mission asset metadata with optional inclusion of removed assets via a shared query parameter helper.
- Provide frontend helper to build asset metadata URLs for both specific and aggregate mission maps.

Enhancements:
- Refactor mission asset JSON construction into a reusable helper that includes current status data.
- Ensure admin map controls are only added for mission maps that allow mission administration.

Tests:
- Add backend tests verifying aggregate mission asset APIs, including filtering by mission state and asset status inclusion.
- Add frontend unit tests for asset metadata URL generation across mission scopes.