### PR TITLE
frontend: abandon a search from its map popup

### DIFF
--- a/frontend/search/SearchAbandonDialog.test.tsx
+++ b/frontend/search/SearchAbandonDialog.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+vi.mock('../ajax', () => ({
+  smmGet: vi.fn(() => Promise.resolve('')),
+  smmGetJSON: vi.fn(() => Promise.resolve({})),
+  smmPost: vi.fn(() => Promise.resolve('')),
+  smmPatch: vi.fn(() => Promise.resolve('')),
+  smmDelete: vi.fn(() => Promise.resolve())
+}))
+
+import { smmPost } from '../ajax'
+import { SearchAbandonDialog } from './SearchAbandonDialog'
+
+function renderDialog() {
+  const onClose = vi.fn()
+  render(<SearchAbandonDialog searchPk={42} assetName="asset_a" onClose={onClose} />)
+  return onClose
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('SearchAbandonDialog', () => {
+  it('posts the default reason to the abandon endpoint', () => {
+    renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abandon Search' }))
+
+    expect(smmPost).toHaveBeenCalledWith('/search/42/abandon/', { reason: 'Abandoned from map' }, expect.any(Function), expect.any(Function))
+  })
+
+  it('posts an edited reason', () => {
+    renderDialog()
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'weather' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Abandon Search' }))
+
+    expect(smmPost).toHaveBeenCalledWith('/search/42/abandon/', { reason: 'weather' }, expect.any(Function), expect.any(Function))
+  })
+
+  it('closes when the post succeeds', () => {
+    vi.mocked(smmPost).mockImplementationOnce((_url, _data, success) => {
+      success?.('')
+      return Promise.resolve('')
+    })
+    const onClose = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abandon Search' }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the server error and stays open', () => {
+    vi.mocked(smmPost).mockImplementationOnce((_url, _data, _success, error) => {
+      error?.({ errors: { __all__: ['You do not have permission to command this asset'] } })
+      return Promise.resolve('')
+    })
+    const onClose = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abandon Search' }))
+
+    expect(screen.getByText('You do not have permission to command this asset')).toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('shows a generic error when the response is not json', () => {
+    vi.mocked(smmPost).mockImplementationOnce((_url, _data, _success, error) => {
+      error?.(undefined)
+      return Promise.resolve('')
+    })
+    renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abandon Search' }))
+
+    expect(screen.getByText('Failed to abandon search')).toBeInTheDocument()
+  })
+
+  it('refuses an empty reason without posting', () => {
+    renderDialog()
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '   ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Abandon Search' }))
+
+    expect(smmPost).not.toHaveBeenCalled()
+    expect(screen.getByText('Reason is required')).toBeInTheDocument()
+  })
+
+  it('cancels without posting', () => {
+    const onClose = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(smmPost).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/search/SearchAbandonDialog.tsx
+++ b/frontend/search/SearchAbandonDialog.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+
+import { smmPost } from '../ajax'
+import { FormInputGroup } from '../components/FormInputGroup'
+
+interface Props {
+  searchPk: number
+  assetName: string
+  onClose: () => void
+}
+
+export function SearchAbandonDialog({ searchPk, assetName, onClose }: Props) {
+  const [reason, setReason] = useState('Abandoned from map')
+  const [error, setError] = useState('')
+
+  function handleAbandon() {
+    if (!reason.trim()) {
+      setError('Reason is required')
+      return
+    }
+    setError('')
+    smmPost(
+      `/search/${searchPk}/abandon/`,
+      { reason },
+      () => onClose(),
+      (errData) => {
+        if (errData && typeof errData === 'object' && 'errors' in errData) {
+          const msgs = Object.entries((errData as { errors: Record<string, string[]> }).errors).flatMap(([f, es]) => es.map((e) => (f === '__all__' ? e : `${f}: ${e}`)))
+          setError(msgs.join('; ') || 'Failed to abandon search')
+        } else {
+          setError('Failed to abandon search')
+        }
+      }
+    )
+  }
+
+  return (
+    <div>
+      <p>Take {assetName} off this search?</p>
+      <FormInputGroup label="Reason">
+        <input type="text" className="form-control" value={reason} onChange={(e) => setReason(e.target.value)} />
+      </FormInputGroup>
+      {error && <div className="text-danger mb-2">{error}</div>}
+      <div className="btn-group">
+        <button className="btn btn-warning" onClick={handleAbandon}>
+          Abandon Search
+        </button>
+        <button className="btn btn-danger" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/search/SearchPopup.test.tsx
+++ b/frontend/search/SearchPopup.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 
+import { MissionId } from '../mission/MissionId'
 import { SMMSearchObjectDetailsData } from './types'
 import { SearchPopup } from './SearchPopup'
 
@@ -17,16 +18,19 @@ function searchData(overrides: Partial<SMMSearchObjectDetailsData> = {}): SMMSea
   }
 }
 
-function renderPopup(search: SMMSearchObjectDetailsData, callbacks = {}) {
+function renderPopup(search: SMMSearchObjectDetailsData, callbacks = {}, missionId: MissionId = 1) {
   const props = {
     onDelete: vi.fn(),
     onQueueDialog: vi.fn(),
     onUnqueue: vi.fn(),
+    onAbandon: vi.fn(),
     ...callbacks
   }
-  render(<SearchPopup search={search} missionId={1} status="Unassigned" {...props} />)
+  render(<SearchPopup search={search} missionId={missionId} status="Unassigned" {...props} />)
   return props
 }
+
+const inprogress = { inprogress_at: '2026-06-28T00:10:00.000Z', inprogress_by: 'asset_a' }
 
 describe('SearchPopup', () => {
   it('shows Queue for an unqueued waiting search', () => {
@@ -48,9 +52,35 @@ describe('SearchPopup', () => {
   })
 
   it('does not show queue controls for an in-progress search', () => {
-    renderPopup(searchData({ queued_at: '2026-06-28T00:05:00.000Z', inprogress_at: '2026-06-28T00:10:00.000Z' }))
+    renderPopup(searchData({ queued_at: '2026-06-28T00:05:00.000Z', ...inprogress }))
 
     expect(screen.queryByRole('button', { name: 'Queue' })).toBeNull()
     expect(screen.queryByRole('button', { name: 'Unqueue' })).toBeNull()
+  })
+
+  it('shows Abandon Search for an in-progress search', () => {
+    const props = renderPopup(searchData(inprogress))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abandon Search' }))
+
+    expect(props.onAbandon).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show Abandon Search for a not-started search', () => {
+    renderPopup(searchData())
+
+    expect(screen.queryByRole('button', { name: 'Abandon Search' })).toBeNull()
+  })
+
+  it('does not show Abandon Search for a completed search', () => {
+    renderPopup(searchData({ ...inprogress, completed_at: '2026-06-28T00:20:00.000Z', completed_by: 'asset_a' }))
+
+    expect(screen.queryByRole('button', { name: 'Abandon Search' })).toBeNull()
+  })
+
+  it('does not show Abandon Search in the all-missions view', () => {
+    renderPopup(searchData(inprogress), {}, 'all')
+
+    expect(screen.queryByRole('button', { name: 'Abandon Search' })).toBeNull()
   })
 })

--- a/frontend/search/SearchPopup.tsx
+++ b/frontend/search/SearchPopup.tsx
@@ -12,9 +12,10 @@ interface Props {
   onDelete: () => void
   onQueueDialog: () => void
   onUnqueue: () => void
+  onAbandon: () => void
 }
 
-export function SearchPopup({ search, missionId, status, onDelete, onQueueDialog, onUnqueue }: Props) {
+export function SearchPopup({ search, missionId, status, onDelete, onQueueDialog, onUnqueue, onAbandon }: Props) {
   const rows: { label: string; value: string }[] = [
     { label: 'Search Type', value: search.search_type },
     { label: 'Status', value: status },
@@ -43,6 +44,9 @@ export function SearchPopup({ search, missionId, status, onDelete, onQueueDialog
     }
     if (search.queued_at && !search.inprogress_at) {
       buttons.push({ label: 'Unqueue', btnClass: 'btn-light', onclick: onUnqueue })
+    }
+    if (search.inprogress_at && !search.completed_at) {
+      buttons.push({ label: 'Abandon Search', btnClass: 'btn-warning', onclick: onAbandon })
     }
     buttons.push({ label: 'Details', btnClass: 'btn-light', href: `/search/${search.pk}/` })
   }

--- a/frontend/search/map.tsx
+++ b/frontend/search/map.tsx
@@ -9,8 +9,10 @@ import { SMMRealtime } from '../smmmap'
 import { SMMSearchObjectDetailsData } from './types'
 import { smmDelete } from '../ajax'
 import { SearchQueueDialog } from './SearchQueueDialog'
+import { SearchAbandonDialog } from './SearchAbandonDialog'
 import { SearchPopup } from './SearchPopup'
 import { mountPopup } from '../components/mountPopup'
+import { renderInLeafletDialog } from '../components/renderInLeafletDialog'
 
 class SMMSearch {
   parent: SMMSearches
@@ -25,6 +27,7 @@ class SMMSearch {
     this.searchQueueDestroy = this.searchQueueDestroy.bind(this)
     this.searchQueueDialog = this.searchQueueDialog.bind(this)
     this.unqueueCallback = this.unqueueCallback.bind(this)
+    this.searchAbandonDialog = this.searchAbandonDialog.bind(this)
   }
 
   deleteCallback() {
@@ -57,6 +60,12 @@ class SMMSearch {
     )
   }
 
+  searchAbandonDialog() {
+    renderInLeafletDialog(this.parent.map, (onClose) => <SearchAbandonDialog searchPk={this.search.pk} assetName={this.search.inprogress_by ?? 'this asset'} onClose={onClose} />, {
+      initOpen: true
+    })
+  }
+
   createPopup(layer: L.Layer) {
     this.popup?.unmount()
     this.popup = mountPopup(
@@ -68,6 +77,7 @@ class SMMSearch {
         onDelete={this.deleteCallback}
         onQueueDialog={this.searchQueueDialog}
         onUnqueue={this.unqueueCallback}
+        onAbandon={this.searchAbandonDialog}
       />,
       { minWidth: 200 }
     )


### PR DESCRIPTION
## Description

The popup for a search an asset is actually flying had nothing operational on it - Delete, Queue and Unqueue are all gated on !inprogress_at, leaving only Details. Taking the asset off meant leaving the object the operator is looking at, opening the asset command dialog and finding the asset in a mission-wide list by name.

Add an Abandon Search button that posts to the search-scoped endpoint, via a dialog that asks for the reason. Asset commands carry a reason and the timeline shows it, so a one-click abandon would be worse for the mission record - and the confirm also stops a misclick pulling an aircraft off a search it's halfway through. Server errors, including the permission check, are surfaced in the dialog.

The dialog uses the existing renderInLeafletDialog helper rather than repeating the manual dialog/root dance searchQueueDialog does.

## Summary by Sourcery

Add support for abandoning an in-progress search directly from its map popup via a dedicated confirmation dialog that records a reason and surfaces server-side errors.

New Features:
- Introduce an Abandon Search action in the search map popup for in-progress, not-yet-completed searches.
- Add a SearchAbandonDialog component that lets operators provide a reason when abandoning a search and posts to the search-scoped abandon endpoint.

Enhancements:
- Use the shared renderInLeafletDialog helper to present the abandon dialog from the map popup instead of custom dialog wiring.

Tests:
- Extend SearchPopup tests to cover Abandon Search visibility and callback behavior across mission views and search states.
- Add tests for SearchAbandonDialog covering reason submission, validation, success handling, and server error display.