### PR TITLE
search: release the search when an asset is told to abandon it

### DIFF
--- a/search/apps.py
+++ b/search/apps.py
@@ -10,3 +10,9 @@ class SearchConfig(AppConfig):
     Define the search app
     """
     name = 'search'
+
+    def ready(self):
+        """
+        Connect the signal handlers that link asset commands to searches
+        """
+        from . import signals  # noqa: F401  pylint: disable=C0415,W0611

--- a/search/signals.py
+++ b/search/signals.py
@@ -1,0 +1,28 @@
+"""
+Signal handlers that connect asset commands to searches
+
+The mission app can't import search directly (search.models -> data.models
+-> mission.models is a cycle), so the search app listens for the commands
+it cares about instead.
+"""
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from mission.models import AssetCommand
+
+from .view_helpers import abandon_inprogress_search
+
+
+@receiver(post_save, sender=AssetCommand, dispatch_uid='search_release_on_abandon')
+def release_search_on_abandon(sender, instance, created, **kwargs):
+    """
+    Release the asset's in-progress search when it is told to abandon it
+
+    Hooking the command rather than the view means every path that issues
+    'AS' - the map action, the asset command dialog, a shell - releases the
+    search, so the command and the release can't diverge.
+    """
+    # pylint: disable=W0613
+    if created and instance.command == 'AS' and instance.mission is not None:
+        abandon_inprogress_search(instance.mission, instance.asset, instance.issued_by)

--- a/search/test_abandon.py
+++ b/search/test_abandon.py
@@ -15,6 +15,7 @@ from data.models import GeoTimeLabel
 from smm.tests import SMMTestUsers
 
 from assets.tests import AssetsHelpers
+from mission.models import AssetCommand
 from mission.tests import MissionFunctions
 from timeline.models import TimeLineEntry
 
@@ -22,9 +23,9 @@ from .models import Search
 from .tests import SearchHelpers
 
 
-class SearchAbandonModelTestCase(TestCase):
+class SearchAbandonTestBase(TestCase):
     """
-    Tests for Search.abandon()
+    A mission with two assets of the same type and a datum to search from
     """
     def setUp(self):
         self.smm = SMMTestUsers()
@@ -47,6 +48,12 @@ class SearchAbandonModelTestCase(TestCase):
         search = self.searches.create_sector(self.poi, 200, self.asset_type).as_object()
         self.assertTrue(search.set_inprogress_by(asset, self.smm.user1))
         return search
+
+
+class SearchAbandonModelTestCase(SearchAbandonTestBase):
+    """
+    Tests for Search.abandon()
+    """
 
     def test_abandon_clears_inprogress_and_queue(self):
         """
@@ -204,3 +211,104 @@ class SearchAbandonModelTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['object_url'], f'/search/{search.pk}/')
+
+
+class SearchAbandonCommandTestCase(SearchAbandonTestBase):
+    """
+    Tests that an 'AS' asset command releases the asset's search
+    """
+    def issue_command(self, command, asset=None, client=None):
+        """
+        Send a command to an asset via the mission command endpoint
+        """
+        if asset is None:
+            asset = self.asset
+        if client is None:
+            client = self.smm.client1
+        return client.post(f'/mission/{self.mission.mission_pk}/assets/command/set/', data={
+            'asset': asset.pk, 'command': command, 'reason': 'test',
+        })
+
+    def test_abandon_command_releases_the_search(self):
+        """
+        Issuing 'AS' releases the search the asset is conducting
+        """
+        search = self.create_inprogress_search()
+
+        response = self.issue_command('AS')
+
+        self.assertEqual(response.status_code, 200)
+        search.refresh_from_db()
+        self.assertIsNone(search.inprogress_at)
+        self.assertIsNone(search.inprogress_by)
+        self.assertEqual(list(search.abandoned_by.all()), [self.asset])
+
+    def test_abandon_command_records_timeline_entry(self):
+        """
+        The handover is visible in the timeline, not just as a command
+        """
+        self.create_inprogress_search()
+
+        self.issue_command('AS')
+
+        self.assertEqual(TimeLineEntry.objects.filter(mission=self.mission.get_object(), event_type='sab').count(), 1)
+
+    def test_abandon_command_direct_model_create_releases(self):
+        """
+        Any path that creates the command releases the search, not just the view
+        """
+        search = self.create_inprogress_search()
+
+        AssetCommand.objects.create(asset=self.asset, issued_by=self.smm.user1, command='AS', reason='test', mission=self.mission.get_object())
+
+        search.refresh_from_db()
+        self.assertIsNone(search.inprogress_by)
+
+    def test_other_commands_leave_the_search_alone(self):
+        """
+        Only 'AS' releases a search
+        """
+        search = self.create_inprogress_search()
+
+        for command in ('RTL', 'RON', 'CIR', 'MC'):
+            self.issue_command(command)
+            search.refresh_from_db()
+            self.assertEqual(search.inprogress_by, self.asset, f'{command} released the search')
+
+    def test_abandon_command_only_affects_the_commanded_asset(self):
+        """
+        Another asset's search in the same mission is untouched
+        """
+        others_search = self.create_inprogress_search(asset=self.other_asset)
+
+        self.issue_command('AS')
+
+        others_search.refresh_from_db()
+        self.assertEqual(others_search.inprogress_by, self.other_asset)
+
+    def test_abandon_command_response_does_not_re_release(self):
+        """
+        The asset responding to an 'AS' command must not abandon a second search
+        """
+        self.create_inprogress_search()
+        self.issue_command('AS')
+        command = AssetCommand.objects.get(asset=self.asset, command='AS')
+        next_search = self.create_inprogress_search()
+
+        command.responded_at = timezone.now()
+        command.responded_by = self.smm.user1
+        command.response_type = 'ok'
+        command.response_message = 'abandoned'
+        command.save()
+
+        next_search.refresh_from_db()
+        self.assertEqual(next_search.inprogress_by, self.asset)
+
+    def test_abandon_command_with_no_search_is_harmless(self):
+        """
+        Abandoning when the asset isn't searching is a no-op, not an error
+        """
+        response = self.issue_command('AS')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(TimeLineEntry.objects.filter(event_type='sab').count(), 0)

--- a/search/view_helpers.py
+++ b/search/view_helpers.py
@@ -14,3 +14,15 @@ def check_searches_in_progress(mission, asset):
     """
     searches = Search.objects.filter(inprogress_by=asset, mission=mission).exclude(completed_at__isnull=False)
     return searches[0] if searches.exists() else None
+
+
+def abandon_inprogress_search(mission, asset, user):
+    """
+    Release any search this asset has in progress in this mission
+
+    Returns the search that was released, or None if there wasn't one.
+    """
+    search = check_searches_in_progress(mission, asset)
+    if search is not None and search.abandon(asset, user):
+        return search
+    return None


### PR DESCRIPTION
## Description

Hook AssetCommand's post_save from the search app, so every path that issues 'AS' - the asset command dialog, the API, a shell - releases the search and the command can't diverge from its effect.

The receiver lives in search rather than in AssetCommand.save() because
mission can't import search: search.models -> data.models ->
mission.models is a cycle, and nothing in mission/data/assets/organization imports search today. Listening from this side keeps that one-way.

Guarded on created, since save() runs again when the asset responds to the command.

## Summary by Sourcery

Link asset abandon commands to search abandonment via signals so that issuing an 'AS' command consistently releases any in-progress search by that asset across all entry points.

New Features:
- Add a signal handler that listens for AssetCommand creation and abandons any in-progress search when an 'AS' command is issued.
- Expose a helper for abandoning an asset's in-progress search within a mission.

Tests:
- Extend search abandonment tests to cover behavior triggered by asset commands created through the mission command endpoint and direct model creation.