### PR TITLE
search: add POST /search/<id>/abandon/

### DIFF
--- a/search/test_abandon.py
+++ b/search/test_abandon.py
@@ -312,3 +312,159 @@ class SearchAbandonCommandTestCase(SearchAbandonTestBase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(TimeLineEntry.objects.filter(event_type='sab').count(), 0)
+
+
+class SearchAbandonViewTestCase(SearchAbandonTestBase):
+    """
+    Tests for POST /search/<id>/abandon/
+    """
+    def abandon(self, search, reason='Abandoned from map', client=None):
+        """
+        Abandon a search via the endpoint
+        """
+        if client is None:
+            client = self.smm.client1
+        data = {} if reason is None else {'reason': reason}
+        return client.post(f'/search/{search.pk}/abandon/', data=data)
+
+    def test_abandon_as_mission_admin(self):
+        """
+        A mission admin can take an asset off a search
+        """
+        search = self.create_inprogress_search()
+
+        response = self.abandon(search)
+
+        self.assertEqual(response.status_code, 200)
+        search.refresh_from_db()
+        self.assertIsNone(search.inprogress_by)
+        self.assertEqual(AssetCommand.objects.filter(asset=self.asset, command='AS').count(), 1)
+
+    def test_abandon_records_the_reason(self):
+        """
+        The reason reaches the command, and so the timeline
+        """
+        search = self.create_inprogress_search()
+
+        self.abandon(search, reason='weather')
+
+        self.assertEqual(AssetCommand.objects.get(asset=self.asset, command='AS').reason, 'weather')
+
+    def test_abandon_as_asset_owner(self):
+        """
+        A non-admin member who owns the asset can take it off a search
+        """
+        owned_asset = AssetsHelpers(self.smm).create_asset(name='owned', asset_type=self.asset_type, owner=self.smm.user2)
+        self.mission.add_asset(owned_asset)
+        self.mission.add_user(user=self.smm.user2)
+        search = self.create_inprogress_search(asset=owned_asset)
+
+        response = self.abandon(search, client=self.smm.client2)
+
+        self.assertEqual(response.status_code, 200)
+        search.refresh_from_db()
+        self.assertIsNone(search.inprogress_by)
+
+    def test_abandon_rejected_for_plain_member(self):
+        """
+        A member who cannot command the asset cannot take it off the search
+        """
+        self.mission.add_user(user=self.smm.user2)
+        search = self.create_inprogress_search()
+
+        response = self.abandon(search, client=self.smm.client2)
+
+        self.assertEqual(response.status_code, 403)
+        search.refresh_from_db()
+        self.assertEqual(search.inprogress_by, self.asset)
+        self.assertEqual(AssetCommand.objects.filter(command='AS').count(), 0)
+
+    def test_abandon_rejected_for_non_member(self):
+        """
+        A user who isn't in the mission can't reach the search at all
+
+        mission_is_member_open hides the mission's existence, hence 404.
+        """
+        search = self.create_inprogress_search()
+
+        response = self.abandon(search, client=self.smm.client2)
+
+        self.assertEqual(response.status_code, 404)
+        search.refresh_from_db()
+        self.assertEqual(search.inprogress_by, self.asset)
+
+    def test_abandon_rejects_search_not_in_progress(self):
+        """
+        There is nothing to abandon on a search nobody is conducting
+        """
+        search = self.searches.create_sector(self.poi, 200, self.asset_type).as_object()
+
+        response = self.abandon(search)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(AssetCommand.objects.filter(command='AS').count(), 0)
+
+    def test_abandon_rejects_completed_search(self):
+        """
+        A completed search can't be abandoned
+        """
+        search = self.create_inprogress_search()
+        search.completed_at = timezone.now()
+        search.completed_by = self.asset
+        search.save()
+
+        response = self.abandon(search)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(AssetCommand.objects.filter(command='AS').count(), 0)
+
+    def test_abandon_requires_a_reason(self):
+        """
+        An abandonment with no reason is worse for the record than no abandonment
+        """
+        search = self.create_inprogress_search()
+
+        response = self.abandon(search, reason='   ')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('reason', response.json()['errors'])
+        search.refresh_from_db()
+        self.assertEqual(search.inprogress_by, self.asset)
+
+    def test_abandon_rejects_get(self):
+        """
+        Abandoning is a POST-only action
+        """
+        search = self.create_inprogress_search()
+
+        response = self.smm.client1.get(f'/search/{search.pk}/abandon/')
+
+        self.assertEqual(response.status_code, 405)
+
+    def test_abandon_errors_are_json(self):
+        """
+        The map dialog can only show a message it can parse
+        """
+        self.mission.add_user(user=self.smm.user2)
+        search = self.create_inprogress_search()
+
+        response = self.abandon(search, client=self.smm.client2)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn('errors', response.json())
+
+    def test_abandon_rejected_on_closed_mission(self):
+        """
+        Nothing changes in a closed mission
+        """
+        search = self.create_inprogress_search()
+        mission_obj = self.mission.get_object()
+        mission_obj.closed = timezone.now()
+        mission_obj.closed_by = self.smm.user1
+        mission_obj.save()
+
+        response = self.abandon(search)
+
+        self.assertEqual(response.status_code, 403)
+        search.refresh_from_db()
+        self.assertEqual(search.inprogress_by, self.asset)

--- a/search/urls.py
+++ b/search/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     re_path(r'^search/(?P<search_id>\d+)/queue/$', views.search_queue, name='search_queue'),
     re_path(r'^search/(?P<search_id>\d+)/begin/$', views.search_begin, {'object_class': Search}, name='search_begin'),
     re_path(r'^search/(?P<search_id>\d+)/finished/$', views.search_finished, {'object_class': Search}, name='search_finished'),
+    re_path(r'^search/(?P<search_id>\d+)/abandon/$', views.search_abandon, name='search_abandon'),
     re_path(r'^search/sector/create/$', views.SectorSearchCreateView.as_view(), name='sector_search_create'),
     re_path(r'^search/expandingbox/create/$', views.ExpandingBoxSearchCreateView.as_view(), name='expanding_box_search_create'),
     re_path(r'^search/trackline/create/$', views.TrackLineSearchCreateView.as_view(), name='track_line_search_create'),

--- a/search/views.py
+++ b/search/views.py
@@ -35,6 +35,7 @@ from data.models import GeoTimeLabel
 from data.view_helpers import to_kml, to_geojson
 from mission.models import Mission, MissionAsset, AssetCommand
 from mission.decorators import mission_is_member, mission_is_member_open, mission_asset_get_mission, mission_asset_get, mission_user_get, mission_closed_response
+from mission.helpers import user_can_command_asset
 from timeline.helpers import timeline_record_search_finished
 from .decorators import search_from_id
 from .models import Search, SearchParams, ExpandingBoxSearchParams, TrackLineCreepingSearchParams, TERMINAL_COMPLETED, TERMINAL_DELETED, TERMINAL_REPLACED, search_terminal_state
@@ -146,15 +147,15 @@ def check_search_state(search, action, asset):
     if action == 'begin':
         if search.inprogress_by is not None and search.inprogress_by != asset:
             return HttpResponseForbidden("Search already in progress")
-    elif action == 'queue':
-        if search.inprogress_by is not None:
-            return HttpResponseForbidden("Search currently in progress")
-    elif action == 'delete':
+    elif action in ('queue', 'delete'):
         if search.inprogress_by is not None:
             return HttpResponseForbidden("Search currently in progress")
     elif action == 'complete':
         if search.inprogress_by is None or search.inprogress_by.id != asset.id:
             return HttpResponseForbidden("Search not in progress by this asset")
+    elif action == 'abandon':
+        if search.inprogress_by is None:
+            return HttpResponseForbidden("Search is not in progress")
 
     return None
 
@@ -217,6 +218,43 @@ def search_finished(request, search_id, object_class, asset, mission):
     timeline_record_search_finished(mission, request.user, asset, search)
 
     return HttpResponse("Completed")
+
+
+@require_POST
+@login_required
+@search_from_id
+@data_get_mission_id(arg_name='search')
+@mission_is_member_open
+def search_abandon(request, search, mission_user):
+    """
+    Take the asset currently conducting this search off it
+
+    The asset is resolved from the search rather than supplied by the caller:
+    the search geojson carries inprogress_by as an asset name, not a pk.
+
+    Issuing the command is the whole action - the release itself hangs off
+    AssetCommand, so the command and the release can't diverge.
+    """
+    error = check_search_state(search, 'abandon', None)
+    if error is not None:
+        return error
+
+    if not user_can_command_asset(mission_user, search.inprogress_by):
+        return JsonResponse({'errors': {'__all__': ['You do not have permission to command this asset']}}, status=403)
+
+    reason = request.POST.get('reason', '').strip()
+    if not reason:
+        return JsonResponse({'errors': {'reason': ['This field is required.']}}, status=400)
+
+    AssetCommand(
+        asset=search.inprogress_by,
+        command='AS',
+        issued_by=request.user,
+        reason=reason,
+        mission=mission_user.mission,
+    ).save()
+
+    return HttpResponse("Success")
 
 
 def _queue_search(request, search, mission_user):


### PR DESCRIPTION
## Description

A search-scoped endpoint so an operator can take an asset off the search they're looking at. The asset is resolved server-side from inprogress_by: the search geojson carries it as a name, not a pk, and adding a pk to the serialisation just to let the client re-address the command would be the wrong seam.

Authorised with user_can_command_asset - this issues a command to somebody's asset, so it must not be looser than the command dialog. A reason is required, and errors are returned as JSON so the caller can show them.

check_search_state's queue and delete arms were identical; fold them together rather than suppress the branch count the new arm pushes over.

## Summary by Sourcery

Add a search-scoped endpoint to abandon an in-progress search and issue an asset command, with appropriate permissions and validation.

New Features:
- Introduce POST /search/<id>/abandon/ endpoint to allow authorized users to remove the asset currently conducting a search.
- Record an abandonment reason on the asset command so it propagates into the search timeline.

Enhancements:
- Consolidate identical queue and delete branches in check_search_state and add an abandonment-specific state check.

Tests:
- Add integration tests covering authorization, mission membership, search state validation, HTTP method restriction, reason requirement, and JSON error responses for the new abandon endpoint.